### PR TITLE
feat(www): docs nav polish and prev/next navigation

### DIFF
--- a/apps/dejajs-www/app/docs/layout.tsx
+++ b/apps/dejajs-www/app/docs/layout.tsx
@@ -1,4 +1,5 @@
 import DocsSidebar from '../../components/DocsSidebar';
+import DocsPrevNext from '../../components/DocsPrevNext';
 import { generateDocsNav } from '../../lib/generate-docs-nav';
 
 export const metadata = {
@@ -18,6 +19,7 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
       </aside>
       <article className="flex-1 min-w-0 max-w-3xl">
         {children}
+        <DocsPrevNext nav={nav} />
       </article>
     </div>
   );

--- a/apps/dejajs-www/components/DocsPrevNext.tsx
+++ b/apps/dejajs-www/components/DocsPrevNext.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import type { DocNavItem } from '../lib/generate-docs-nav';
+
+function flattenNav(items: DocNavItem[]): DocNavItem[] {
+  const flat: DocNavItem[] = [];
+  for (const item of items) {
+    if (!item.comingSoon && item.href !== '#') {
+      flat.push(item);
+    }
+    if (item.children) {
+      flat.push(...flattenNav(item.children));
+    }
+  }
+  // Deduplicate by href (section parents may duplicate their overview child)
+  const seen = new Set<string>();
+  return flat.filter((item) => {
+    if (seen.has(item.href)) return false;
+    seen.add(item.href);
+    return true;
+  });
+}
+
+export default function DocsPrevNext({ nav }: { nav: DocNavItem[] }) {
+  const pathname = usePathname();
+  const pages = flattenNav(nav);
+  const currentIdx = pages.findIndex((p) => p.href === pathname);
+
+  if (currentIdx === -1) return null;
+
+  const prev = currentIdx > 0 ? pages[currentIdx - 1] : null;
+  const next = currentIdx < pages.length - 1 ? pages[currentIdx + 1] : null;
+
+  if (!prev && !next) return null;
+
+  return (
+    <nav aria-label="Previous and next pages" className="mt-12 pt-6 border-t border-gray-200 dark:border-gray-700/50 flex justify-between gap-4">
+      {prev ? (
+        <Link
+          href={prev.href}
+          className="group flex items-center gap-2 px-4 py-2.5 rounded-lg border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:border-gray-400 dark:hover:border-gray-500 hover:text-gray-900 dark:hover:text-white transition-colors"
+        >
+          <svg className="w-4 h-4 shrink-0 transition-transform group-hover:-translate-x-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+          </svg>
+          <span className="min-w-0">
+            <span className="block text-[10px] uppercase tracking-wider font-semibold opacity-50">Prev</span>
+            <span className="block text-sm font-medium truncate">{prev.title}</span>
+          </span>
+        </Link>
+      ) : (
+        <span />
+      )}
+      {next ? (
+        <Link
+          href={next.href}
+          className="group flex items-center gap-2 px-4 py-2.5 rounded-lg border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:border-gray-400 dark:hover:border-gray-500 hover:text-gray-900 dark:hover:text-white transition-colors text-right"
+        >
+          <span className="min-w-0">
+            <span className="block text-[10px] uppercase tracking-wider font-semibold opacity-50">Next</span>
+            <span className="block text-sm font-medium truncate">{next.title}</span>
+          </span>
+          <svg className="w-4 h-4 shrink-0 transition-transform group-hover:translate-x-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+          </svg>
+        </Link>
+      ) : (
+        <span />
+      )}
+    </nav>
+  );
+}

--- a/apps/dejajs-www/components/Header.tsx
+++ b/apps/dejajs-www/components/Header.tsx
@@ -80,25 +80,25 @@ const defaultProducts: ProductItem[] = [
 ];
 
 const defaultGuidesLinks: DocItem[] = [
-  { name: 'Getting Started', href: '/guides/getting-started', icon: '🚀' },
-  { name: 'Architecture', href: '/guides/architecture', icon: '🏗️' },
-  { name: 'Throttle', href: '/guides/throttle', icon: '🚂' },
-  { name: 'Cloud', href: '/guides/cloud', icon: '☁️', comingSoon: true },
-  { name: 'Monitor', href: '/guides/monitor', icon: '📊', comingSoon: true },
-  { name: 'Server', href: '/guides/server', icon: '🖥️', comingSoon: true },
-  { name: 'IO', href: '/guides/io', icon: '🔌', comingSoon: true },
+  { name: 'Getting Started', href: '/guides/getting-started' },
+  { name: 'Architecture', href: '/guides/architecture' },
+  { name: 'Throttle', href: '/guides/throttle' },
+  { name: 'Cloud', href: '/guides/cloud', comingSoon: true },
+  { name: 'Monitor', href: '/guides/monitor', comingSoon: true },
+  { name: 'Server', href: '/guides/server', comingSoon: true },
+  { name: 'IO', href: '/guides/io', comingSoon: true },
 ];
 
 const defaultDocsLinks: DocItem[] = [
-  { name: 'Server', href: '/docs/server', icon: '🖥️' },
-  { name: 'Throttle', href: '/docs/throttle', icon: '🚂' },
-  { name: 'Cloud', href: '/docs/cloud', icon: '☁️' },
-  { name: 'Monitor', href: '/docs/monitor', icon: '📊' },
-  { name: 'Tour', href: '/docs/tour', icon: '🗺️' },
-  { name: 'IO', href: '/docs/io', icon: '🔌' },
-  { name: 'Program', href: '#', icon: '⚙️', comingSoon: true },
-  { name: 'AI Ops', href: '#', icon: '🤖', comingSoon: true },
-  { name: 'Dispatcher', href: '#', icon: '🚦', comingSoon: true },
+  { name: 'Server', href: '/docs/server' },
+  { name: 'Throttle', href: '/docs/throttle' },
+  { name: 'Cloud', href: '/docs/cloud' },
+  { name: 'Monitor', href: '/docs/monitor' },
+  { name: 'Tour', href: '/docs/tour' },
+  { name: 'IO', href: '/docs/io' },
+  { name: 'Program', href: '#', comingSoon: true },
+  { name: 'AI Ops', href: '#', comingSoon: true },
+  { name: 'Dispatcher', href: '#', comingSoon: true },
 ];
 
 function useDropdown() {
@@ -297,9 +297,9 @@ export default function Header({ settings }: { settings?: SiteSettings | null })
                         href={product.href}
                         role="menuitem"
                         aria-current={pathname === product.href ? 'page' : undefined}
-                        className="flex items-start gap-3 p-3 rounded-lg hover:bg-slate-50 dark:hover:bg-slate-700 transition-colors group/item"
+                        className="flex items-center gap-3 p-3 rounded-lg hover:bg-slate-50 dark:hover:bg-slate-700 transition-colors group/item"
                       >
-                        <Image src={product.logo} alt="" width={40} height={40} className="h-10 w-10 flex-shrink-0 mt-0.5" />
+                        <Image src={product.logo} alt="" width={40} height={40} className="h-10 w-10 flex-shrink-0" />
                         <div className="min-w-0">
                           <div className="font-medium text-slate-900 dark:text-white group-hover/item:text-cyan-400 transition-colors">
                             {product.name}

--- a/apps/dejajs-www/content/docs/io/custom-devices.mdx
+++ b/apps/dejajs-www/content/docs/io/custom-devices.mdx
@@ -1,5 +1,6 @@
 ---
 title: Building Custom Devices
+navTitle: Custom Devices
 description: How to build custom MQTT and serial devices that communicate with the DEJA.js server for layout automation.
 section: io
 order: 9

--- a/apps/dejajs-www/content/docs/io/websocket-integration.mdx
+++ b/apps/dejajs-www/content/docs/io/websocket-integration.mdx
@@ -1,5 +1,6 @@
 ---
 title: WebSocket Integration
+navTitle: WebSocket
 description: How to connect custom scripts and applications to the DEJA.js server via WebSocket for real-time command and status monitoring.
 section: io
 order: 10

--- a/apps/dejajs-www/lib/generate-docs-nav.ts
+++ b/apps/dejajs-www/lib/generate-docs-nav.ts
@@ -28,6 +28,13 @@ function getSectionFromPath(file: string): string {
   return 'Getting Started';
 }
 
+const NAV_TITLE_SUFFIXES = /\s+(Management|Configuration|Integration|View|Screen|List|Viewer|Library|Console)$/i;
+const NAV_TITLE_PREFIXES = /^(Building|Explore|Locomotive)\s+/i;
+
+function shortenNavTitle(title: string): string {
+  return title.replace(NAV_TITLE_PREFIXES, '').replace(NAV_TITLE_SUFFIXES, '').trim();
+}
+
 function getSectionSlug(sectionName: string): string {
   const map: Record<string, string> = {
     'Throttle': 'throttle',
@@ -58,7 +65,7 @@ export function generateDocsNav(): DocNavItem[] {
     const href = `/docs${slugArray.length > 0 ? '/' + slugArray.join('/') : ''}`;
 
     const item: DocNavItem = {
-      title: frontmatter.title || path.basename(file, '.mdx').replace(/-/g, ' ').replace(/\b\w/g, (l: string) => l.toUpperCase()),
+      title: frontmatter.navTitle || shortenNavTitle(frontmatter.title || path.basename(file, '.mdx').replace(/-/g, ' ').replace(/\b\w/g, (l: string) => l.toUpperCase())),
       href,
       order: frontmatter.order || 999,
     };


### PR DESCRIPTION
## Summary
- 🚫 Remove emoji icons from Guides and Docs dropdown menus in the site header
- 🎯 Center-align product nav labels with their icons (was `items-start`, now `items-center`)
- ⏮️⏭️ Add prev/next page navigation component at the bottom of every docs page
- ✂️ Auto-shorten verbose doc sidebar titles (e.g., "Effects Management" → "Effects", "Locomotive Roster" → "Roster")

## Changes
- **`Header.tsx`** — stripped `icon` props from `defaultGuidesLinks` and `defaultDocsLinks`, changed product card alignment
- **`DocsPrevNext.tsx`** — new client component: flattens sidebar nav tree, finds current page, renders ghost bordered buttons with chevrons + page title
- **`layout.tsx`** (docs) — renders `<DocsPrevNext>` below every docs page
- **`generate-docs-nav.ts`** — added `shortenNavTitle()` (strips common prefixes/suffixes like "Management", "Configuration", "View", etc.) and `navTitle` frontmatter override support

## Test plan
- [ ] Verify Guides/Docs dropdowns render cleanly without emoji icons
- [ ] Verify product dropdown labels are vertically centered with logos
- [ ] Navigate through docs pages — prev/next buttons should show correct adjacent pages
- [ ] Check docs sidebar — titles should be concise (no "Configuration", "Management" suffixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)