### PR TITLE
Update readme to use turbo

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,17 +106,17 @@
 git clone https://github.com/jmcdannel/deja.git
 cd deja
 
-# Install dependencies (uses pnpm workspaces)
-npm install -g pnpm
-pnpm install
+# Install dependencies (uses turbo for monorepo management)
+npm install -g turbo
+turbo install
 
 # Start all applications in development mode
-pnpm dev
+turbo dev
 ```
 
 ### 🌍 Application URLs
 
-After running `pnpm dev`, access the applications at:
+After running `turbo dev`, access the applications at:
 
 - 🚂 **Throttle**: http://localhost:5173
 - ☁️ **Cloud**: http://localhost:5174  
@@ -157,22 +157,22 @@ VITE_FIREBASE_AUTH_DOMAIN=your-domain
 
 ```bash
 # Development
-pnpm dev              # 🚀 Start all apps in development mode
-pnpm dev:throttle     # 🎮 Start only throttle app
-pnpm dev:cloud        # ☁️ Start only cloud app
+turbo dev              # 🚀 Start all apps in development mode
+turbo dev:throttle     # 🎮 Start only throttle app
+turbo dev:cloud        # ☁️ Start only cloud app
 
 # Building
-pnpm build            # 🏗️ Build all applications
-pnpm build:throttle   # 📦 Build only throttle app
+turbo build            # 🏗️ Build all applications
+turbo build:throttle   # 📦 Build only throttle app
 
 # Code Quality
-pnpm lint             # 🔍 Lint all packages
-pnpm format          # 💄 Format all code
-pnpm type-check      # 🔬 TypeScript type checking
+turbo lint             # 🔍 Lint all packages
+turbo format          # 💄 Format all code
+turbo type-check      # 🔬 TypeScript type checking
 
 # Dependencies
-pnpm deps:check      # 📋 Check dependency versions
-pnpm deps:fix        # 🔧 Fix dependency mismatches
+turbo deps:check      # 📋 Check dependency versions
+turbo deps:fix        # 🔧 Fix dependency mismatches
 ```
 
 ---
@@ -180,7 +180,7 @@ pnpm deps:fix        # 🔧 Fix dependency mismatches
 ## 🎯 Usage Scenarios
 
 ### 🏠 Home Layout Control
-1. 🚀 Start the server: `pnpm run start:server`
+1. 🚀 Start the server: `turbo run start:server`
 2. 🎮 Open throttle app for train control
 3. ☁️ Use cloud app for layout management
 

--- a/apps/cloud/README.md
+++ b/apps/cloud/README.md
@@ -78,8 +78,8 @@
 2. **🚀 Start the Application**
    ```bash
    cd apps/cloud
-   pnpm install
-   pnpm dev
+   turbo install
+   turbo dev
    ```
 
 3. **🌐 Access the Interface**
@@ -230,11 +230,11 @@ interface FirebaseConfig {
 
 ```bash
 # Development commands
-pnpm dev          # 🚀 Start development server
-pnpm build        # 📦 Build for production
-pnpm preview      # 👀 Preview production build
-pnpm lint         # 🔍 Lint code
-pnpm type-check   # 🔬 TypeScript checking
+turbo dev          # 🚀 Start development server
+turbo build        # 📦 Build for production
+turbo preview      # 👀 Preview production build
+turbo lint         # 🔍 Lint code
+turbo type-check   # 🔬 TypeScript checking
 ```
 
 ---

--- a/apps/monitor/README.md
+++ b/apps/monitor/README.md
@@ -80,8 +80,8 @@
 2. **🚀 Start the Application**
    ```bash
    cd apps/monitor
-   pnpm install
-   pnpm dev
+   turbo install
+   turbo dev
    ```
 
 3. **🌐 Access the Dashboard**
@@ -242,18 +242,18 @@ interface AnalyticsConfig {
 
 ```bash
 # Development
-pnpm dev          # 🚀 Start development server
-pnpm build        # 📦 Build for production
-pnpm preview      # 👀 Preview production build
+turbo dev          # 🚀 Start development server
+turbo build        # 📦 Build for production
+turbo preview      # 👀 Preview production build
 
 # Testing & Quality
-pnpm lint         # 🔍 Lint code
-pnpm type-check   # 🔬 TypeScript checking
-pnpm test         # 🧪 Run unit tests
+turbo lint         # 🔍 Lint code
+turbo type-check   # 🔬 TypeScript checking
+turbo test         # 🧪 Run unit tests
 
 # Monitoring Tools
-pnpm monitor:logs # 📋 Stream live logs
-pnpm monitor:perf # 📊 Performance monitoring
+turbo monitor:logs # 📋 Stream live logs
+turbo monitor:perf # 📊 Performance monitoring
 ```
 
 ---

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -95,9 +95,9 @@ Copy the values below into your `.env` file:
 Clone this repository and open a terminal in the project root:
 
   ```bash
-  $ npm i -g pnpm
-  $ pnpm install
-  $ pnpm run start
+  $ npm i -g turbo
+  $ turbo install
+  $ turbo run start
   ```
 
 ### 🎛️ Connect Your Throttle
@@ -194,25 +194,25 @@ Clone this repository and open a terminal in the project root:
 
 ```bash
 # 📦 Install dependencies
-pnpm install
+turbo install
 
 # 🚀 Start development server
-pnpm run dev
+turbo run dev
 
 # 🏗️ Build for production
-pnpm run build
+turbo run build
 
 # 🔍 Code quality
-pnpm run lint
-pnpm run format
-pnpm run type-check
+turbo run lint
+turbo run format
+turbo run type-check
 
 # 🧪 Testing
-pnpm run test
-pnpm run test:watch
+turbo run test
+turbo run test:watch
 
 # 🔧 Utilities
-pnpm run mosquitto    # Start MQTT broker
+turbo run mosquitto    # Start MQTT broker
 ```
 
 ---
@@ -249,7 +249,7 @@ pnpm run mosquitto    # Start MQTT broker
 ```bash
 # 🔍 Check system status
 node --version
-pnpm --version
+turbo --version
 
 # 📡 Test serial ports
 ls /dev/tty*           # Linux/Mac

--- a/apps/throttle/README.md
+++ b/apps/throttle/README.md
@@ -84,17 +84,17 @@ Want to run this on your own? Fork it, clone it, PR it. Just don't sell it! 😊
 
 ```bash
 # 📦 Install dependencies
-pnpm install
+turbo install
 
 # 🚀 Start development server
-pnpm run start
+turbo run start
 
 # 🏗️ Build for production
-pnpm run build
+turbo run build
 
 # 🔍 Lint and format
-pnpm run lint
-pnpm run format
+turbo run lint
+turbo run format
 ```
 
 ---

--- a/apps/tour/README.md
+++ b/apps/tour/README.md
@@ -80,8 +80,8 @@
 2. **🚀 Start the Application**
    ```bash
    cd apps/tour
-   pnpm install
-   pnpm dev
+   turbo install
+   turbo dev
    ```
 
 3. **🌐 Access the Experience**
@@ -258,19 +258,19 @@ npm run generate-qr --type=achievement --id=engineer-badge
 
 ```bash
 # Development
-pnpm dev              # 🚀 Start development server
-pnpm build            # 📦 Build for production
-pnpm preview          # 👀 Preview production build
+turbo dev              # 🚀 Start development server
+turbo build            # 📦 Build for production
+turbo preview          # 👀 Preview production build
 
 # Content Management
-pnpm audio:process    # 🎵 Process audio files
-pnpm qr:generate      # 📱 Generate QR codes
-pnpm content:validate # 📋 Validate tour content
+turbo audio:process    # 🎵 Process audio files
+turbo qr:generate      # 📱 Generate QR codes
+turbo content:validate # 📋 Validate tour content
 
 # Testing
-pnpm test             # 🧪 Run tests
-pnpm test:touch       # 📱 Touch interaction tests
-pnpm test:audio       # 🎵 Audio system tests
+turbo test             # 🧪 Run tests
+turbo test:touch       # 📱 Touch interaction tests
+turbo test:audio       # 🎵 Audio system tests
 ```
 
 ---


### PR DESCRIPTION
Update README files to instruct readers to use `turbo` instead of `pnpm` for install, dev, and other commands.

---
<a href="https://cursor.com/background-agent?bcId=bc-5b6c8183-22c9-40fa-a61b-9d98da384b40">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5b6c8183-22c9-40fa-a61b-9d98da384b40">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

