### PR TITLE
feat: add slider option to throttle controls

### DIFF
--- a/apps/throttle/src/conductor/ConductorLayout.vue
+++ b/apps/throttle/src/conductor/ConductorLayout.vue
@@ -1,45 +1,68 @@
 <script setup lang="ts">
-import { ref } from 'vue'
-import type { Loco, Throttle } from '@repo/modules/locos'
-import { useLocos } from '@repo/modules/locos'
-import SimpleThrottle from '@/throttle/SimpleThrottle.vue'
-import ThrottleTile from '@/throttle/ThrottleTile.vue'
-import { TurnoutList, EffectList } from '@repo/ui'
+import { ref, computed } from "vue";
+import type { Loco, Throttle } from "@repo/modules/locos";
+import { useLocos } from "@repo/modules/locos";
+import SimpleThrottle from "@/throttle/SimpleThrottle.vue";
+import ThrottleTile from "@/throttle/ThrottleTile.vue";
+import { TurnoutList, EffectList } from "@repo/ui";
+import { useRoute } from "vue-router";
 
-const drawer = ref(false)
-const { getThrottles } = useLocos()
-const throttles = getThrottles()
-
+const drawer = ref(false);
+const { getThrottles } = useLocos();
+const throttles = getThrottles();
+const route = useRoute();
+const controls = computed(() =>
+  route.query.controls === "slider" ? "slider" : "buttons"
+);
 </script>
 <template>
   <main class="@container relative">
-    <div class="conductor-layout grid grid-cols-1 @[960px]:grid-cols-3 gap-2 w-full">
-      <div class=" bg-slate-700 bg-opacity-20 rounded border-1 border-green-500 border-opacity-50 order-2 @[960px]:!order-1 overflow-hidden">
+    <div
+      class="conductor-layout grid grid-cols-1 @[960px]:grid-cols-3 gap-2 w-full"
+    >
+      <div
+        class="bg-slate-700 bg-opacity-20 rounded border-1 border-green-500 border-opacity-50 order-2 @[960px]:!order-1 overflow-hidden"
+      >
         <div class="@container h-full overflow-y-auto p-4">
           <!-- Column 1 content goes here -->
-          <div v-if="throttles?.length" class="flex-grow flex flex-row flex-wrap gap-1 relative overflow-auto items-end content-end">
+          <div
+            v-if="throttles?.length"
+            class="flex-grow flex flex-row flex-wrap gap-1 relative overflow-auto items-end content-end"
+          >
             <div class="flex-grow"></div>
-            <div 
+            <div
               class="basis-full @[960px]:basis-1/2"
-              v-for="item in throttles" 
-              :key="item.address">
-                <ThrottleTile :address="item.address" />
+              v-for="item in throttles"
+              :key="item.address"
+            >
+              <ThrottleTile :address="item.address" :controls="controls" />
             </div>
           </div>
         </div>
       </div>
-      <div class=" bg-slate-700 bg-opacity-20 order-1 @[960px]:!order-2 overflow-hidden">
+      <div
+        class="bg-slate-700 bg-opacity-20 order-1 @[960px]:!order-2 overflow-hidden"
+      >
         <div class="@containermin-h-[500px] h-full overflow-y-auto p-4">
           <!-- Column 2 content goes here -->
           <!-- <pre>{{throttles}}</pre> -->
-          <v-carousel v-if="throttles && throttles.length > 0" height="100%" class="min-h-90vh" hideDelimiters>
-            <v-carousel-item v-for="(item) in throttles" :key="item.address" draggable>
-              <SimpleThrottle :address="item.address" />
+          <v-carousel
+            v-if="throttles && throttles.length > 0"
+            height="100%"
+            class="min-h-90vh"
+            hideDelimiters
+          >
+            <v-carousel-item
+              v-for="item in throttles"
+              :key="item.address"
+              draggable
+            >
+              <SimpleThrottle :address="item.address" :controls="controls" />
             </v-carousel-item>
           </v-carousel>
         </div>
       </div>
-      <div class=" bg-slate-700 bg-opacity-20 order-3 overflow-hidden">
+      <div class="bg-slate-700 bg-opacity-20 order-3 overflow-hidden">
         <div class="@container h-full overflow-y-auto p-4">
           <!-- Column 3 content goes here -->
           <TurnoutList />
@@ -48,12 +71,19 @@ const throttles = getThrottles()
     </div>
   </main>
   <aside>
-    <div 
-      class="fixed top-1/2 px-2 py-4 cursor-pointer z-[100] -translate-y-1/2 bg-sky-700 bg-opacity-80 rounded-r-none rounded-l-xl" @click="drawer = !drawer" 
-      :class="drawer ? 'drawer-open' : 'drawer-closed'">
+    <div
+      class="fixed top-1/2 px-2 py-4 cursor-pointer z-[100] -translate-y-1/2 bg-sky-700 bg-opacity-80 rounded-r-none rounded-l-xl"
+      @click="drawer = !drawer"
+      :class="drawer ? 'drawer-open' : 'drawer-closed'"
+    >
       <div class="vertical-text text-xs text-sky-200 uppercase">Settings</div>
     </div>
-    <v-navigation-drawer v-model="drawer" location="right" temporary class="relative">
+    <v-navigation-drawer
+      v-model="drawer"
+      location="right"
+      temporary
+      class="relative"
+    >
       <v-form class="pa-4">
         <h2 class="mb-4">Settings</h2>
         <!-- Add form controls here -->
@@ -86,5 +116,4 @@ const throttles = getThrottles()
     height: calc(100vh - var(--v-layout-bottom) - var(--v-layout-top));
   }
 }
-
 </style>

--- a/apps/throttle/src/throttle/SimpleThrottle.vue
+++ b/apps/throttle/src/throttle/SimpleThrottle.vue
@@ -1,55 +1,79 @@
 <script setup lang="ts">
-import ThrottleButtonControls from '@/throttle/ThrottleButtonControls.vue'
-import CurrentSpeed from '@/throttle/CurrentSpeed.vue'
-import ThrottleHeader from '@/throttle/ThrottleHeader.vue'
-import { FunctionsSpeedDial } from '@repo/ui'
-import { LocoAvatar, MiniConsist } from '@repo/ui'
-import { useThrottle } from '@/throttle/useThrottle'
-import { useRouter } from 'vue-router'
+import CurrentSpeed from "@/throttle/CurrentSpeed.vue";
+import ThrottleHeader from "@/throttle/ThrottleHeader.vue";
+import { FunctionsSpeedDial } from "@repo/ui";
+import { LocoAvatar, MiniConsist } from "@repo/ui";
+import { useThrottle } from "@/throttle/useThrottle";
+import { useRouter } from "vue-router";
+import ThrottleControls from "@/throttle/ThrottleControls.vue";
 
-const emit = defineEmits(['release'])
+const emit = defineEmits(["release"]);
 const props = defineProps({
   address: {
     type: Number,
-    required: true
-  }
-})
+    required: true,
+  },
+  controls: {
+    type: String,
+    default: "buttons",
+  },
+});
 
-const $router = useRouter()
+const $router = useRouter();
 
-const { 
-  adjustSpeed: handleAdjustSpeed, 
-  currentSpeed, 
+const {
+  adjustSpeed: handleAdjustSpeed,
+  currentSpeed,
   throttle,
   loco,
   stop: handleStop,
-} = useThrottle(props.address)
-
+  direction,
+} = useThrottle(props.address);
 </script>
 <template>
-  <main v-if="throttle" class="flex flex-col gap-2 p-3 overflow-hidden w-full h-full flex-1 shadow-xl relative bg-gradient-to-br from-violet-800 to-cyan-500 bg-gradient-border min-h-[80vh]">
+  <main
+    v-if="throttle"
+    class="flex flex-col gap-2 p-3 overflow-hidden w-full h-full flex-1 shadow-xl relative bg-gradient-to-br from-violet-800 to-cyan-500 bg-gradient-border min-h-[80vh]"
+  >
     <ThrottleHeader>
       <template v-slot:left>
-        <LocoAvatar 
-          v-if="loco" 
-          :loco="loco" 
-          :size="48" 
-          @select="$router.push({ name: 'throttle', params: { address } })" />
+        <LocoAvatar
+          v-if="loco"
+          :loco="loco"
+          :size="48"
+          @select="$router.push({ name: 'throttle', params: { address } })"
+        />
         <MiniConsist v-if="loco" :loco="loco" />
       </template>
       <template v-slot:center>
-          <span v-if="loco" class="text-2xl bg-clip-text text-transparent bg-gradient-to-r from-blue-400 to-cyan-400 font-bold">{{loco.name}}</span>
+        <span
+          v-if="loco"
+          class="text-2xl bg-clip-text text-transparent bg-gradient-to-r from-blue-400 to-cyan-400 font-bold"
+          >{{ loco.name }}</span
+        >
       </template>
-      <template v-slot:right>
-      </template>
+      <template v-slot:right> </template>
     </ThrottleHeader>
-    <section class="throttle w-full min-h-0 flex flex-col justify-around flex-grow relative z-10">
-      <section v-if="loco" class="flex flex-col flex-grow items-center justify-between flex-1 my-4">
+    <section
+      class="throttle w-full min-h-0 flex flex-col justify-around flex-grow relative z-10"
+    >
+      <section
+        v-if="loco"
+        class="flex flex-col flex-grow items-center justify-between flex-1 my-4"
+      >
         <FunctionsSpeedDial :loco="loco" />
       </section>
-      <section class="flex flex-col gap-2 mb-2 items-center justify-between flex-grow h-full">
+      <section
+        class="flex flex-col gap-2 mb-2 items-center justify-between flex-grow h-full"
+      >
         <CurrentSpeed :speed="currentSpeed" />
-        <ThrottleButtonControls @update:currentSpeed="handleAdjustSpeed" @stop="handleStop" />
+        <ThrottleControls
+          :type="controls"
+          :speed="currentSpeed"
+          :direction="direction"
+          @update:currentSpeed="handleAdjustSpeed"
+          @stop="handleStop"
+        />
       </section>
     </section>
   </main>

--- a/apps/throttle/src/throttle/Throttle.vue
+++ b/apps/throttle/src/throttle/Throttle.vue
@@ -1,44 +1,43 @@
 <script setup lang="ts">
-import { ref } from 'vue'
-import { useRouter } from 'vue-router'
-import type { Loco } from '@repo/modules/locos'
-import ThrottleButtonControls from '@/throttle/ThrottleButtonControls.vue'
-import ThrottleSliderControls from '@/throttle/ThrottleSliderControls.vue'
-import CurrentSpeed from '@/throttle/CurrentSpeed.vue'
-import ThrottleHeader from '@/throttle/ThrottleHeader.vue'
-import ThrottleActionMenu from '@/throttle/ThrottleActionMenu.vue'
-import { Consist, LocoAvatar, MiniConsist, FunctionsSpeedDial } from '@repo/ui'
-import { useThrottle } from '@/throttle/useThrottle'
+import { ref } from "vue";
+import { useRouter } from "vue-router";
+import type { Loco } from "@repo/modules/locos";
+import CurrentSpeed from "@/throttle/CurrentSpeed.vue";
+import ThrottleHeader from "@/throttle/ThrottleHeader.vue";
+import ThrottleActionMenu from "@/throttle/ThrottleActionMenu.vue";
+import { Consist, LocoAvatar, MiniConsist, FunctionsSpeedDial } from "@repo/ui";
+import { useThrottle } from "@/throttle/useThrottle";
+import ThrottleControls from "@/throttle/ThrottleControls.vue";
 
 const props = defineProps({
   address: {
     type: Number,
-    required: true
-  }
-})
+    required: true,
+  },
+  controls: {
+    type: String,
+    default: "buttons",
+  },
+});
 
-const { 
+const {
   adjustSpeed: handleAdjustSpeed,
-  currentSpeed, 
+  currentSpeed,
   direction,
   loco,
   releaseThrottle,
   stop: handleStop,
   throttle,
-} = useThrottle(props.address)
+} = useThrottle(props.address);
 
-const $router = useRouter()
+const $router = useRouter();
 // const consistCmp = ref<InstanceType<typeof Consist> | null>(null)
 // const functionsCmp = ref<InstanceType<typeof Functions> | null>(null)
 
-function handleSlider(val: number): void { // handle slider changes
-  // currentSpeed.value = parseInt(val.toString()) // debounced speed changes
-}
-
 async function clearLoco() {
-  handleStop()
-  releaseThrottle()
-  $router.push({ name: 'throttle-list' })
+  handleStop();
+  releaseThrottle();
+  $router.push({ name: "throttle-list" });
 }
 
 function openFunctions() {
@@ -52,43 +51,67 @@ function openConsist() {
 function openFunctionSettings() {
   // functionsCmp.value && functionsCmp.value.openSettings()
 }
-
 </script>
 <template>
-  <main v-if="throttle" class="flex flex-col gap-2 p-2 overflow-hidden w-full h-full flex-1 shadow-xl relative  ">
+  <main
+    v-if="throttle"
+    class="flex flex-col gap-2 p-2 overflow-hidden w-full h-full flex-1 shadow-xl relative"
+  >
     <!-- <pre>locoDocId:{{locoDocId}}</pre>-->
     <!-- <pre>loco:{{loco.functions}}</pre>  -->
     <!-- <pre>currentSpeed {{ currentSpeed }}</pre> -->
     <!-- <pre>throttleDir {{ throttleDir }}</pre> -->
     <!-- <pre>props.throttle {{ props.throttle }}</pre> -->
-    <ThrottleHeader class="bg-gradient-to-r from-purple-300/10 to-pink-600/10 text-purple-400/10">
+    <ThrottleHeader
+      class="bg-gradient-to-r from-purple-300/10 to-pink-600/10 text-purple-400/10"
+    >
       <template v-slot:left>
-        <LocoAvatar v-if="loco" :loco="loco as Loco" :size="48" @park="clearLoco" @stop="handleStop" />
+        <LocoAvatar
+          v-if="loco"
+          :loco="loco as Loco"
+          :size="48"
+          @park="clearLoco"
+          @stop="handleStop"
+        />
         <MiniConsist v-if="loco" :loco="loco" />
       </template>
       <template v-slot:center>
-        <h1 class="text-4xl font-bold tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-pink-500 to-violet-500 drop-shadow-lg">{{ loco?.name }}</h1>
+        <h1
+          class="text-4xl font-bold tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-pink-500 to-violet-500 drop-shadow-lg"
+        >
+          {{ loco?.name }}
+        </h1>
       </template>
       <template v-slot:right>
-        <ThrottleActionMenu 
-          @park="clearLoco" 
-          @functions="openFunctions" 
+        <ThrottleActionMenu
+          @park="clearLoco"
+          @functions="openFunctions"
           @consist="openConsist"
         />
       </template>
     </ThrottleHeader>
-    <section class="throttle w-full h-full flex flex-row justify-around flex-grow relative z-10">
-      <section class="px-1 text-center flex-1 hidden sm:block">
-      <!-- <ThrottleSliderControls :direction="direction" :speed="currentSpeed" @update:currentSpeed="handleSlider" @stop="handleStop" /> -->
-      </section>
-      <section v-if="loco" class="flex flex-col gap-2 mb-2 items-center justify-between flex-1/2 sm:flex-1">
+    <section
+      class="throttle w-full h-full flex flex-row justify-around flex-grow relative z-10"
+    >
+      <section
+        v-if="loco"
+        class="flex flex-col gap-2 mb-2 items-center justify-between flex-1/2 sm:flex-1"
+      >
         <Consist v-if="loco" :loco="loco" />
         <v-spacer />
         <FunctionsSpeedDial :loco="loco" />
       </section>
-      <section class="flex flex-col gap-2 mb-2 items-center justify-between flex-1/2 sm:flex-1">
-      <CurrentSpeed :speed="currentSpeed" />
-      <ThrottleButtonControls @update:currentSpeed="handleAdjustSpeed" @stop="handleStop" />
+      <section
+        class="flex flex-col gap-2 mb-2 items-center justify-between flex-1/2 sm:flex-1"
+      >
+        <CurrentSpeed :speed="currentSpeed" />
+        <ThrottleControls
+          :type="controls"
+          :speed="currentSpeed"
+          :direction="direction"
+          @update:currentSpeed="handleAdjustSpeed"
+          @stop="handleStop"
+        />
       </section>
     </section>
   </main>

--- a/apps/throttle/src/throttle/ThrottleControls.vue
+++ b/apps/throttle/src/throttle/ThrottleControls.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import ThrottleButtonControls from "./ThrottleButtonControls.vue";
+import ThrottleSliderControls from "./ThrottleSliderControls.vue";
+
+const props = defineProps({
+  type: {
+    type: String,
+    default: "buttons",
+  },
+  speed: {
+    type: Number,
+    default: 0,
+  },
+  direction: {
+    type: Boolean,
+    default: true,
+  },
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+  horizontal: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const emit = defineEmits(["update:currentSpeed", "stop"]);
+</script>
+<template>
+  <ThrottleSliderControls
+    v-if="type === 'slider'"
+    :speed="speed"
+    :direction="direction"
+    :disabled="disabled"
+    @update:currentSpeed="emit('update:currentSpeed', $event)"
+    @stop="emit('stop')"
+  />
+  <ThrottleButtonControls
+    v-else
+    :disabled="disabled"
+    :horizontal="horizontal"
+    @update:currentSpeed="emit('update:currentSpeed', $event)"
+    @stop="emit('stop')"
+  />
+</template>

--- a/apps/throttle/src/throttle/ThrottleSliderControls.vue
+++ b/apps/throttle/src/throttle/ThrottleSliderControls.vue
@@ -1,41 +1,46 @@
 <script setup lang="ts">
-import { ref, toRef, watch } from 'vue'
-import { debounce } from 'vue-debounce'
-import ThrottleSlider from './ThrottleSlider.vue'
+import { ref, toRef, watch } from "vue";
+import { debounce } from "vue-debounce";
+import ThrottleSlider from "./ThrottleSlider.vue";
 
-const DEBOUNCE_DELAY = 1000 // debounce speed changes by 100ms to prevent too many requests
+const DEBOUNCE_DELAY = 1000; // debounce speed changes by 100ms to prevent too many requests
 
-const emit = defineEmits(['update:currentSpeed', 'stop'])
+const emit = defineEmits(["update:currentSpeed", "stop"]);
 
-const props  = defineProps({
+const props = defineProps({
   speed: {
     type: Number,
-    required: true
+    required: true,
   },
   direction: {
     type: Boolean,
-    default: null // null means no direction set
+    default: null, // null means no direction set
   },
   disabled: {
     type: Boolean,
-    default: false
-  }
-})
+    default: false,
+  },
+});
 
-const speed = toRef(props, 'speed')
-const setSpeed = debounce((val: number): void => { emit('update:currentSpeed', val); }, `${DEBOUNCE_DELAY}ms`)
+const speed = toRef(props, "speed");
+const direction = toRef(props, "direction");
+const setSpeed = debounce((val: number): void => {
+  emit("update:currentSpeed", val);
+}, `${DEBOUNCE_DELAY}ms`);
 
-function setSliderSpeed(val: number): void { // handle slider changes
-  setSpeed(parseInt(val.toString())) // debounced speed changes
+function setSliderSpeed(val: number): void {
+  // handle slider changes
+  const signed = direction.value ? val : -val;
+  setSpeed(parseInt(signed.toString())); // debounced speed changes
 }
 function handleForward() {
-  console.log('forward')
-  emit('stop')
+  console.log("forward");
+  emit("stop");
 }
 
 function handleReverse() {
-  console.log('reverse')
-  emit('stop')
+  console.log("reverse");
+  emit("stop");
 }
 
 // function handleSliderUpdate(val: number) {
@@ -49,30 +54,22 @@ function handleReverse() {
 // }
 
 function isDisabled() {
-  return props.direction === null
+  return props.direction === null;
 }
-
 </script>
 <template>
   <div class="flex flex-col h-full justify-end">
-    <ThrottleSlider 
-      :speed="speed" 
+    <ThrottleSlider
+      :speed="speed"
       :disabled="isDisabled()"
       :label="direction ? 'FWD' : 'REV'"
-      @update="setSliderSpeed" 
-      @stop="$emit('stop')"  />
+      @update="setSliderSpeed"
+      @stop="$emit('stop')"
+    />
     <div class="flex mt-4 align-middle justify-center">
-      <v-btn 
-        @click="handleReverse" 
-        prepend-icon="mdi-chevron-left"
-      >Rev</v-btn>
-      <v-btn 
-        @click="handleForward"
-        append-icon="mdi-chevron-right"
-      >Fwd</v-btn>
+      <v-btn @click="handleReverse" prepend-icon="mdi-chevron-left">Rev</v-btn>
+      <v-btn @click="handleForward" append-icon="mdi-chevron-right">Fwd</v-btn>
     </div>
   </div>
 </template>
-<style scoped>
-  
-</style>
+<style scoped></style>

--- a/apps/throttle/src/throttle/ThrottleTile.vue
+++ b/apps/throttle/src/throttle/ThrottleTile.vue
@@ -1,49 +1,66 @@
 <script setup lang="ts">
-import { LocoAvatar } from '@repo/ui'
-import ThrottleButtonControls from './ThrottleButtonControls.vue'
-import CurrentSpeed from './CurrentSpeed.vue'
-import { useThrottle } from './useThrottle'
+import { LocoAvatar } from "@repo/ui";
+import CurrentSpeed from "./CurrentSpeed.vue";
+import { useThrottle } from "./useThrottle";
+import ThrottleControls from "./ThrottleControls.vue";
 
 const props = defineProps({
   address: {
     type: Number,
-    required: true
-  }
-})
+    required: true,
+  },
+  controls: {
+    type: String,
+    default: "buttons",
+  },
+});
 
-const { 
+const {
   adjustSpeed: handleAdjustSpeed,
   currentSpeed,
   loco,
   releaseThrottle,
   stop: handleStop,
   throttle,
-} = useThrottle(props.address)
-
+  direction,
+} = useThrottle(props.address);
 </script>
 <template>
-  <main v-if="throttle" class="rounded-2xl shadow-xl relative bg-gradient-to-br from-violet-800 to-cyan-500 bg-gradient-border ">
-    <section class="p-1 flex flex-row flex-wrap items-center justify-between overflow-auto">
-      <div class="order-1 basis-1/3 pl-2" >
+  <main
+    v-if="throttle"
+    class="rounded-2xl shadow-xl relative bg-gradient-to-br from-violet-800 to-cyan-500 bg-gradient-border"
+  >
+    <section
+      class="p-1 flex flex-row flex-wrap items-center justify-between overflow-auto"
+    >
+      <div class="order-1 basis-1/3 pl-2">
         <CurrentSpeed class="!justify-start =" :speed="currentSpeed" />
       </div>
       <div class="flex-grow order-4 basis-full my-1">
-        <ThrottleButtonControls
+        <ThrottleControls
+          :type="controls"
+          :speed="currentSpeed"
+          :direction="direction"
           horizontal
-          @stop="handleStop" 
-          @update:currentSpeed="handleAdjustSpeed" 
+          @stop="handleStop"
+          @update:currentSpeed="handleAdjustSpeed"
         />
       </div>
-      <div class="order-2 basis-1/3 py-2 flex justify-center text-base @[960px]:text-xl">
-        <span class="bg-clip-text text-transparent bg-gradient-to-r from-violet-500 to-cyan-400 font-bold">{{loco?.name || throttle.address}}</span>
+      <div
+        class="order-2 basis-1/3 py-2 flex justify-center text-base @[960px]:text-xl"
+      >
+        <span
+          class="bg-clip-text text-transparent bg-gradient-to-r from-violet-500 to-cyan-400 font-bold"
+          >{{ loco?.name || throttle.address }}</span
+        >
       </div>
-      <div class="order-2  basis-1/3 pr-2">
-        <LocoAvatar 
-          v-if="loco" 
-          :loco="loco" 
+      <div class="order-2 basis-1/3 pr-2">
+        <LocoAvatar
+          v-if="loco"
+          :loco="loco"
           class="justify-end"
-          @park="releaseThrottle" 
-          :size="48" 
+          @park="releaseThrottle"
+          :size="48"
           @stop="handleStop"
           showConsist
           showMenu
@@ -55,8 +72,8 @@ const {
   <main v-else>
     <div class="flex items-center justify-center h-full">
       <p class="text-gray-500">Loading throttle...</p>
-      {{address}}
-      {{throttle}}
+      {{ address }}
+      {{ throttle }}
     </div>
   </main>
 </template>

--- a/apps/throttle/src/views/ThrottleList.vue
+++ b/apps/throttle/src/views/ThrottleList.vue
@@ -1,23 +1,37 @@
 <script async setup lang="ts">
-import { useStorage } from '@vueuse/core'
-import type { Throttle } from '@repo/modules/locos'
-import ThrottleTile from '@/throttle/ThrottleTile.vue'
-import { useLocos } from '@repo/modules/locos'
-import { ListMenu } from '@repo/ui'
+import { useStorage } from "@vueuse/core";
+import type { Throttle } from "@repo/modules/locos";
+import ThrottleTile from "@/throttle/ThrottleTile.vue";
+import { useLocos } from "@repo/modules/locos";
+import { ListMenu } from "@repo/ui";
+import { useRoute } from "vue-router";
+import { computed } from "vue";
 
-const viewAs = useStorage('@DEJA/prefs/throttles/View', ['button'])
-const sortBy = useStorage<string[]>('@DEJA/prefs/throttles/Sort', ['device'])
+const viewAs = useStorage("@DEJA/prefs/throttles/View", ["button"]);
+const sortBy = useStorage<string[]>("@DEJA/prefs/throttles/Sort", ["device"]);
 
-const { getThrottles } = useLocos()
-const throttles = getThrottles()
+const { getThrottles } = useLocos();
+const throttles = getThrottles();
+const route = useRoute();
+const controls = computed(() =>
+  route.query.controls === "slider" ? "slider" : "buttons"
+);
 </script>
 
 <template>
-  <main class="@containerp p-2 md:p-4  flex-grow flex flex-col relative overflow-auto w-full h-full flex-1">
+  <main
+    class="@containerp p-2 md:p-4 flex-grow flex flex-col relative overflow-auto w-full h-full flex-1"
+  >
     <div class="absolute inset-0 overflow-hidden">
-      <div class="absolute w-[600px] h-[600px] rounded-full bg-purple-600/10 blur-[100px] -top-[200px] -left-[300px]"></div>
-      <div class="absolute w-[500px] h-[500px] rounded-full bg-blue-500/10 blur-[80px] -bottom-[100px] -right-[200px]"></div>
-      <div class="absolute w-[400px] h-[400px] rounded-full bg-violet-500/10 blur-[90px] top-[30%] left-[40%]"></div>
+      <div
+        class="absolute w-[600px] h-[600px] rounded-full bg-purple-600/10 blur-[100px] -top-[200px] -left-[300px]"
+      ></div>
+      <div
+        class="absolute w-[500px] h-[500px] rounded-full bg-blue-500/10 blur-[80px] -bottom-[100px] -right-[200px]"
+      ></div>
+      <div
+        class="absolute w-[400px] h-[400px] rounded-full bg-violet-500/10 blur-[90px] top-[30%] left-[40%]"
+      ></div>
     </div>
     <v-toolbar color="green-darken-2" :elevation="8">
       <template #prepend>
@@ -26,17 +40,22 @@ const throttles = getThrottles()
       <template #append>
         <ListMenu :module-name="'throttles'" />
       </template>
-      <v-toolbar-title class="text-xl md:text-3xl">Throttles</v-toolbar-title>    
+      <v-toolbar-title class="text-xl md:text-3xl">Throttles</v-toolbar-title>
     </v-toolbar>
-    <div v-if="throttles" class="flex-grow flex flex-row flex-wrap relative overflow-auto items-end content-end justify-end">
+    <div
+      v-if="throttles"
+      class="flex-grow flex flex-row flex-wrap relative overflow-auto items-end content-end justify-end"
+    >
       <!-- <div class="basis-full @[960px]:basis-1/2 flex-grow"></div> -->
-      <div 
-        class="basis-full @[960px]:basis-1/2 p-1"  
+      <div
+        class="basis-full @[960px]:basis-1/2 p-1"
         v-for="item in throttles"
-        :key="((item as unknown) as Throttle).id">
-          <ThrottleTile 
-            :address="((item as unknown) as Throttle).address" 
-          />
+        :key="((item as unknown) as Throttle).id"
+      >
+        <ThrottleTile
+          :address="((item as unknown) as Throttle).address"
+          :controls="controls"
+        />
       </div>
     </div>
   </main>

--- a/apps/throttle/src/views/ThrottleView.vue
+++ b/apps/throttle/src/views/ThrottleView.vue
@@ -1,20 +1,30 @@
 <script async setup lang="ts">
-  import { ref } from 'vue'
-  import { useRoute } from 'vue-router'
-  import Throttle from '@/throttle/Throttle.vue'
+import { ref, computed } from "vue";
+import { useRoute } from "vue-router";
+import Throttle from "@/throttle/Throttle.vue";
 
-  const route = useRoute()
-  const address = ref(parseInt(route.params.address?.toString()))
-
+const route = useRoute();
+const address = ref(parseInt(route.params.address?.toString()));
+const controls = computed(() =>
+  route.query.controls === "slider" ? "slider" : "buttons"
+);
 </script>
 
 <template>
-  <div class="@container flex-grow flex flex-col relative overflow-hidden w-full h-full flex-1">
+  <div
+    class="@container flex-grow flex flex-col relative overflow-hidden w-full h-full flex-1"
+  >
     <div class="absolute inset-0 overflow-hidden">
-      <div class="absolute w-[600px] h-[600px] rounded-full bg-purple-600/10 blur-[100px] -top-[200px] -left-[300px]"></div>
-      <div class="absolute w-[500px] h-[500px] rounded-full bg-blue-500/10 blur-[80px] -bottom-[100px] -right-[200px]"></div>
-      <div class="absolute w-[400px] h-[400px] rounded-full bg-violet-500/10 blur-[90px] top-[30%] left-[40%]"></div>
+      <div
+        class="absolute w-[600px] h-[600px] rounded-full bg-purple-600/10 blur-[100px] -top-[200px] -left-[300px]"
+      ></div>
+      <div
+        class="absolute w-[500px] h-[500px] rounded-full bg-blue-500/10 blur-[80px] -bottom-[100px] -right-[200px]"
+      ></div>
+      <div
+        class="absolute w-[400px] h-[400px] rounded-full bg-violet-500/10 blur-[90px] top-[30%] left-[40%]"
+      ></div>
     </div>
-    <Throttle :address="address" />
+    <Throttle :address="address" :controls="controls" />
   </div>
 </template>


### PR DESCRIPTION
## Summary
- allow throttles to use button or slider controls via new `ThrottleControls` component
- support query param `controls=slider` to enable slider controls in throttle views
- emit signed speed based on direction in slider controls

## Testing
- `pnpm --filter deja-throttle lint` *(fails: ESLint couldn't find configuration)*
- `pnpm --filter deja-throttle test:unit` *(fails: vite/esbuild ESM require issue)*

------
https://chatgpt.com/codex/tasks/task_e_68a02bcbdc00832d9382d57bcd5030d7