### PR TITLE
fix: correct command pool interval

### DIFF
--- a/apps/server/src/modules/layout.ts
+++ b/apps/server/src/modules/layout.ts
@@ -24,7 +24,7 @@ interface Connection {
 }
 
 const baudRate = 115200
-const POOL_INTERVAL = 5000 // 3 seconds
+const POOL_INTERVAL = 3000 // 3 seconds
 
 const layoutId = process.env.LAYOUT_ID || 'betatrack'
 const _connections: { [key: string]: Connection } = {}


### PR DESCRIPTION
## Summary
- set command pool interval to 3000ms for accurate 3s timing

## Testing
- `pnpm -F deja-serverts type-check` *(fails: missing module type declarations)*
- `pnpm lint` *(fails: missing ESLint config in some packages)*

------
https://chatgpt.com/codex/tasks/task_e_689df3f2065c832d920d97a94e7fba41