### PR TITLE
fix(auth): auto-redirect to login on signout + debug ensureAutoLogin

### DIFF
--- a/packages/auth/src/LogoutView.vue
+++ b/packages/auth/src/LogoutView.vue
@@ -2,10 +2,12 @@
 import { ref, onMounted } from 'vue'
 import { signOut } from 'firebase/auth'
 import { useFirebaseAuth } from 'vuefire'
+import { useRouter } from 'vue-router'
 import { createLogger } from '@repo/utils'
 
 const log = createLogger('Auth')
 const auth = useFirebaseAuth()
+const router = useRouter()
 
 const signingOut = ref(true)
 const error = ref(false)
@@ -18,10 +20,10 @@ onMounted(async () => {
   try {
     await signOut(auth)
     log.debug('User signed out successfully')
+    router.replace('/login')
   } catch (reason) {
     log.error('Failed signOut', reason)
     error.value = true
-  } finally {
     signingOut.value = false
   }
 })

--- a/packages/auth/src/ensureAutoLogin.ts
+++ b/packages/auth/src/ensureAutoLogin.ts
@@ -5,6 +5,11 @@ import { createLogger } from '@repo/utils'
 const log = createLogger('AutoLogin')
 
 export async function ensureAutoLogin(): Promise<void> {
+  log.debug('ensureAutoLogin check:', {
+    VITE_AUTO_LOGIN: import.meta.env.VITE_AUTO_LOGIN,
+    VITE_DEMO_EMAIL: import.meta.env.VITE_DEMO_EMAIL ? '✅ set' : '❌ missing',
+    VITE_DEMO_PASSWORD: import.meta.env.VITE_DEMO_PASSWORD ? '✅ set' : '❌ missing',
+  })
   if (import.meta.env.VITE_AUTO_LOGIN !== 'true') return
 
   const currentUser = await getCurrentUser()


### PR DESCRIPTION
## Summary
- 🚪 **LogoutView** now auto-redirects to `/login` after signout via `router.replace()` instead of showing a manual "sign in again" button
- 🔍 Added debug logging to `ensureAutoLogin()` to diagnose `pnpm dev:demo` env var issues (logs `VITE_AUTO_LOGIN`, `VITE_DEMO_EMAIL`, `VITE_DEMO_PASSWORD` status)

## Test plan
- [ ] Run `pnpm dev:demo` and verify auto-login works in all apps
- [ ] Sign out from any app → should land on `/login` automatically (no manual click)
- [ ] Check browser console for `[AutoLogin] ensureAutoLogin check:` debug output

🤖 Generated with [Claude Code](https://claude.com/claude-code)