### PR TITLE
fix(package): update start script to filter for 'deja-serverts'

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dev": "turbo run dev",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "lint": "turbo run lint",
-    "start": "turbo run start --filter=apps/server --filter=apps/monitor",
+    "start": "turbo run start --filter=deja-serverts",
     "start:all": "turbo run start",
     "scan-sounds": "turbo run scan-sounds --filter=@repo/sounds"
   },


### PR DESCRIPTION
This pull request makes a small update to the `start` script in the `package.json` file, changing the filter to run only the `deja-serverts` app when starting the project.