### PR TITLE
feat(cloud): loading states, empty states, filters & UI polish

### DIFF
--- a/apps/cloud/src/Effects/Effects.vue
+++ b/apps/cloud/src/Effects/Effects.vue
@@ -1,25 +1,46 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import type { Effect } from '@repo/modules'
 import { efxTypes, useEfx } from '@repo/modules/effects'
-import { useLayout, type Tag } from '@repo/modules'
+import { useLayout, type Tag, useSubscription, PLAN_DISPLAY } from '@repo/modules'
 import { useRouter } from 'vue-router'
 import { PageHeader, ListControlBar, useListControls } from '@repo/ui'
 import type { ListFilter } from '@repo/ui'
 import EffectsList from '@/Effects/EffectsList.vue'
+import EmptyState from '@/Core/UI/EmptyState.vue'
 
 const router = useRouter()
 const { getEffects } = useEfx()
 const { getDevices, getLayout } = useLayout()
+const { plan } = useSubscription()
 const devices = getDevices()
 const layout = getLayout()
 const effects = getEffects()
+
+// 🔄 Loading state
+const isLoaded = ref(false)
+let loadingTimeout: ReturnType<typeof setTimeout> | undefined
+onMounted(async () => {
+  loadingTimeout = setTimeout(() => { isLoaded.value = true }, 3000)
+  try {
+    await (effects as any).promise
+  } finally {
+    clearTimeout(loadingTimeout)
+    isLoaded.value = true
+  }
+})
+onUnmounted(() => clearTimeout(loadingTimeout))
+
+const isLoading = computed(() => !isLoaded.value)
+const isFreePlan = computed(() => plan.value === 'hobbyist')
 
 const effectsList = computed(() =>
   effects?.value
     ? effects.value.map((effect) => ({ ...effect, id: effect.id }))
     : []
 )
+
+const hasItems = computed(() => isLoaded.value && effectsList.value.length > 0)
 
 const deviceOptions = computed(() =>
   devices?.value ? devices.value.map((d) => ({ label: d.id, value: d.id })) : []
@@ -59,28 +80,54 @@ function handleAdd() {
 }
 </script>
 <template>
-  <PageHeader title="Effects" icon="mdi-rocket-launch" color="indigo" subtitle="Manage lighting, sound, and special effects for your layout.">
-    <template #actions>
-      <v-btn
-        prepend-icon="mdi-plus"
-        color="indigo"
-        variant="flat"
-        @click="handleAdd"
-      >
-        New Effect
-      </v-btn>
-    </template>
-    <template #controls>
-      <ListControlBar
-        :controls="controls"
-        color="indigo"
-        :sort-options="sortOptions"
-        :filters="filters"
-        :show-view="false"
-        search-placeholder="Search effects..."
-      />
-    </template>
-  </PageHeader>
+  <!-- 🔄 Loading -->
+  <div v-if="isLoading" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 p-4">
+    <v-skeleton-loader v-for="n in 6" :key="n" type="card" />
+  </div>
 
-  <EffectsList :filtered-list="controls.filteredList.value" @edit="handleEdit" />
+  <!-- ✅ Has items -->
+  <template v-else-if="hasItems">
+    <PageHeader title="Effects" icon="mdi-rocket-launch" color="indigo" subtitle="Manage lighting, sound, and special effects for your layout.">
+      <template #actions>
+        <v-btn
+          prepend-icon="mdi-plus"
+          color="indigo"
+          variant="flat"
+          @click="handleAdd"
+        >
+          New Effect
+        </v-btn>
+      </template>
+      <template #controls>
+        <ListControlBar
+          :controls="controls"
+          color="indigo"
+          :sort-options="sortOptions"
+          :filters="filters"
+          :show-view="false"
+          search-placeholder="Search effects..."
+        />
+      </template>
+    </PageHeader>
+
+    <EffectsList :filtered-list="controls.filteredList.value" @edit="handleEdit" />
+  </template>
+
+  <!-- 📭 Empty -->
+  <EmptyState
+    v-else
+    icon="mdi-rocket-launch"
+    color="indigo"
+    title="No Effects Yet"
+    :description="isFreePlan
+      ? `Upgrade to ${PLAN_DISPLAY.engineer.name} to create lighting, sound, and animation effects for your layout.`
+      : 'Create lighting, sound, and animation effects to bring your layout to life with immersive scenery and interactive elements.'"
+    :use-cases="[
+      { icon: 'mdi-volume-high', text: 'Ambient sounds & audio' },
+      { icon: 'mdi-led-on', text: 'LED animations & lighting' },
+      { icon: 'mdi-play-circle', text: 'Triggered sequences' },
+    ]"
+    :action-label="isFreePlan ? `Upgrade to ${PLAN_DISPLAY.engineer.name}` : 'Create Your First Effect'"
+    :action-to="isFreePlan ? '/upgrade' : '/effects/new'"
+  />
 </template>

--- a/apps/cloud/src/Effects/EffectsList.vue
+++ b/apps/cloud/src/Effects/EffectsList.vue
@@ -5,7 +5,6 @@ import { useEfx, type Effect } from '@repo/modules'
 import { createLogger } from '@repo/utils'
 import { useSortableList } from '@/Core/composables/useSortableList'
 import EffectListItem from '@/Effects/EffectListItem.vue'
-import EmptyState from '@/Core/UI/EmptyState.vue'
 
 const log = createLogger('EffectsList')
 
@@ -51,16 +50,10 @@ function handleEdit(item: Effect) {
       </template>
     </draggable>
   </v-container>
-  <EmptyState
-    v-if="!list?.length"
-    icon="mdi-rocket-launch"
-    color="indigo"
-    title="No Effects Yet"
-    description="Create lighting, sound, and animation effects to bring your layout to life with immersive scenery and interactive elements."
-    :use-cases="[{ icon: 'mdi-volume-high', text: 'Ambient sounds & audio' }, { icon: 'mdi-led-on', text: 'LED animations & lighting' }, { icon: 'mdi-play-circle', text: 'Triggered sequences' }]"
-    action-label="Create Your First Effect"
-    action-to="/effects/new"
-  />
+  <div v-if="!list?.length" class="flex flex-col items-center justify-center py-12 px-4">
+    <v-icon size="48" class="opacity-30 mb-3">mdi-magnify-close</v-icon>
+    <p class="text-sm opacity-60">No effects match your filters.</p>
+  </div>
 </template>
 <style scoped>
 .ghost {

--- a/apps/cloud/src/Layout/Layout.vue
+++ b/apps/cloud/src/Layout/Layout.vue
@@ -7,6 +7,7 @@ import { PageHeader } from '@repo/ui'
 import DeviceListItem from '@/Layout/Devices/DeviceListItem.vue'
 import AddDeviceItem from '@/Layout/Devices/AddDeviceItem.vue'
 import AddTile from '@/Core/UI/AddTile.vue'
+import PortList from '@/Layout/PortList.vue'
 
 const { getLayout, getDevices, updateDevice } = useLayout()
 
@@ -41,6 +42,8 @@ const showAdd = ref(false)
       </template>
     </draggable>
     <AddDeviceItem :show="showAdd" @close="showAdd = false" class="mt-4" />
+
+    <PortList v-if="layout?.ports?.length" :ports="layout.ports" class="mt-6" />
   </div>
 </template>
 <style scoped>

--- a/apps/cloud/src/Roster/Roster.vue
+++ b/apps/cloud/src/Roster/Roster.vue
@@ -6,11 +6,12 @@ import { useStorage } from '@vueuse/core'
 import { rtdb } from '@repo/firebase-config'
 import type { Loco } from '@repo/modules/locos'
 import { useLocos } from '@repo/modules/locos'
-import { useLayout, useServerStatus } from '@repo/modules'
+import { useLayout, useServerStatus, useSubscription, PLAN_DISPLAY } from '@repo/modules'
 import { useDcc } from '@repo/dccex'
 import { PageHeader, ListControlBar, useListControls } from '@repo/ui'
+import type { ListFilter } from '@repo/ui'
 import RosterList from '@/Roster/RosterList.vue'
-import AddTile from '@/Core/UI/AddTile.vue'
+import EmptyState from '@/Core/UI/EmptyState.vue'
 import { ThrottleLaunchQR } from '@repo/ui'
 
 const router = useRouter()
@@ -19,9 +20,26 @@ const { getLocos } = useLocos()
 const { syncAllRoster, importRoster } = useDcc()
 const { getDevices } = useLayout()
 const { serverStatus } = useServerStatus()
+const { plan } = useSubscription()
 
 const locos = getLocos()
 const devices = getDevices()
+
+// 🔄 Loading state
+const isLoaded = ref(false)
+let loadingTimeout: ReturnType<typeof setTimeout> | undefined
+onMounted(async () => {
+  loadingTimeout = setTimeout(() => { isLoaded.value = true }, 3000)
+  try {
+    await (locos as any).promise
+  } finally {
+    clearTimeout(loadingTimeout)
+    isLoaded.value = true
+  }
+})
+
+const isLoading = computed(() => !isLoaded.value)
+const isFreePlan = computed(() => plan.value === 'hobbyist')
 
 const isDisconnected = computed(() => {
   const serverOffline = !serverStatus.value?.online
@@ -32,10 +50,45 @@ const isDisconnected = computed(() => {
 })
 
 const rosterList = computed(() =>
-  locos?.value ? locos.value.map((l) => ({ ...l, id: l.address })) : []
+  locos?.value ? locos.value.map((l) => ({
+    ...l,
+    id: l.address,
+    sound: l.hasSound ? 'sound' : 'silent',
+    locoType: l.consist?.length ? 'consist' : 'single',
+  })) : []
 )
-const rosterControls = useListControls('cloud-roster', { list: rosterList })
 
+const hasItems = computed(() => isLoaded.value && rosterList.value.length > 0)
+
+// 🔍 Filter & sort options
+const soundOptions = [
+  { label: 'Sound Decoder', value: 'sound' },
+  { label: 'Silent', value: 'silent' },
+]
+
+const typeOptions = [
+  { label: 'Consist', value: 'consist' },
+  { label: 'Single', value: 'single' },
+]
+
+const filters = computed<ListFilter[]>(() => [
+  { type: 'sound', label: 'Sound', options: soundOptions },
+  { type: 'locoType', label: 'Type', options: typeOptions },
+])
+
+const sortOptions = [
+  { value: 'order', label: 'Default' },
+  { value: 'name', label: 'Name' },
+  { value: 'address', label: 'Address' },
+]
+
+const rosterControls = useListControls('cloud-roster', {
+  list: rosterList,
+  filters: filters.value,
+  sortOptions,
+})
+
+// 📡 Roster sync status
 interface RosterSyncStatus {
   status: 'syncing' | 'success' | 'error' | 'importing'
   message: string
@@ -76,6 +129,7 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
+  clearTimeout(loadingTimeout)
   if (unsubscribeStatus) unsubscribeStatus()
 })
 
@@ -98,53 +152,79 @@ async function importFromCS() {
 </script>
 
 <template>
-  <PageHeader title="Roster" icon="mdi-train" color="pink">
-    <template #controls>
-      <ListControlBar
-        :controls="rosterControls"
-        color="pink"
-        :show-filters="false"
-        :show-view="false"
-        :show-sort="false"
-        search-placeholder="Search roster..."
-      />
-    </template>
-    <template #actions>
-      <v-btn
-        :loading="rosterSyncStatus?.status === 'syncing'"
-        :disabled="isSyncing || isDisconnected"
-        prepend-icon="mdi-sync"
-        variant="tonal"
-        color="primary"
-        size="small"
-        @click="syncToCS"
-      >
-        Sync to DCC-EX
-      </v-btn>
-      <v-btn
-        :loading="rosterSyncStatus?.status === 'importing'"
-        :disabled="isSyncing || isDisconnected"
-        prepend-icon="mdi-download"
-        variant="tonal"
-        color="secondary"
-        size="small"
-        @click="importFromCS"
-      >
-        Import from DCC-EX
-      </v-btn>
-    </template>
-  </PageHeader>
+  <!-- 🔄 Loading -->
+  <div v-if="isLoading" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 p-4">
+    <v-skeleton-loader v-for="n in 6" :key="n" type="card" />
+  </div>
 
-  <RosterList @edit="handleEditLoco">
-    <template #prepend>
-      <AddTile @click="handleAddLoco" />
-    </template>
-    <template #append>
-      <v-card variant="outlined" class="d-flex flex-column align-center justify-center pa-4 text-center" min-height="120">
-        <ThrottleLaunchQR :size="100" label="Open Throttle on phone" />
-      </v-card>
-    </template>
-  </RosterList>
+  <!-- ✅ Has items -->
+  <template v-else-if="hasItems">
+    <PageHeader title="Roster" icon="mdi-train" color="pink" subtitle="Manage your locomotive fleet and decoder configurations.">
+      <template #controls>
+        <ListControlBar
+          :controls="rosterControls"
+          color="pink"
+          :sort-options="sortOptions"
+          :filters="filters"
+          :show-view="false"
+          search-placeholder="Search roster..."
+        />
+      </template>
+      <template #actions>
+        <v-btn prepend-icon="mdi-plus" color="pink" variant="flat" @click="handleAddLoco">
+          New Loco
+        </v-btn>
+        <v-btn
+          :loading="rosterSyncStatus?.status === 'syncing'"
+          :disabled="isSyncing || isDisconnected"
+          prepend-icon="mdi-sync"
+          variant="tonal"
+          color="pink"
+          size="small"
+          @click="syncToCS"
+        >
+          Sync to DCC-EX
+        </v-btn>
+        <v-btn
+          :loading="rosterSyncStatus?.status === 'importing'"
+          :disabled="isSyncing || isDisconnected"
+          prepend-icon="mdi-download"
+          variant="tonal"
+          color="pink"
+          size="small"
+          @click="importFromCS"
+        >
+          Import from DCC-EX
+        </v-btn>
+      </template>
+    </PageHeader>
+
+    <RosterList :filtered-list="rosterControls.filteredList.value" @edit="handleEditLoco">
+      <template #append>
+        <v-card variant="outlined" class="d-flex flex-column align-center justify-center pa-4 text-center" min-height="120">
+          <ThrottleLaunchQR :size="100" label="Open Throttle on phone" />
+        </v-card>
+      </template>
+    </RosterList>
+  </template>
+
+  <!-- 📭 Empty -->
+  <EmptyState
+    v-else
+    icon="mdi-train"
+    color="pink"
+    title="No Locomotives Yet"
+    :description="isFreePlan
+      ? `Upgrade to ${PLAN_DISPLAY.engineer.name} to unlock the full roster experience with up to 25 locomotives and advanced features.`
+      : 'Build your digital roster by adding locomotives with their DCC addresses, decoder functions, and custom configurations.'"
+    :use-cases="[
+      { icon: 'mdi-memory', text: 'Program DCC decoders' },
+      { icon: 'mdi-tune', text: 'Configure functions & lights' },
+      { icon: 'mdi-train-car', text: 'Build consists' },
+    ]"
+    :action-label="isFreePlan ? `Upgrade to ${PLAN_DISPLAY.engineer.name}` : 'Add Your First Loco'"
+    :action-to="isFreePlan ? '/upgrade' : '/locos/new'"
+  />
 
   <v-snackbar
     v-model="snackbarOpen"

--- a/apps/cloud/src/Roster/RosterList.vue
+++ b/apps/cloud/src/Roster/RosterList.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
+import { computed, type PropType } from 'vue'
 import draggable from 'vuedraggable'
-import EmptyState from '@/Core/UI/EmptyState.vue'
 import RosterItem from '@/Roster/RosterItem.vue'
 import { useLocos, type Loco } from '@repo/modules/locos'
 import { createLogger } from '@repo/utils'
@@ -8,12 +8,17 @@ import { useSortableList } from '@/Core/composables/useSortableList'
 
 const log = createLogger('RosterList')
 
+const props = defineProps({
+  filteredList: { type: Array as PropType<Loco[]>, default: undefined },
+})
 const emit = defineEmits(['edit'])
 
 const { getLocos, updateLoco } = useLocos()
 
 const rawLocos = getLocos()
-const { list: locos, onDragStart, onDragEnd } = useSortableList<Loco>(rawLocos as any, (id, data) => updateLoco(id, data as any))
+const { list: sortableLocos, onDragStart, onDragEnd } = useSortableList<Loco>(rawLocos as any, (id, data) => updateLoco(id, data as any))
+
+const list = computed(() => props.filteredList ?? sortableLocos.value)
 
 function handleEdit(loco: Loco) {
   log.debug('handleEdit', loco)
@@ -23,8 +28,8 @@ function handleEdit(loco: Loco) {
 </script>
 <template>
   <draggable
-    v-if="locos?.length"
-    :list="locos"
+    v-if="list?.length"
+    :list="list"
     item-key="id"
     handle=".drag-handle"
     ghost-class="ghost"
@@ -43,16 +48,10 @@ function handleEdit(loco: Loco) {
       </div>
     </template>
   </draggable>
-  <EmptyState
-    v-if="!locos?.length"
-    icon="mdi-train"
-    color="pink"
-    title="No Locomotives Yet"
-    description="Build your digital roster by adding locomotives with their DCC addresses, decoder functions, and custom configurations."
-    :use-cases="[{ icon: 'mdi-memory', text: 'Program DCC decoders' }, { icon: 'mdi-tune', text: 'Configure functions & lights' }, { icon: 'mdi-train-car', text: 'Build consists' }]"
-    action-label="Add Your First Loco"
-    action-to="/locos/new"
-  />
+  <div v-if="!list?.length" class="flex flex-col items-center justify-center py-12 px-4">
+    <v-icon size="48" class="opacity-30 mb-3">mdi-magnify-close</v-icon>
+    <p class="text-sm opacity-60">No locomotives match your filters.</p>
+  </div>
 </template>
 <style scoped>
 .ghost {

--- a/apps/cloud/src/Routes/Routes.vue
+++ b/apps/cloud/src/Routes/Routes.vue
@@ -1,11 +1,64 @@
 <script setup lang="ts">
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import type { Route } from '@repo/modules'
+import { useRoutes } from '@repo/modules/routes/useRoutes'
+import { useLayout, type Tag, useSubscription, PLAN_DISPLAY } from '@repo/modules'
 import { useRouter } from 'vue-router'
-import { PageHeader } from '@repo/ui'
+import { PageHeader, ListControlBar, useListControls } from '@repo/ui'
+import type { ListFilter } from '@repo/ui'
 import RoutesList from '@/Routes/RoutesList.vue'
-import AddTile from '@/Core/UI/AddTile.vue'
+import EmptyState from '@/Core/UI/EmptyState.vue'
 
 const router = useRouter()
+const { getRoutes } = useRoutes()
+const { getLayout } = useLayout()
+const { plan } = useSubscription()
+const layout = getLayout()
+const routes = getRoutes()
+
+// 🔄 Loading state
+const isLoaded = ref(false)
+let loadingTimeout: ReturnType<typeof setTimeout> | undefined
+onMounted(async () => {
+  loadingTimeout = setTimeout(() => { isLoaded.value = true }, 3000)
+  try {
+    await (routes as any).promise
+  } finally {
+    clearTimeout(loadingTimeout)
+    isLoaded.value = true
+  }
+})
+onUnmounted(() => clearTimeout(loadingTimeout))
+
+const isLoading = computed(() => !isLoaded.value)
+const isFreePlan = computed(() => plan.value === 'hobbyist')
+
+const routesList = computed(() =>
+  routes?.value ? routes.value.map((r) => ({ ...r, id: r.id })) : []
+)
+
+const hasItems = computed(() => isLoaded.value && routesList.value.length > 0)
+
+const tagOptions = computed(() =>
+  layout?.value?.tags
+    ? layout.value.tags.map((tag: Tag) => ({ label: tag.name, value: tag.id }))
+    : []
+)
+
+const filters = computed<ListFilter[]>(() => [
+  ...(tagOptions.value.length ? [{ type: 'tags', label: 'Tags', options: tagOptions.value }] : []),
+])
+
+const sortOptions = [
+  { value: 'order', label: 'Default' },
+  { value: 'name', label: 'Name' },
+]
+
+const controls = useListControls('cloud-routes', {
+  list: routesList,
+  filters: filters.value,
+  sortOptions,
+})
 
 function handleEdit(route: Route) {
   router.push({ name: 'Edit Route', params: { routeId: route.id } })
@@ -14,13 +67,51 @@ function handleEdit(route: Route) {
 function handleAdd() {
   router.push({ name: 'Add Route' })
 }
-
 </script>
 <template>
-  <PageHeader title="Routes" icon="mdi-map" color="purple" />
-  <RoutesList @edit="handleEdit">
-    <template #prepend>
-      <AddTile @click="handleAdd" color="purple" />
-    </template>
-  </RoutesList>
+  <!-- 🔄 Loading -->
+  <div v-if="isLoading" class="grid grid-cols-1 gap-3 p-4">
+    <v-skeleton-loader v-for="n in 4" :key="n" type="card" />
+  </div>
+
+  <!-- ✅ Has items -->
+  <template v-else-if="hasItems">
+    <PageHeader title="Routes" icon="mdi-map" color="purple" subtitle="Automated multi-turnout paths for your layout.">
+      <template #actions>
+        <v-btn prepend-icon="mdi-plus" color="purple" variant="flat" @click="handleAdd">
+          New Route
+        </v-btn>
+      </template>
+      <template #controls>
+        <ListControlBar
+          :controls="controls"
+          color="purple"
+          :sort-options="sortOptions"
+          :filters="filters"
+          :show-view="false"
+          search-placeholder="Search routes..."
+        />
+      </template>
+    </PageHeader>
+
+    <RoutesList :filtered-list="controls.filteredList.value" @edit="handleEdit" />
+  </template>
+
+  <!-- 📭 Empty -->
+  <EmptyState
+    v-else
+    icon="mdi-map"
+    color="purple"
+    title="No Routes Yet"
+    :description="isFreePlan
+      ? `Upgrade to ${PLAN_DISPLAY.engineer.name} to create automated routes that throw multiple turnouts in sequence.`
+      : 'Create automated paths that throw multiple turnouts in sequence, making complex track arrangements a single-click operation.'"
+    :use-cases="[
+      { icon: 'mdi-arrow-decision', text: 'Yard entry paths' },
+      { icon: 'mdi-highway', text: 'Mainline bypass' },
+      { icon: 'mdi-format-list-group', text: 'Multi-turnout sequences' },
+    ]"
+    :action-label="isFreePlan ? `Upgrade to ${PLAN_DISPLAY.engineer.name}` : 'Create Your First Route'"
+    :action-to="isFreePlan ? '/upgrade' : '/routes/new'"
+  />
 </template>

--- a/apps/cloud/src/Routes/RoutesList.vue
+++ b/apps/cloud/src/Routes/RoutesList.vue
@@ -1,4 +1,5 @@
 <script async setup lang="ts">
+import { computed, type PropType } from 'vue'
 import draggable from 'vuedraggable'
 import { useCollection } from 'vuefire'
 import { type Route } from '@repo/modules/index.ts'
@@ -6,15 +7,19 @@ import { useRoutes } from '@repo/modules/routes/useRoutes'
 import { createLogger } from '@repo/utils'
 import { useSortableList } from '@/Core/composables/useSortableList'
 import RouteListItem from '@/Routes/RouteListItem.vue'
-import EmptyState from '@/Core/UI/EmptyState.vue'
 
 const log = createLogger('RoutesList')
 
+const props = defineProps({
+  filteredList: { type: Array as PropType<Route[]>, default: undefined },
+})
 const emit = defineEmits(['edit'])
 
 const { routesCol, setRoute } = useRoutes()
 const rawList = useCollection<Route>(routesCol, { ssrKey: 'routes' })
-const { list, onDragStart, onDragEnd } = useSortableList<Route>(rawList as any, (id, data) => setRoute(id, data as any))
+const { list: sortableList, onDragStart, onDragEnd } = useSortableList<Route>(rawList as any, (id, data) => setRoute(id, data as any))
+
+const list = computed(() => props.filteredList ?? sortableList.value)
 
 function handleEdit(item: Route) {
   log.debug('handleEdit', item)
@@ -45,16 +50,10 @@ function handleEdit(item: Route) {
       </template>
     </draggable>
   </v-container>
-  <EmptyState
-    v-if="!list?.length"
-    icon="mdi-map"
-    color="purple"
-    title="No Routes Yet"
-    description="Create automated paths that throw multiple turnouts in sequence, making complex track arrangements a single-click operation."
-    :use-cases="[{ icon: 'mdi-arrow-decision', text: 'Yard entry paths' }, { icon: 'mdi-highway', text: 'Mainline bypass' }, { icon: 'mdi-format-list-group', text: 'Multi-turnout sequences' }]"
-    action-label="Create Your First Route"
-    action-to="/routes/new"
-  />
+  <div v-if="!list?.length" class="flex flex-col items-center justify-center py-12 px-4">
+    <v-icon size="48" class="opacity-30 mb-3">mdi-magnify-close</v-icon>
+    <p class="text-sm opacity-60">No routes match your filters.</p>
+  </div>
 </template>
 <style scoped>
 .ghost {

--- a/apps/cloud/src/Sensors/SensorList.vue
+++ b/apps/cloud/src/Sensors/SensorList.vue
@@ -3,7 +3,6 @@ import { computed, ref, type PropType } from 'vue'
 import draggable from 'vuedraggable'
 import { useSensors, type Sensor, sensorTypes, sensorInputTypes } from '@repo/modules/sensors'
 import { useSortableList } from '@/Core/composables/useSortableList'
-import EmptyState from '@/Core/UI/EmptyState.vue'
 
 defineEmits(['edit'])
 const props = defineProps({
@@ -145,16 +144,10 @@ function getInputTypeLabel(inputType: string): string {
       </template>
     </draggable>
   </v-container>
-  <EmptyState
-    v-if="!list?.length"
-    icon="mdi-access-point"
-    color="teal"
-    title="No Sensors Yet"
-    description="Configure sensors to detect train positions, occupancy, and environmental conditions on your layout."
-    :use-cases="[{ icon: 'mdi-map-marker', text: 'Block occupancy detection' }, { icon: 'mdi-motion-sensor', text: 'Position tracking' }, { icon: 'mdi-robot', text: 'Automation triggers' }]"
-    action-label="Add Your First Sensor"
-    action-to="/sensors/new"
-  />
+  <div v-if="!list?.length" class="flex flex-col items-center justify-center py-12 px-4">
+    <v-icon size="48" class="opacity-30 mb-3">mdi-magnify-close</v-icon>
+    <p class="text-sm opacity-60">No sensors match your filters.</p>
+  </div>
 </template>
 <style scoped>
 .ghost {

--- a/apps/cloud/src/Sensors/Sensors.vue
+++ b/apps/cloud/src/Sensors/Sensors.vue
@@ -1,23 +1,44 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import type { Sensor } from '@repo/modules/sensors'
 import { useSensors } from '@repo/modules/sensors'
-import { useLayout, type Tag } from '@repo/modules'
+import { useLayout, type Tag, useSubscription, PLAN_DISPLAY } from '@repo/modules'
 import { useRouter } from 'vue-router'
 import { PageHeader, ListControlBar, useListControls } from '@repo/ui'
 import type { ListFilter } from '@repo/ui'
 import SensorList from '@/Sensors/SensorList.vue'
+import EmptyState from '@/Core/UI/EmptyState.vue'
 
 const router = useRouter()
 const { getSensors } = useSensors()
 const { getDevices, getLayout } = useLayout()
+const { plan } = useSubscription()
 const devices = getDevices()
 const layout = getLayout()
 const sensors = getSensors()
 
+// 🔄 Loading state
+const isLoaded = ref(false)
+let loadingTimeout: ReturnType<typeof setTimeout> | undefined
+onMounted(async () => {
+  loadingTimeout = setTimeout(() => { isLoaded.value = true }, 3000)
+  try {
+    await (sensors as any).promise
+  } finally {
+    clearTimeout(loadingTimeout)
+    isLoaded.value = true
+  }
+})
+onUnmounted(() => clearTimeout(loadingTimeout))
+
+const isLoading = computed(() => !isLoaded.value)
+const isFreePlan = computed(() => plan.value === 'hobbyist')
+
 const sensorsList = computed(() =>
   sensors?.value ? sensors.value.map((s) => ({ ...s, id: s.id })) : []
 )
+
+const hasItems = computed(() => isLoaded.value && sensorsList.value.length > 0)
 
 const deviceOptions = computed(() =>
   devices?.value ? devices.value.map((d) => ({ label: d.id, value: d.id })) : []
@@ -54,22 +75,49 @@ function handleAdd() {
 }
 </script>
 <template>
-  <PageHeader title="Sensors" icon="mdi-access-point" color="teal" subtitle="Monitor track occupancy and feedback sensors.">
-    <template #actions>
-      <v-btn prepend-icon="mdi-plus" color="teal" variant="flat" @click="handleAdd">
-        New Sensor
-      </v-btn>
-    </template>
-    <template #controls>
-      <ListControlBar
-        :controls="controls"
-        color="teal"
-        :sort-options="sortOptions"
-        :filters="filters"
-        :show-view="false"
-        search-placeholder="Search sensors..."
-      />
-    </template>
-  </PageHeader>
-  <SensorList :filtered-list="controls.filteredList.value" @edit="handleEdit" />
+  <!-- 🔄 Loading -->
+  <div v-if="isLoading" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 p-4">
+    <v-skeleton-loader v-for="n in 6" :key="n" type="card" />
+  </div>
+
+  <!-- ✅ Has items -->
+  <template v-else-if="hasItems">
+    <PageHeader title="Sensors" icon="mdi-access-point" color="teal" subtitle="Monitor track occupancy and feedback sensors.">
+      <template #actions>
+        <v-btn prepend-icon="mdi-plus" color="teal" variant="flat" @click="handleAdd">
+          New Sensor
+        </v-btn>
+      </template>
+      <template #controls>
+        <ListControlBar
+          :controls="controls"
+          color="teal"
+          :sort-options="sortOptions"
+          :filters="filters"
+          :show-view="false"
+          search-placeholder="Search sensors..."
+        />
+      </template>
+    </PageHeader>
+
+    <SensorList :filtered-list="controls.filteredList.value" @edit="handleEdit" />
+  </template>
+
+  <!-- 📭 Empty -->
+  <EmptyState
+    v-else
+    icon="mdi-access-point"
+    color="teal"
+    title="No Sensors Yet"
+    :description="isFreePlan
+      ? `Upgrade to ${PLAN_DISPLAY.engineer.name} to add sensors and monitor track occupancy across your layout.`
+      : 'Configure track occupancy detectors and feedback sensors to monitor train positions and enable block signaling.'"
+    :use-cases="[
+      { icon: 'mdi-radar', text: 'Block occupancy detection' },
+      { icon: 'mdi-train', text: 'Train position tracking' },
+      { icon: 'mdi-shield-check', text: 'Automated block signals' },
+    ]"
+    :action-label="isFreePlan ? `Upgrade to ${PLAN_DISPLAY.engineer.name}` : 'Add Your First Sensor'"
+    :action-to="isFreePlan ? '/upgrade' : '/sensors/new'"
+  />
 </template>

--- a/apps/cloud/src/Signals/Signals.vue
+++ b/apps/cloud/src/Signals/Signals.vue
@@ -1,23 +1,44 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import type { Signal } from '@repo/modules/signals'
 import { useSignals } from '@repo/modules/signals'
-import { useLayout, type Tag } from '@repo/modules'
+import { useLayout, type Tag, useSubscription, PLAN_DISPLAY } from '@repo/modules'
 import { useRouter } from 'vue-router'
 import { PageHeader, ListControlBar, useListControls } from '@repo/ui'
 import type { ListFilter } from '@repo/ui'
 import SignalList from '@/Signals/SignalsList.vue'
+import EmptyState from '@/Core/UI/EmptyState.vue'
 
 const router = useRouter()
 const { getSignals } = useSignals()
 const { getDevices, getLayout } = useLayout()
+const { plan } = useSubscription()
 const devices = getDevices()
 const layout = getLayout()
 const signals = getSignals()
 
+// 🔄 Loading state
+const isLoaded = ref(false)
+let loadingTimeout: ReturnType<typeof setTimeout> | undefined
+onMounted(async () => {
+  loadingTimeout = setTimeout(() => { isLoaded.value = true }, 3000)
+  try {
+    await (signals as any).promise
+  } finally {
+    clearTimeout(loadingTimeout)
+    isLoaded.value = true
+  }
+})
+onUnmounted(() => clearTimeout(loadingTimeout))
+
+const isLoading = computed(() => !isLoaded.value)
+const isFreePlan = computed(() => plan.value === 'hobbyist')
+
 const signalsList = computed(() =>
   signals?.value ? signals.value.map((s) => ({ ...s, id: s.id })) : []
 )
+
+const hasItems = computed(() => isLoaded.value && signalsList.value.length > 0)
 
 const deviceOptions = computed(() =>
   devices?.value ? devices.value.map((d) => ({ label: d.id, value: d.id })) : []
@@ -54,24 +75,49 @@ function handleAdd() {
 }
 </script>
 <template>
-  <PageHeader title="Signals" icon="mdi-traffic-light" color="emerald" subtitle="Manage signal aspects and track-side indicators.">
-    <template #actions>
-      <v-btn prepend-icon="mdi-plus" color="emerald" variant="flat" @click="handleAdd">
-        New Signal
-      </v-btn>
-    </template>
-    <template #controls>
-      <ListControlBar
-        :controls="controls"
-        color="emerald"
-        :sort-options="sortOptions"
-        :filters="filters"
-        :show-view="false"
-        search-placeholder="Search signals..."
-      />
-    </template>
-  </PageHeader>
-  <SignalList :filtered-list="controls.filteredList.value" @edit="handleEdit" />
+  <!-- 🔄 Loading -->
+  <div v-if="isLoading" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 p-4">
+    <v-skeleton-loader v-for="n in 6" :key="n" type="card" />
+  </div>
+
+  <!-- ✅ Has items -->
+  <template v-else-if="hasItems">
+    <PageHeader title="Signals" icon="mdi-traffic-light" color="emerald" subtitle="Manage signal aspects and track-side indicators.">
+      <template #actions>
+        <v-btn prepend-icon="mdi-plus" color="emerald" variant="flat" @click="handleAdd">
+          New Signal
+        </v-btn>
+      </template>
+      <template #controls>
+        <ListControlBar
+          :controls="controls"
+          color="emerald"
+          :sort-options="sortOptions"
+          :filters="filters"
+          :show-view="false"
+          search-placeholder="Search signals..."
+        />
+      </template>
+    </PageHeader>
+
+    <SignalList :filtered-list="controls.filteredList.value" @edit="handleEdit" />
+  </template>
+
+  <!-- 📭 Empty -->
+  <EmptyState
+    v-else
+    icon="mdi-traffic-light"
+    color="emerald"
+    title="No Signals Yet"
+    :description="isFreePlan
+      ? `Upgrade to ${PLAN_DISPLAY.engineer.name} to add signals and manage block protection on your layout.`
+      : 'Configure signal heads with red, yellow, and green aspects to manage block protection and interlocking on your layout.'"
+    :use-cases="[
+      { icon: 'mdi-shield-check', text: 'Block signal protection' },
+      { icon: 'mdi-lock', text: 'Interlocking control' },
+      { icon: 'mdi-lightbulb-on', text: 'Approach lighting' },
+    ]"
+    :action-label="isFreePlan ? `Upgrade to ${PLAN_DISPLAY.engineer.name}` : 'Add Your First Signal'"
+    :action-to="isFreePlan ? '/upgrade' : '/signals/new'"
+  />
 </template>
-
-

--- a/apps/cloud/src/Signals/SignalsList.vue
+++ b/apps/cloud/src/Signals/SignalsList.vue
@@ -3,7 +3,6 @@ import { computed, ref, type PropType } from 'vue'
 import draggable from 'vuedraggable'
 import { useSignals, type Signal, type SignalAspect } from '@repo/modules/signals'
 import { useSortableList } from '@/Core/composables/useSortableList'
-import EmptyState from '@/Core/UI/EmptyState.vue'
 
 defineEmits(['edit'])
 const props = defineProps({
@@ -151,16 +150,10 @@ const wiring = (signal: Signal) => signal.commonAnode ? 'Common Anode' : 'Common
       </template>
     </draggable>
   </v-container>
-  <EmptyState
-    v-if="!list?.length"
-    icon="mdi-traffic-light"
-    color="emerald"
-    title="No Signals Yet"
-    description="Configure signal heads with red, yellow, and green aspects to manage block protection and interlocking on your layout."
-    :use-cases="[{ icon: 'mdi-shield-check', text: 'Block signal protection' }, { icon: 'mdi-lock', text: 'Interlocking control' }, { icon: 'mdi-lightbulb-on', text: 'Approach lighting' }]"
-    action-label="Add Your First Signal"
-    action-to="/signals/new"
-  />
+  <div v-if="!list?.length" class="flex flex-col items-center justify-center py-12 px-4">
+    <v-icon size="48" class="opacity-30 mb-3">mdi-magnify-close</v-icon>
+    <p class="text-sm opacity-60">No signals match your filters.</p>
+  </div>
 </template>
 <style scoped>
 .ghost {

--- a/apps/cloud/src/Sounds/SoundList.vue
+++ b/apps/cloud/src/Sounds/SoundList.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
-import { ref, onMounted, computed, onUnmounted } from 'vue'
+import { ref, onMounted, computed, onUnmounted, type PropType } from 'vue'
 import { soundFileService, type SoundFile } from '@/Effects/Sounds/SoundFileService'
 import { createLogger } from '@repo/utils'
 import SoundListItem from '@/Sounds/SoundListItem.vue'
-import EmptyState from '@/Core/UI/EmptyState.vue'
 
 const log = createLogger('SoundList')
+
+const props = defineProps({
+  initialSounds: { type: Array as PropType<SoundFile[]>, default: undefined },
+})
 
 const emit = defineEmits<{
   edit: [sound: SoundFile]
@@ -26,7 +29,12 @@ const filteredSoundFiles = computed(() => {
 })
 
 onMounted(() => {
-  loadSoundFiles()
+  if (props.initialSounds) {
+    soundFiles.value = props.initialSounds
+    loading.value = false
+  } else {
+    loadSoundFiles()
+  }
 })
 
 onUnmounted(() => {
@@ -95,28 +103,13 @@ function handleStop() {
     <v-btn @click="loadSoundFiles" color="primary" variant="tonal">Retry</v-btn>
   </div>
 
-  <template v-else-if="filteredSoundFiles.length === 0 && !searchQuery">
-    <EmptyState
-      icon="mdi-volume-high"
-      color="sky"
-      title="No Sounds Yet"
-      description="Upload audio files to build your sound library. Sounds can be used in effects to trigger audio playback on your layout."
-      :use-cases="[
-        { icon: 'mdi-train', text: 'Train Whistles' },
-        { icon: 'mdi-bullhorn', text: 'Station Announcements' },
-        { icon: 'mdi-nature', text: 'Ambient Sounds' },
-        { icon: 'mdi-cog', text: 'Mechanical Effects' },
-      ]"
-      action-label="Upload Sound"
-      action-to="/sounds/new"
-    />
-  </template>
+  <div v-else-if="filteredSoundFiles.length === 0" class="flex flex-col items-center justify-center py-12 px-4">
+    <v-icon size="48" class="opacity-30 mb-3">mdi-magnify-close</v-icon>
+    <p class="text-sm opacity-60">No sounds match your search.</p>
+  </div>
 
   <template v-else>
     <v-row>
-      <v-col cols="12" sm="6" lg="4">
-        <slot name="prepend" />
-      </v-col>
       <v-col
         v-for="sound in filteredSoundFiles"
         :key="sound.url"

--- a/apps/cloud/src/Sounds/Sounds.vue
+++ b/apps/cloud/src/Sounds/Sounds.vue
@@ -1,21 +1,72 @@
 <script setup lang="ts">
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
+import { useSubscription, PLAN_DISPLAY } from '@repo/modules'
 import { PageHeader } from '@repo/ui'
+import { soundFileService, type SoundFile } from '@/Effects/Sounds/SoundFileService'
 import SoundList from '@/Sounds/SoundList.vue'
-import AddTile from '@/Core/UI/AddTile.vue'
+import EmptyState from '@/Core/UI/EmptyState.vue'
 
 const router = useRouter()
+const { plan } = useSubscription()
+
+const soundFiles = ref<SoundFile[]>([])
+const isLoaded = ref(false)
+const isFreePlan = computed(() => plan.value === 'hobbyist')
+const isLoading = computed(() => !isLoaded.value)
+const hasItems = computed(() => isLoaded.value && soundFiles.value.length > 0)
+
+let loadingTimeout: ReturnType<typeof setTimeout> | undefined
+onMounted(async () => {
+  loadingTimeout = setTimeout(() => { isLoaded.value = true }, 5000)
+  try {
+    soundFiles.value = await soundFileService.listSoundFiles()
+  } finally {
+    clearTimeout(loadingTimeout)
+    isLoaded.value = true
+  }
+})
+onUnmounted(() => clearTimeout(loadingTimeout))
 
 function handleAdd() {
   router.push({ name: 'Add Sound' })
 }
 </script>
 <template>
-  <PageHeader title="Sounds" icon="mdi-volume-high" color="sky" />
+  <!-- 🔄 Loading -->
+  <div v-if="isLoading" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 p-4">
+    <v-skeleton-loader v-for="n in 6" :key="n" type="card" />
+  </div>
 
-  <SoundList>
-    <template #prepend>
-      <AddTile @click="handleAdd" color="sky" />
-    </template>
-  </SoundList>
+  <!-- ✅ Has items -->
+  <template v-else-if="hasItems">
+    <PageHeader title="Sounds" icon="mdi-volume-high" color="sky" subtitle="Upload and manage audio files for layout effects.">
+      <template #actions>
+        <v-btn prepend-icon="mdi-plus" color="sky" variant="flat" @click="handleAdd">
+          New Sound
+        </v-btn>
+      </template>
+    </PageHeader>
+
+    <SoundList :initial-sounds="soundFiles" />
+  </template>
+
+  <!-- 📭 Empty -->
+  <EmptyState
+    v-else
+    icon="mdi-volume-high"
+    color="sky"
+    title="No Sounds Yet"
+    :description="isFreePlan
+      ? `Upgrade to ${PLAN_DISPLAY.engineer.name} to upload sounds and create immersive audio effects for your layout.`
+      : 'Upload audio files to build your sound library. Sounds can be used in effects to trigger audio playback on your layout.'"
+    :use-cases="[
+      { icon: 'mdi-train', text: 'Train whistles' },
+      { icon: 'mdi-bullhorn', text: 'Station announcements' },
+      { icon: 'mdi-nature', text: 'Ambient sounds' },
+      { icon: 'mdi-cog', text: 'Mechanical effects' },
+    ]"
+    :action-label="isFreePlan ? `Upgrade to ${PLAN_DISPLAY.engineer.name}` : 'Upload Your First Sound'"
+    :action-to="isFreePlan ? '/upgrade' : '/sounds/new'"
+  />
 </template>

--- a/apps/cloud/src/Turnouts/Turnouts.vue
+++ b/apps/cloud/src/Turnouts/Turnouts.vue
@@ -1,22 +1,43 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useTurnouts, type Turnout } from '@repo/modules'
-import { useLayout, type Tag } from '@repo/modules'
+import { useLayout, type Tag, useSubscription, PLAN_DISPLAY } from '@repo/modules'
 import { PageHeader, ListControlBar, useListControls } from '@repo/ui'
 import type { ListFilter } from '@repo/ui'
 import TurnoutsList from '@/Turnouts/TurnoutsList.vue'
+import EmptyState from '@/Core/UI/EmptyState.vue'
 
 const router = useRouter()
 const { getTurnouts } = useTurnouts()
 const { getDevices, getLayout } = useLayout()
+const { plan } = useSubscription()
 const devices = getDevices()
 const layout = getLayout()
 const turnouts = getTurnouts()
 
+// 🔄 Loading state
+const isLoaded = ref(false)
+let loadingTimeout: ReturnType<typeof setTimeout> | undefined
+onMounted(async () => {
+  loadingTimeout = setTimeout(() => { isLoaded.value = true }, 3000)
+  try {
+    await (turnouts as any).promise
+  } finally {
+    clearTimeout(loadingTimeout)
+    isLoaded.value = true
+  }
+})
+onUnmounted(() => clearTimeout(loadingTimeout))
+
+const isLoading = computed(() => !isLoaded.value)
+const isFreePlan = computed(() => plan.value === 'hobbyist')
+
 const turnoutsList = computed(() =>
   turnouts?.value ? turnouts.value.map((t) => ({ ...t, id: t.id })) : []
 )
+
+const hasItems = computed(() => isLoaded.value && turnoutsList.value.length > 0)
 
 const deviceOptions = computed(() =>
   devices?.value ? devices.value.map((d) => ({ label: d.id, value: d.id })) : []
@@ -53,23 +74,49 @@ function handleAdd() {
 }
 </script>
 <template>
-  <PageHeader title="Turnouts" icon="mdi-call-split" color="amber" subtitle="Configure and control track switches across your layout.">
-    <template #actions>
-      <v-btn prepend-icon="mdi-plus" color="amber" variant="flat" @click="handleAdd">
-        New Turnout
-      </v-btn>
-    </template>
-    <template #controls>
-      <ListControlBar
-        :controls="controls"
-        color="amber"
-        :sort-options="sortOptions"
-        :filters="filters"
-        :show-view="false"
-        search-placeholder="Search turnouts..."
-      />
-    </template>
-  </PageHeader>
+  <!-- 🔄 Loading -->
+  <div v-if="isLoading" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 p-4">
+    <v-skeleton-loader v-for="n in 6" :key="n" type="card" />
+  </div>
 
-  <TurnoutsList :filtered-list="controls.filteredList.value" :viewAs="controls.viewAs.value" @edit="handleEdit" />
+  <!-- ✅ Has items -->
+  <template v-else-if="hasItems">
+    <PageHeader title="Turnouts" icon="mdi-call-split" color="amber" subtitle="Configure and control track switches across your layout.">
+      <template #actions>
+        <v-btn prepend-icon="mdi-plus" color="amber" variant="flat" @click="handleAdd">
+          New Turnout
+        </v-btn>
+      </template>
+      <template #controls>
+        <ListControlBar
+          :controls="controls"
+          color="amber"
+          :sort-options="sortOptions"
+          :filters="filters"
+          :show-view="false"
+          search-placeholder="Search turnouts..."
+        />
+      </template>
+    </PageHeader>
+
+    <TurnoutsList :filtered-list="controls.filteredList.value" :viewAs="controls.viewAs.value" @edit="handleEdit" />
+  </template>
+
+  <!-- 📭 Empty -->
+  <EmptyState
+    v-else
+    icon="mdi-call-split"
+    color="amber"
+    title="No Turnouts Yet"
+    :description="isFreePlan
+      ? `Upgrade to ${PLAN_DISPLAY.engineer.name} to add turnouts and manage track switches across your layout.`
+      : 'Define your track switches and control them remotely. Map each turnout to its DCC address for seamless operation.'"
+    :use-cases="[
+      { icon: 'mdi-swap-horizontal', text: 'Yard switching' },
+      { icon: 'mdi-source-fork', text: 'Mainline junctions' },
+      { icon: 'mdi-warehouse', text: 'Staging areas' },
+    ]"
+    :action-label="isFreePlan ? `Upgrade to ${PLAN_DISPLAY.engineer.name}` : 'Add Your First Turnout'"
+    :action-to="isFreePlan ? '/upgrade' : '/turnouts/new'"
+  />
 </template>

--- a/apps/cloud/src/Turnouts/TurnoutsList.vue
+++ b/apps/cloud/src/Turnouts/TurnoutsList.vue
@@ -6,7 +6,6 @@ import { useSortableList } from '@/Core/composables/useSortableList'
 import TurnoutListItem from '@/Turnouts/TurnoutListItem.vue'
 import ViewJson from '@/Core/UI/ViewJson.vue'
 import LcdDisplay from '@/Core/UI/LcdDisplay.vue'
-import EmptyState from '@/Core/UI/EmptyState.vue'
 
 defineEmits(['edit'])
 const props = defineProps({
@@ -63,16 +62,10 @@ const list = computed(() => props.filteredList ?? sortableList.value)
       </template>
   </v-container>
   <ViewJson :json="list" label="Turnouts"></ViewJson>
-  <EmptyState
-    v-if="!list?.length"
-    icon="mdi-call-split"
-    color="amber"
-    title="No Turnouts Yet"
-    description="Define your track switches and control them remotely. Map each turnout to its DCC address for seamless operation."
-    :use-cases="[{ icon: 'mdi-swap-horizontal', text: 'Yard switching' }, { icon: 'mdi-source-fork', text: 'Mainline junctions' }, { icon: 'mdi-warehouse', text: 'Staging areas' }]"
-    action-label="Add Your First Turnout"
-    action-to="/turnouts/new"
-  />
+  <div v-if="!list?.length" class="flex flex-col items-center justify-center py-12 px-4">
+    <v-icon size="48" class="opacity-30 mb-3">mdi-magnify-close</v-icon>
+    <p class="text-sm opacity-60">No turnouts match your filters.</p>
+  </div>
 </template>
 <style scoped>
 .ghost {


### PR DESCRIPTION
## Summary

- 🔄 **Loading states**: All 7 module pages (Turnouts, Effects, Signals, Routes, Sensors, Roster, Sounds) now show skeleton loaders while data loads, using Vuefire `.promise` with a timeout fallback
- 📭 **Empty states**: When no items exist, shows an upgrade prompt for free plan users or an "Add" button for paid users. Header/controls are hidden when empty
- 🔍 **Roster filters & sort**: Added Sound Decoder/Silent filter, Consist/Single type filter, and Name/Address sort options with `filteredList` prop wired to RosterList
- 🗺️ **Routes controls**: Added search, sort (Default/Name), tag filters, subtitle, and "New Route" button — matching the pattern of other modules
- 🔊 **Sounds restructure**: Parent-controlled loading/empty states with `initialSounds` prop to avoid double-fetching
- 🧹 **UI consistency fixes**:
  - Replaced duplicate EmptyState in list components with lightweight "no results" message for filtered views
  - Unified "New X" button pattern (removed AddTile from Roster)
  - Fixed Roster Sync/Import button colors to match module theme (pink)
  - Added Roster PageHeader subtitle
  - Added PortList (USB ports) to the bottom of the Devices page

## Files changed (15)
- 7 module pages: Effects, Turnouts, Signals, Routes, Sensors, Roster, Sounds
- 7 list components: EffectsList, TurnoutsList, SignalsList, RoutesList, SensorList, RosterList, SoundList
- 1 layout: Devices page (Layout.vue)

## Test plan
- [ ] Navigate to each module page — verify skeleton loaders appear briefly then content loads
- [ ] On a free plan account, verify empty state shows "Upgrade to Engineer" button
- [ ] On a paid plan with no items, verify empty state shows "Add Your First X" button
- [ ] On Roster page, test Sound and Type filters, Name/Address sort
- [ ] On Routes page, test search and sort controls
- [ ] Apply filters that match nothing — verify "No X match your filters" message appears
- [ ] Verify Devices page shows USB ports list at the bottom
- [ ] Verify Sounds page loads without double-loading spinner

🤖 Generated with [Claude Code](https://claude.com/claude-code)