### PR TITLE
feat(throttle): ✨ polish quick menu — logo FAB, entity colors, server awareness

### DIFF
--- a/apps/throttle/README.md
+++ b/apps/throttle/README.md
@@ -32,6 +32,17 @@ Vue 3 train control interface — the primary operator app for driving locomotiv
 | `SignalsView` | 🚦 Signal management |
 | `ConductorView` | 👷 Conductor layout overview |
 
+### 🎯 Quick Menu
+
+A draggable floating action button (FAB) available on every page when logged in with a layout selected. Tap the DEJA.js "D" logo to open a drill-down panel for browsing and controlling layout entities:
+
+- **🚂 Locos** — browse roster, tap 🎮 gamepad to open throttle
+- **🚀 Effects / 🔀 Turnouts / 🚦 Signals** — filter by device, type, or tag; toggle on/off
+- **🛤️ Routes** — filter by waypoint; tap to activate
+- **➕ New** — opens Cloud app in a new tab to create items
+
+Server-dependent actions (toggles, route activation) are automatically disabled when the DEJA server is offline. The FAB position is persisted across sessions.
+
 ### 🎯 Key Composable
 
 `useThrottle(address)` — manages speed, direction, and function state for a locomotive. Writes to `layouts/{layoutId}/throttles/{address}` in Firestore.

--- a/apps/throttle/src/quick-menu/QuickMenu.vue
+++ b/apps/throttle/src/quick-menu/QuickMenu.vue
@@ -1,14 +1,16 @@
 <script setup lang="ts">
 import { ref, watch, computed } from 'vue'
 import { useRouter } from 'vue-router'
-import { onClickOutside } from '@vueuse/core'
+import { onClickOutside, useStorage } from '@vueuse/core'
+import { useCurrentUser } from 'vuefire'
 import { useDraggableFab } from './useDraggableFab'
 import { useQuickMenu, SUBSCREEN_CONFIGS, GROUP_SCREEN_META } from './useQuickMenu'
 import type { EntityScreen } from './useQuickMenu'
 import { useQuickMenuData } from './useQuickMenuData'
 import type { GroupItem } from './useQuickMenuData'
 import type { Ref } from 'vue'
-import { useFeatureFlags } from '@repo/modules'
+import { useFeatureFlags, useServerStatus } from '@repo/modules'
+import dejaLogo from '@repo/ui/src/assets/icons/deja.png'
 import QuickMenuThrottles from './QuickMenuThrottles.vue'
 import QuickMenuFavorites from './QuickMenuFavorites.vue'
 import QuickMenuCloud from './QuickMenuCloud.vue'
@@ -51,6 +53,15 @@ const {
 
 const { isEnabled } = useFeatureFlags()
 const showFavorites = computed(() => isEnabled('quickMenuFavorites'))
+
+// Auth & layout gating
+const user = useCurrentUser()
+const layoutId = useStorage('@DEJA/layoutId', '')
+const canShow = computed(() => !!user.value && !!layoutId.value && quickMenuVisible.value)
+
+// Server connection status — disables server-dependent actions
+const { serverStatus } = useServerStatus()
+const isServerOnline = computed(() => serverStatus.value?.online === true)
 
 // Map group screen keys to their reactive computed refs
 const groupData: Record<string, Ref<GroupItem[]>> = {
@@ -115,6 +126,16 @@ const entityRoutes: Record<string, string> = {
   sensors: 'signals',
 }
 
+// Cloud app paths for "new" actions
+const cloudNewPaths: Record<string, string> = {
+  locos: '/locos/new',
+  effects: '/effects/new',
+  routes: '/routes/new',
+  turnouts: '/turnouts/new',
+  signals: '/signals/new',
+  sensors: '/sensors/new',
+}
+
 // Handle sub-screen item selection
 function handleSubScreenSelect(itemId: string) {
   const entity = currentScreen.value as EntityScreen
@@ -132,11 +153,11 @@ function handleSubScreenSelect(itemId: string) {
     return
   }
 
-  // "new" → navigate to entity page
+  // "new" → open Cloud app in new tab
   if (itemId === 'new') {
-    const routeName = entityRoutes[entity]
-    if (routeName) {
-      router.push({ name: routeName })
+    const cloudPath = cloudNewPaths[entity]
+    if (cloudPath) {
+      window.open(`https://cloud.dejajs.com${cloudPath}`, '_blank')
       closeAll()
     }
     return
@@ -161,6 +182,20 @@ function handleToggle(id: string, state: boolean) {
   const info = itemScreenInfo.value
   if (info) {
     toggleItem(info.entity, id, state)
+  }
+}
+
+// Handle navigate (locos → throttle)
+function handleNavigate(id: string) {
+  router.push({ name: 'throttle', params: { address: id } })
+  closeAll()
+}
+
+// Handle activate (routes)
+function handleActivate(id: string) {
+  const info = itemScreenInfo.value
+  if (info) {
+    toggleItem(info.entity, id, true)
   }
 }
 
@@ -189,7 +224,7 @@ onClickOutside(wrapperRef, () => {
 
 <template>
   <div
-    v-if="quickMenuVisible"
+    v-if="canShow"
     ref="wrapperRef"
     class="quick-menu"
     :style="positionStyle"
@@ -211,7 +246,7 @@ onClickOutside(wrapperRef, () => {
             <QuickMenuFavorites />
           </template>
           <v-divider class="opacity-10" />
-          <QuickMenuCloud @navigate="closeAll" @drill="handleDrill" />
+          <QuickMenuCloud :server-online="isServerOnline" @navigate="closeAll" @drill="handleDrill" />
         </template>
 
         <!-- Entity menu (effects, turnouts, etc.) -->
@@ -234,13 +269,16 @@ onClickOutside(wrapperRef, () => {
           @select="handleGroupSelect"
         />
 
-        <!-- Item list with toggles -->
+        <!-- Item list with toggles / actions -->
         <QuickMenuItemList
           v-else-if="itemScreenInfo"
           :title="itemScreenInfo.title"
           :items="itemListData"
+          :server-online="isServerOnline"
           @back="popScreen"
           @toggle="handleToggle"
+          @navigate="handleNavigate"
+          @activate="handleActivate"
         />
       </v-card>
     </Transition>
@@ -260,9 +298,13 @@ onClickOutside(wrapperRef, () => {
       @pointerup="onPointerUp"
       @click.stop="handleFabClick"
     >
-      <v-icon size="20" :class="{ 'qm-fab__icon--open': isOpen }">
-        {{ isOpen ? 'mdi-close' : 'mdi-train' }}
-      </v-icon>
+      <v-icon v-if="isOpen" size="20" class="qm-fab__icon--open">mdi-close</v-icon>
+      <img
+        v-else
+        :src="dejaLogo"
+        alt="DEJA.js"
+        class="qm-fab__logo"
+      />
     </v-btn>
   </div>
 </template>
@@ -288,6 +330,13 @@ onClickOutside(wrapperRef, () => {
 .quick-menu--dragging .qm-fab {
   transform: scale(1.15);
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.35) !important;
+}
+.qm-fab__logo {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  object-fit: cover;
+  pointer-events: none;
 }
 .qm-fab__icon--open {
   transition: transform 200ms ease;

--- a/apps/throttle/src/quick-menu/QuickMenuCloud.vue
+++ b/apps/throttle/src/quick-menu/QuickMenuCloud.vue
@@ -3,6 +3,12 @@ import { useRouter } from 'vue-router'
 import { CLOUD_MENU_ITEMS } from '@repo/modules/quick-menu'
 import type { EntityScreen } from './useQuickMenu'
 
+const props = withDefaults(defineProps<{
+  serverOnline?: boolean
+}>(), {
+  serverOnline: true,
+})
+
 const router = useRouter()
 const emit = defineEmits<{
   navigate: []
@@ -32,6 +38,10 @@ function handleClick(item: (typeof CLOUD_MENU_ITEMS)[number]) {
 
 <template>
   <div class="quick-cloud">
+    <div v-if="!props.serverOnline" class="quick-cloud__offline">
+      <v-icon size="12" color="warning">mdi-cloud-off-outline</v-icon>
+      <span>Server offline</span>
+    </div>
     <div class="quick-cloud__grid">
       <button
         v-for="item in CLOUD_MENU_ITEMS"
@@ -49,6 +59,15 @@ function handleClick(item: (typeof CLOUD_MENU_ITEMS)[number]) {
 <style scoped>
 .quick-cloud {
   padding: 8px;
+}
+.quick-cloud__offline {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px 6px;
+  font-size: 0.65rem;
+  color: rgba(var(--v-theme-warning), 0.8);
+  letter-spacing: 0.04em;
 }
 .quick-cloud__grid {
   display: grid;

--- a/apps/throttle/src/quick-menu/QuickMenuItemList.vue
+++ b/apps/throttle/src/quick-menu/QuickMenuItemList.vue
@@ -5,20 +5,35 @@ export interface ToggleItem {
   state: boolean
   icon?: string
   color?: string
+  action?: 'toggle' | 'navigate' | 'activate'
+  actionIcon?: string
 }
 
-defineProps<{
+const props = withDefaults(defineProps<{
   title: string
   items: ToggleItem[]
-}>()
+  serverOnline?: boolean
+}>(), {
+  serverOnline: true,
+})
 
 const emit = defineEmits<{
   back: []
   toggle: [id: string, state: boolean]
+  navigate: [id: string]
+  activate: [id: string]
 }>()
 
 function onToggle(id: string, v: unknown) {
   emit('toggle', id, !!v)
+}
+
+function onAction(item: ToggleItem) {
+  if (item.action === 'navigate') {
+    emit('navigate', item.id)
+  } else if (item.action === 'activate') {
+    emit('activate', item.id)
+  }
 }
 </script>
 
@@ -44,11 +59,39 @@ function onToggle(id: string, v: unknown) {
           {{ item.icon }}
         </v-icon>
         <span class="qm-list-item__label">{{ item.name }}</span>
+        <!-- 🎮 Navigate action (locos → throttle) -->
+        <v-btn
+          v-if="item.action === 'navigate'"
+          icon
+          variant="text"
+          size="x-small"
+          :color="item.state ? (item.color || 'green') : undefined"
+          class="qm-item-row__action-btn"
+          @click.stop="onAction(item)"
+        >
+          <v-icon size="18">{{ item.actionIcon || 'mdi-gamepad-variant' }}</v-icon>
+        </v-btn>
+        <!-- 🚂 Activate action (routes) -->
+        <v-btn
+          v-else-if="item.action === 'activate'"
+          icon
+          variant="text"
+          size="x-small"
+          :color="item.state ? (item.color || 'green') : undefined"
+          :disabled="!props.serverOnline"
+          class="qm-item-row__action-btn"
+          @click.stop="onAction(item)"
+        >
+          <v-icon size="18">{{ item.actionIcon || 'mdi-call-split' }}</v-icon>
+        </v-btn>
+        <!-- 🔀 Default toggle switch -->
         <v-switch
+          v-else
           :model-value="item.state"
           density="compact"
           hide-details
           color="green"
+          :disabled="!props.serverOnline"
           class="qm-item-row__switch"
           @update:model-value="(v) => onToggle(item.id, v)"
         />
@@ -78,6 +121,10 @@ function onToggle(id: string, v: unknown) {
 }
 .qm-item-row__switch {
   flex-shrink: 0;
+}
+.qm-item-row__action-btn {
+  flex-shrink: 0;
+  margin-left: auto;
 }
 .qm-item-row__switch :deep(.v-switch__track) {
   height: 14px;

--- a/apps/throttle/src/quick-menu/useQuickMenuData.ts
+++ b/apps/throttle/src/quick-menu/useQuickMenuData.ts
@@ -127,7 +127,7 @@ export function useQuickMenuData() {
       name: e.name || e.id,
       state: e.state,
       icon: 'mdi-rocket-launch',
-      color: 'indigo',
+      color: e.color || 'indigo',
     }))
   }
 
@@ -137,7 +137,7 @@ export function useQuickMenuData() {
       name: t.name || t.id,
       state: t.state,
       icon: 'mdi-call-split',
-      color: 'amber',
+      color: t.color || 'amber',
     }))
   }
 
@@ -166,11 +166,13 @@ export function useQuickMenuData() {
       ((throttles.value || []) as Array<{ address: number }>).map((t) => t.address)
     )
     return list.map((l) => ({
-      id: l.id,
+      id: String(l.address),
       name: l.name || `Loco ${l.address}`,
       state: activeAddresses.has(l.address),
       icon: 'mdi-train',
-      color: 'pink',
+      color: l.meta?.color || 'pink',
+      action: 'navigate' as const,
+      actionIcon: 'mdi-gamepad-variant',
     }))
   }
 
@@ -180,7 +182,9 @@ export function useQuickMenuData() {
       name: r.name || r.id,
       state: false,
       icon: 'mdi-map',
-      color: 'purple',
+      color: r.color || 'purple',
+      action: 'activate' as const,
+      actionIcon: 'mdi-call-split',
     }))
   }
 

--- a/apps/throttle/src/throttle/Dashboard.vue
+++ b/apps/throttle/src/throttle/Dashboard.vue
@@ -106,7 +106,7 @@ function setNotch(notch: number) {
 }
 
 // ⬆️⬇️ Direction reverser
-function toggleDirection(val: boolean) {
+function toggleDirection(val: boolean | null) {
   if (currentSpeed.value !== 0) {
     vibrate('heavy')
     return

--- a/apps/throttle/src/throttle/SliderThrottle.vue
+++ b/apps/throttle/src/throttle/SliderThrottle.vue
@@ -48,8 +48,8 @@ watch(debouncedSpeed, (speed) => {
   setSpeed(signedSpeed)
 })
 
-function toggleDirection(val: boolean) {
-  isForward.value = val
+function toggleDirection(val: boolean | null) {
+  isForward.value = val ?? true
   if (sliderVal.value !== 0) {
     const signedSpeed = isForward.value ? sliderVal.value : -sliderVal.value
     setSpeed(signedSpeed)

--- a/docs/throttle/overview.mdx
+++ b/docs/throttle/overview.mdx
@@ -27,6 +27,7 @@ Operators can run a single train with detailed throttle controls, manage multipl
 - **Signal monitoring** with red, yellow, and green aspect indicators.
 - **Effects control** for triggering sound effects, lights, and animations on your layout.
 - **Swipe navigation** between locomotives on the throttle screen.
+- **Quick Menu** — a draggable floating button for instant access to locos, effects, turnouts, routes, signals, and sensors from any page, with drill-down filtering and one-tap actions.
 - **Emergency stop** accessible from the app header on every page.
 - **Theme switching** between light and dark modes.
 - **Guest access** available without authentication for quick demonstrations.
@@ -42,6 +43,7 @@ The Throttle app uses a customizable footer navigation bar and a slide-out side 
 | [Home](/docs/throttle/home) | `/` | Landing page with speedometer widgets for active throttles, login cards, and layout selection |
 | [Throttle Control](/docs/throttle/throttle) | `/throttle/:address` | Full single-locomotive control with speed, functions, consist, and emergency stop |
 | [Throttle List](/docs/throttle/throttle-list) | `/throttles` | Grid view of all active throttles for multi-train operation |
+| [Quick Menu](/docs/throttle/quick-menu) | *(floating overlay)* | Draggable FAB with drill-down access to all layout entities |
 | [Conductor View](/docs/throttle/conductor) | `/conductor` | Three-pane operator station layout with throttle list, active throttle, and turnouts |
 | [Effects](/docs/throttle/effects) | `/effects` | Sound effects, lights, and animation control |
 | [Routes](/docs/throttle/routes) | `/routes` | Interactive track maps and route execution |
@@ -61,5 +63,6 @@ The Throttle app shell includes three persistent UI elements visible across all 
 - **AppHeader** -- displays the app name, layout power toggle, emergency stop button, device connection status, and user profile. The hamburger menu opens the side navigation drawer.
 - **Side Menu** -- a slide-out drawer with the full list of navigation items, each with an icon and color. Items marked as favorites also appear in the footer bar.
 - **Footer Bar** -- a pill-shaped button group at the bottom of the screen showing your favorited navigation items for quick access. The default favorites are Throttles, Conductor, Throttle, Effects, Routes, Turnouts, and Signals.
+- **[Quick Menu](/docs/throttle/quick-menu)** -- a draggable floating action button (FAB) displaying the DEJA.js logo. Tap to open a drill-down panel for browsing and controlling locos, effects, turnouts, routes, signals, and sensors without leaving the current page. The FAB can be repositioned by dragging and remembers its position across sessions.
 
 Page transitions use a fade animation when navigating between views. Swipe gestures on the main content area navigate forward and backward through the menu (disabled on the Throttle Control page, which uses swipe for locomotive switching).

--- a/docs/throttle/quick-menu.mdx
+++ b/docs/throttle/quick-menu.mdx
@@ -1,0 +1,134 @@
+---
+title: Quick Menu
+description: A floating action button with a drill-down menu for fast access to locomotives, effects, turnouts, routes, signals, and sensors — available on every page when logged in.
+section: apps
+order: 2.5
+---
+
+# Quick Menu
+
+The Quick Menu is a draggable floating button that gives you instant access to your layout's locomotives, effects, turnouts, routes, signals, and sensors from any page in the Throttle app. It appears whenever you are logged in and have a layout selected.
+
+{/* TODO: screenshot of quick menu FAB and expanded panel */}
+
+## The FAB
+
+The Quick Menu button displays the DEJA.js "D" logo and floats above all page content. You can:
+
+- **Tap** to open the menu panel.
+- **Drag** to reposition the button anywhere along the left or right edge of the screen. Your position is remembered across sessions.
+
+When the menu is open, the logo changes to an **✕** close icon. Tapping outside the panel or dragging the button also closes the menu.
+
+The panel opens to the left or right of the button depending on which side of the screen the FAB is positioned — it always stays fully visible.
+
+## Home Screen
+
+When first opened, the Quick Menu shows three sections:
+
+### Active Throttles
+
+A compact list of your currently active throttle sessions showing locomotive name and speed. Tap any throttle to jump directly to its [Throttle Control](/docs/throttle/throttle) screen.
+
+### Favorites
+
+If the Quick Menu Favorites feature flag is enabled, a favorites section appears below the throttle list. This allows you to pin frequently used items for one-tap access.
+
+### Layout Controls
+
+A grid of icon buttons for each area of your layout:
+
+| Icon | Label | Action |
+|------|-------|--------|
+| 🚂 Locos | Locos | Drill into locomotive browser |
+| 🚀 Effects | Effects | Drill into effects browser |
+| 🗺️ Routes | Routes | Drill into routes browser |
+| 🔀 Turnouts | Turnouts | Drill into turnouts browser |
+| 🚦 Signals | Signals | Drill into signals browser |
+| 🔌 Connect | Connect | Navigate to connection settings |
+| 🧩 Program | Program | Navigate to CV programmer |
+| ⚙️ Settings | Settings | Navigate to app settings |
+
+If the DEJA.js server is offline, a **"Server offline"** indicator appears above the grid to let you know that server-dependent actions (toggles, route activation) will be disabled.
+
+## Drill-Down Navigation
+
+Tapping an entity (e.g., Effects) opens a sub-menu with filtering options specific to that entity type:
+
+### Locos
+
+- **All** — browse every locomotive in your roster
+- **Active** — show only locomotives with active throttle sessions
+- **By Roadname** — group locomotives by railroad company (e.g., BNSF, Union Pacific)
+- **New** — opens the [Cloud app](https://cloud.dejajs.com/locos/new) in a new tab to add a locomotive
+
+### Effects
+
+- **All** — every effect on the layout
+- **By Device** — group by the device that controls the effect
+- **By Type** — group by effect type (sound, LED, relay, macro, etc.)
+- **By Tag** — group by user-defined tags
+- **New** — opens the Cloud app to add an effect
+
+### Turnouts
+
+- **All** — every turnout on the layout
+- **By Device** — group by controller device
+- **By Tag** — group by tag
+- **Labels** — group by turnout type
+- **New** — opens the Cloud app to add a turnout
+
+### Routes
+
+- **All** — every route on the layout
+- **By Waypoint** — group by start/end waypoint
+- **New** — opens the Cloud app to add a route
+
+### Signals
+
+- **All** — every signal on the layout
+- **By Device** — group by controller device
+- **By Aspect** — group by current aspect (red, yellow, green)
+- **New** — opens the Cloud app to add a signal
+
+### Sensors
+
+- **All** — every sensor on the layout
+- **By Device** — group by controller device
+- **Automations** — sensors with attached automations
+- **New** — opens the Cloud app to add a sensor
+
+## Item Lists and Actions
+
+After selecting a filter (or "All"), you see the individual items. Each item displays its name, an icon in the item's configured color, and an action control:
+
+| Entity | Action | Behavior |
+|--------|--------|----------|
+| **Locos** | 🎮 Gamepad button | Navigates to `/throttle/:address` for that locomotive |
+| **Routes** | 🔀 Turnout button | Activates the route (fires the turnout sequence) |
+| **Effects** | Toggle switch | Turns the effect on or off |
+| **Turnouts** | Toggle switch | Throws or closes the turnout |
+| **Signals** | Toggle switch | Sets the signal to green or red |
+| **Sensors** | Toggle switch | Activates or deactivates the sensor |
+
+### Item Colors
+
+Each item uses its own color as configured in the Cloud app. If no custom color is set, items fall back to a default color for their entity type (pink for locos, indigo for effects, amber for turnouts, purple for routes, emerald for signals, teal for sensors).
+
+### Server Offline Behavior
+
+Toggle switches and route activation buttons are **disabled** when the DEJA.js server is not connected. The loco gamepad button and "New" links remain functional since they don't require the server — they navigate within the app or open the Cloud app in a new tab.
+
+## Creating New Items
+
+Every entity sub-menu includes a **New** option (green ✚ icon) that opens the corresponding form in the [Cloud app](https://cloud.dejajs.com) in a new browser tab. This lets you quickly add a locomotive, effect, turnout, route, signal, or sensor without leaving your operating session.
+
+## Visibility
+
+The Quick Menu is visible on every page in the Throttle app as long as:
+
+1. You are **logged in**.
+2. A **layout is selected**.
+3. The page is not a **fullscreen page** (login, signup, layout selection).
+
+You can toggle Quick Menu visibility in the [Settings](/docs/throttle/settings) page.


### PR DESCRIPTION
## Summary

- 🎯 **Logo FAB** — collapsed Quick Menu button shows the DEJA.js "D" logo instead of the train icon
- 🌐 **"New" → Cloud app** — all entity "New" actions open `cloud.dejajs.com/<entity>/new` in a new tab
- 🎮 **Loco gamepad button** — loco items show a gamepad icon that navigates to `/throttle/:address` (replaces toggle switch)
- 🔀 **Route activate button** — route items show a turnout icon that fires the route (replaces toggle switch)
- 🎨 **Per-item colors** — locos, effects, turnouts, and routes use their Firestore-configured color with category defaults as fallback
- 👤 **Auth + layout gating** — Quick Menu only renders when logged in with a layout selected
- ⚡ **Server offline awareness** — toggle switches and route activation disabled when DEJA server is offline; "Server offline" indicator shown in Cloud section
- 📖 **Documentation** — new `docs/throttle/quick-menu.mdx` user guide, updated overview and README

## Test plan

- [ ] Verify "D" logo appears on collapsed FAB, ✕ on open
- [ ] Drag FAB to reposition — verify position persists
- [ ] Tap loco → gamepad button navigates to `/throttle/:address`
- [ ] Tap route → activate button fires the route
- [ ] Verify effects/turnouts/signals/sensors still use toggle switches
- [ ] Verify per-item colors from Firestore appear on icons and action buttons
- [ ] Tap "New" on any entity → opens Cloud app in new tab
- [ ] Log out → verify Quick Menu disappears
- [ ] Deselect layout → verify Quick Menu disappears
- [ ] With server offline → verify toggles and activate buttons are disabled
- [ ] With server offline → verify "Server offline" indicator appears
- [ ] With server offline → verify loco gamepad and "New" links still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)