### PR TITLE
feat(ui): stack Logo title on mobile in AppHeader

### DIFF
--- a/packages/ui/.storybook/preview.ts
+++ b/packages/ui/.storybook/preview.ts
@@ -8,7 +8,11 @@ import '@mdi/font/css/materialdesignicons.css'
 import './tailwind.css'
 import { mockRouter } from './mocks/router'
 
-const vuetify = createVuetify({ components, directives })
+const vuetify = createVuetify({
+  components,
+  directives,
+  theme: { defaultTheme: 'dark' },
+})
 
 setup((app) => {
   app.use(vuetify)

--- a/packages/ui/src/AppHeader.vue
+++ b/packages/ui/src/AppHeader.vue
@@ -45,6 +45,7 @@ const router = useRouter()
 const { mdAndUp } = useDisplay()
 
 const { serverStatus } = useServerStatus()
+const stackedLogo = computed(() => !mdAndUp.value)
 
 const email = computed(() => user.value?.email ?? null)
 const layouts = getLayouts(email)
@@ -154,7 +155,7 @@ const defaultProps = {
     <template v-slot:title>
       <Logo
         :size="mdAndUp ? 'md' : 'sm'"
-        :stacked="!mdAndUp"
+        :stacked="stackedLogo"
         :app-title="appName || defaultProps.appName"
         :variant="variant || defaultProps.variant"
         @click="handleLogoClick"
@@ -182,19 +183,6 @@ const defaultProps = {
       </template>
     </template>
   </v-app-bar>
-  <!-- <v-app-bar class="header-gradient2 elative overflow-hidden"
-    :dark="dark !== undefined ? dark : defaultProps.dark">
-    <BackgroundDecor variant="blurred-bubbles-1" />
-    <template v-slot:prepend>
-      
-    </template>
-    <template v-slot:append>
-
-    </template>
-  </v-app-bar> -->
-
-
-
 </template>
 
 <style scoped>

--- a/packages/ui/src/AppHeader.vue
+++ b/packages/ui/src/AppHeader.vue
@@ -154,6 +154,7 @@ const defaultProps = {
     <template v-slot:title>
       <Logo
         :size="mdAndUp ? 'md' : 'sm'"
+        :stacked="!mdAndUp"
         :app-title="appName || defaultProps.appName"
         :variant="variant || defaultProps.variant"
         @click="handleLogoClick"

--- a/packages/ui/src/Logo.stories.ts
+++ b/packages/ui/src/Logo.stories.ts
@@ -16,6 +16,7 @@ const meta: Meta<typeof Logo> = {
       control: 'select',
       options: ['default', 'cloud', 'throttle', 'monitor', 'tour'],
     },
+    stacked: { control: 'boolean' },
   },
 }
 
@@ -66,6 +67,44 @@ export const AllVariants: Story = {
         <Logo size="lg" variant="throttle" app-title="Throttle" />
         <Logo size="lg" variant="monitor" app-title="Monitor" />
         <Logo size="lg" variant="tour" app-title="Tour" />
+      </div>
+    `,
+  }),
+}
+
+export const Stacked: Story = {
+  args: {
+    size: 'sm',
+    showIcon: true,
+    appTitle: 'Throttle',
+    variant: 'throttle',
+    stacked: true,
+  },
+}
+
+export const StackedVsInline: Story = {
+  render: () => ({
+    components: { Logo },
+    template: `
+      <div class="flex flex-col gap-8 p-4">
+        <div>
+          <p class="text-sm text-gray-400 mb-2">Inline (desktop)</p>
+          <Logo size="md" variant="throttle" app-title="Throttle" />
+        </div>
+        <div>
+          <p class="text-sm text-gray-400 mb-2">Stacked (mobile)</p>
+          <Logo size="sm" variant="throttle" app-title="Throttle" :stacked="true" />
+        </div>
+        <div>
+          <p class="text-sm text-gray-400 mb-2">Stacked — all variants</p>
+          <div class="flex flex-col gap-4">
+            <Logo size="sm" variant="default" app-title="Default" :stacked="true" />
+            <Logo size="sm" variant="cloud" app-title="Cloud" :stacked="true" />
+            <Logo size="sm" variant="throttle" app-title="Throttle" :stacked="true" />
+            <Logo size="sm" variant="monitor" app-title="Monitor" :stacked="true" />
+            <Logo size="sm" variant="tour" app-title="Tour" :stacked="true" />
+          </div>
+        </div>
       </div>
     `,
   }),

--- a/packages/ui/src/Logo.vue
+++ b/packages/ui/src/Logo.vue
@@ -31,6 +31,10 @@ const sizeMap = {
 
 const s = computed(() => sizeMap[props.size])
 
+const textContainerClass = computed(() =>
+  props.stacked && props.appTitle ? 'flex-col' : `items-end ${s.value.gap}`
+)
+
 const appIconSrc = computed(() => {
   switch (props.variant) {
     case 'throttle':
@@ -64,7 +68,7 @@ const appIconSrc = computed(() => {
     <!-- Text container: stacked = flex-col, inline = flex-row -->
     <div
       class="flex"
-      :class="stacked && appTitle ? 'flex-col' : `items-center ${s.gap}`"
+      :class="textContainerClass"
     >
       <!-- Brand text -->
       <span class="font-bold tracking-[0.08em] leading-none whitespace-nowrap" :class="s.brand">

--- a/packages/ui/src/Logo.vue
+++ b/packages/ui/src/Logo.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, useSlots } from 'vue'
+import { computed } from 'vue'
 
 export type LogoSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl'
 export type LogoVariant = 'default' | 'cloud' | 'throttle' | 'monitor' | 'tour'
@@ -9,15 +9,15 @@ interface Props {
   showIcon?: boolean
   appTitle?: string
   variant?: LogoVariant
+  stacked?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
   size: 'md',
   showIcon: true,
   variant: 'default',
+  stacked: false,
 })
-
-const slots = useSlots()
 
 const sizeMap = {
   xs:  { brand: 'text-sm',  js: 'text-[0.55rem]', icon: 'w-4 h-4',   gap: 'gap-1',   title: 'text-xs' },
@@ -46,7 +46,6 @@ const appIconSrc = computed(() => {
   }
 })
 
-const hasIconSlot = computed(() => !!slots.icon)
 </script>
 
 <template>
@@ -62,19 +61,25 @@ const hasIconSlot = computed(() => !!slots.icon)
       </slot>
     </template>
 
-    <!-- Brand text -->
-    <span class="font-bold tracking-[0.08em] leading-none whitespace-nowrap" :class="s.brand">
-      <span class="bg-gradient-to-r from-blue-500 to-cyan-400 bg-clip-text text-transparent">DEJA</span><span class="text-lime-400">.</span><span class="text-fuchsia-500 font-mono" :class="s.js">js</span>
-    </span>
-
-    <!-- Optional app title suffix -->
-    <span
-      v-if="appTitle"
-      class="font-semibold leading-none whitespace-nowrap"
-      style="color: rgba(var(--v-theme-on-surface), 0.9)"
-      :class="s.title"
+    <!-- Text container: stacked = flex-col, inline = flex-row -->
+    <div
+      class="flex"
+      :class="stacked && appTitle ? 'flex-col' : `items-center ${s.gap}`"
     >
-      {{ appTitle }}
-    </span>
+      <!-- Brand text -->
+      <span class="font-bold tracking-[0.08em] leading-none whitespace-nowrap" :class="s.brand">
+        <span class="bg-gradient-to-r from-blue-500 to-cyan-400 bg-clip-text text-transparent">DEJA</span><span class="text-lime-400">.</span><span class="text-fuchsia-500 font-mono" :class="s.js">js</span>
+      </span>
+
+      <!-- Optional app title suffix -->
+      <span
+        v-if="appTitle"
+        class="font-semibold leading-none whitespace-nowrap"
+        style="color: rgba(var(--v-theme-on-surface), 0.9)"
+        :class="s.title"
+      >
+        {{ appTitle }}
+      </span>
+    </div>
   </div>
 </template>


### PR DESCRIPTION
## Summary

- 🎨 Add `stacked` boolean prop to `Logo.vue` — toggles flex-col layout so the app title stacks below "DEJA.js" on small screens
- 📱 Wire `:stacked="!mdAndUp"` in `AppHeader.vue` for automatic mobile stacking
- 📖 Add Storybook stories (`Stacked`, `StackedVsInline`) for visual QA across all variants
- 🌙 Set Storybook dark theme to match production app
- 🧹 Remove commented-out AppHeader template block, extract `textContainerClass` computed

## Test plan

- [ ] Open Storybook → Logo → **StackedVsInline** — verify inline vs stacked comparison
- [ ] Open Storybook → Logo → **Stacked** — verify single stacked layout
- [ ] Toggle `stacked` control in Storybook panel on any Logo story
- [ ] Verify no layout shift when `appTitle` is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)