### PR TITLE
feat(install): 🚀 simplify installer UX and fix TUI installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -31,22 +31,13 @@ echo "    2. Install pnpm if needed"
 echo "    3. Download DEJA.js"
 echo "    4. Install dependencies"
 echo "    5. Install the deja CLI"
-echo "    6. Create your .env.local configuration file"
 echo ""
 
 # ── 0. Account check ──────────────────────────────────────────────────────
-echo -e "  ${BOLD}${YELLOW}Before you begin:${NC}"
-echo "  You need a DEJA.js account to get your configuration credentials."
+echo -e "  ${BOLD}${YELLOW}Before you begin:${NC} Sign up for a free DEJA Cloud account"
+echo -e "  🚀 ${BLUE}https://cloud.dejajs.com/signup${NC}"
 echo ""
-echo "  If you haven't already:"
-echo "    1. Sign up at https://cloud.dejajs.com/signup"
-echo "    2. Wait for your account to be approved"
-echo "    3. Complete the onboarding wizard to create your layout"
-echo "    4. Copy your LAYOUT_ID and VITE_FIREBASE_* values from the"
-echo '       "Environment Setup" step (you can also find them later under'
-echo '       "View Local Environment Configuration" in your layout)'
-echo ""
-read -rp "  Press Enter if you have your credentials ready, or Ctrl+C to sign up first... "
+read -rp "  Press Enter to continue, or Ctrl+C to sign up first... "
 
 # ── 1. Check Node.js ────────────────────────────────────────────────────────
 step "Checking Node.js..."
@@ -112,8 +103,10 @@ SERVER_VERSION=$(node -e "console.log(require('./apps/server/package.json').vers
 echo "$SERVER_VERSION" > "$DEJA_HOME/server/version.txt"
 ok "Server version $SERVER_VERSION recorded"
 
-# Install CLI script
+# Install CLI script + TUI
 cp scripts/deja "$DEJA_HOME/deja"
+cp scripts/deja-ui-ink.mjs "$DEJA_HOME/deja-ui-ink.mjs"
+cp -r scripts/tui "$DEJA_HOME/tui"
 chmod +x "$DEJA_HOME/deja"
 
 # Add to PATH if not already there
@@ -144,82 +137,18 @@ else
     warn ".env.local already exists — skipping copy"
 fi
 
-# ── 8. Set LAYOUT_ID ─────────────────────────────────────────────────────────
-echo ""
-echo -e "  ${BOLD}Layout ID${NC}"
-info "A unique name for your layout. Used to identify your data in DEJA Cloud."
-info "Rules: lowercase letters, numbers, and hyphens only."
-info "Examples: basement-empire  |  club-layout-2024  |  riverside-yard"
-echo ""
-
-LAYOUT_PATTERN='^[a-z0-9]([a-z0-9-]*[a-z0-9])?$'
-while true; do
-    read -rp "  Enter your Layout ID: " LAYOUT_ID
-    if [[ "$LAYOUT_ID" =~ $LAYOUT_PATTERN ]]; then
-        break
-    else
-        warn "Invalid ID — use lowercase letters, numbers, and hyphens only."
-    fi
-done
-
-if grep -q "^LAYOUT_ID=" .env.local; then
-    sed -i.bak "s/^LAYOUT_ID=.*/LAYOUT_ID=$LAYOUT_ID/" .env.local && rm -f .env.local.bak
-else
-    echo "LAYOUT_ID=$LAYOUT_ID" >> .env.local
-fi
-ok "Layout ID set to: $LAYOUT_ID"
-
-# ── 9. Firebase credentials ──────────────────────────────────────────────────
-echo ""
-echo -e "  ${BOLD}Firebase Credentials${NC}"
-echo ""
-info "Paste the VITE_FIREBASE_* values from your onboarding setup."
-info "If you need to find them again:"
-echo ""
-info "  1. Log in to https://cloud.dejajs.com"
-info "  2. Select your layout"
-info '  3. Click "View Local Environment Configuration"'
-info "  4. Copy all the VITE_FIREBASE_* values shown"
-echo ""
-info "Your .env.local file is at:"
-info "  $INSTALL_DIR/.env.local"
-echo ""
-read -rp "  Press Enter to open .env.local in your editor..."
-
-# Open in the best available editor
-if command -v code &>/dev/null; then
-    code "$INSTALL_DIR/.env.local"
-elif command -v nano &>/dev/null; then
-    nano "$INSTALL_DIR/.env.local"
-elif command -v vim &>/dev/null; then
-    vim "$INSTALL_DIR/.env.local"
-elif command -v open &>/dev/null; then
-    open "$INSTALL_DIR/.env.local"
-elif command -v xdg-open &>/dev/null; then
-    xdg-open "$INSTALL_DIR/.env.local"
-else
-    info "Could not find a text editor. Open the file manually:"
-    info "  $INSTALL_DIR/.env.local"
-fi
-
-# ── 10. Done ─────────────────────────────────────────────────────────────────
+# ── 8. Done ──────────────────────────────────────────────────────────────────
 echo ""
 echo -e "  ${GREEN}${BOLD}Setup complete!${NC}"
 echo ""
 echo "  Next steps:"
 echo ""
-echo "  1. Register your DCC-EX CommandStation in DEJA Cloud:"
-echo "     https://cloud.dejajs.com → Layout → Devices → Add"
-echo "     (Select DCC-EX CommandStation → USB)"
+echo "  1. Start the DEJA Server:"
+echo "     deja start"
 echo ""
-echo "  2. Start the DEJA Server (run from $INSTALL_DIR):"
-echo "     pnpm deja"
-echo ""
-echo "  3. Connect your CommandStation:"
-echo "     https://monitor.dejajs.com → select USB port → Connect"
-echo ""
-echo "  4. Drive trains:"
-echo "     https://throttle.dejajs.com"
+echo "  2. Connect your CommandStation:"
+echo "     Use the CLI:  deja devices"
+echo "     Or connect from the Throttle app: https://throttle.dejajs.com"
 echo ""
 echo "  Full documentation: https://www.dejajs.com"
 echo ""

--- a/scripts/deja
+++ b/scripts/deja
@@ -767,7 +767,7 @@ case "${1:-}" in
     cmd_help
     ;;
   "")
-    cmd_help
+    cmd_start
     ;;
   *)
     err "Unknown command: $1"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -103,8 +103,10 @@ link_account() {
 
   if [ -z "${uid}" ]; then
     echo ""
-    info "Link your DEJA.js account."
-    info "Find your UID and Layout ID at: https://cloud.dejajs.com → Settings → Install"
+    echo -e "  ${BOLD}${YELLOW}Before you begin:${NC} Sign up for a free DEJA Cloud account"
+    echo -e "  🚀 ${CYAN}https://cloud.dejajs.com/signup${NC}"
+    echo ""
+    info "Then find your install command at: Cloud → Settings → Install"
     echo ""
     read -rp "Your UID: " uid < /dev/tty
   fi


### PR DESCRIPTION
## Summary

- 🎯 Shorten pre-install instructions to a single "sign up for a cloud account" CTA — removed LAYOUT_ID prompts, Firebase credential entry, and account approval wait (credentials are now embedded, accounts are auto-approved)
- 🛠️ Streamline "setup complete" next steps to `deja start` + connect via CLI or Throttle app
- 🚂 Default `deja` CLI (no args) to `deja start` instead of showing help
- 🐛 Fix TUI not working on fresh installs (e.g. Raspberry Pi) — `install.sh` now copies `deja-ui-ink.mjs` and `tui/` directory alongside the CLI script

## Test plan

- [ ] Run `install.sh` on a fresh Raspberry Pi and verify TUI launches with `deja`
- [ ] Verify pre-install messaging shows simplified signup CTA
- [ ] Verify "setup complete" shows updated next steps
- [ ] Confirm `deja` with no args launches interactive TUI (same as `deja start`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)