### PR TITLE
docs: fix typo in serial cancel comment

### DIFF
--- a/apps/cloud/src/DejaDirectConnect/useSerial.ts
+++ b/apps/cloud/src/DejaDirectConnect/useSerial.ts
@@ -211,7 +211,7 @@ export function useSerial(handleMessage: (message: string) => void) {
     if (port) {
       // Close the input stream (reader).
       if (reader) {
-        await reader.cancel() // .cancel is asynchronous so must use await to wave for it to finish
+        await reader.cancel() // .cancel is asynchronous so must use await to wait for it to finish
         await inputDone?.catch(() => {})
         reader = null
         inputDone = null


### PR DESCRIPTION
## Summary
- fix typo in `useSerial.ts` comment to clarify waiting for `reader.cancel()`

## Testing
- `pnpm exec eslint apps/cloud/src/DejaDirectConnect/useSerial.ts` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_689df075fc34832db3017b4f1c4ffb4d