### PR TITLE
feat(www): 🔌 IO Guide, shared guide components, and IO documentation

### DIFF
--- a/apps/dejajs-www/app/guides/io/page.tsx
+++ b/apps/dejajs-www/app/guides/io/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next';
+import IoGuide from '../../../components/guides/IoGuide';
+
+export const metadata: Metadata = {
+  title: 'IO Guide — DEJA.js',
+  description: 'Control your entire layout with DEJA IO — Arduino, Pico W, Serial, MQTT, and WebSocket hardware integration.',
+};
+
+export default function IoGuidePage() {
+  return <IoGuide />;
+}

--- a/apps/dejajs-www/app/guides/page.tsx
+++ b/apps/dejajs-www/app/guides/page.tsx
@@ -52,9 +52,8 @@ const guides = [
     href: '/guides/io',
     desc: 'Hardware expansion with Arduino and Pico W — LEDs, servos, signals, sensors, and MQTT.',
     icon: '🔌',
-    comingSoon: true,
-    color: 'border-gray-700/30',
-    iconBg: 'bg-gray-800',
+    color: 'border-fuchsia-400/30 hover:border-fuchsia-400/60',
+    iconBg: 'bg-fuchsia-400/10',
   },
   {
     label: 'Monitor',

--- a/apps/dejajs-www/components/GuidesSidebar.tsx
+++ b/apps/dejajs-www/components/GuidesSidebar.tsx
@@ -17,9 +17,9 @@ const guides: GuideItem[] = [
   { title: 'Architecture', href: '/guides/architecture', desc: 'How the platform works' },
   { title: 'Throttle', href: '/guides/throttle', desc: 'Train control & functions' },
 
-  { title: 'Server', href: '/guides/server', desc: 'Installation & CLI reference', comingSoon: true },
+  { title: 'Server', href: '/guides/server', desc: 'Installation & CLI reference' },
   { title: 'Cloud', href: '/guides/cloud', desc: 'Roster, turnouts & effects' },
-  { title: 'IO', href: '/guides/io', desc: 'Hardware expansion & MQTT', comingSoon: true },
+  { title: 'IO', href: '/guides/io', desc: 'Hardware expansion & MQTT' },
   { title: 'Monitor', href: '/guides/monitor', desc: 'Diagnostics & logging', comingSoon: true },
 ];
 

--- a/apps/dejajs-www/components/Header.tsx
+++ b/apps/dejajs-www/components/Header.tsx
@@ -63,7 +63,7 @@ const defaultProducts: ProductItem[] = [
     name: 'IO',
     desc: 'Arduino and Pico W code for layout expansion.',
     logo: '/icon-512.png',
-    href: '/tour',
+    href: '/guides/io',
   },
   {
     name: 'Monitor',
@@ -83,10 +83,10 @@ const defaultGuidesLinks: DocItem[] = [
   { name: 'Getting Started', href: '/guides/getting-started' },
   { name: 'Architecture', href: '/guides/architecture' },
   { name: 'Throttle', href: '/guides/throttle' },
-  { name: 'Cloud', href: '/guides/cloud', comingSoon: true },
-  { name: 'Monitor', href: '/guides/monitor', comingSoon: true },
+  { name: 'Cloud', href: '/guides/cloud' },
   { name: 'Server', href: '/guides/server' },
-  { name: 'IO', href: '/guides/io', comingSoon: true },
+  { name: 'IO', href: '/guides/io' },
+  { name: 'Monitor', href: '/guides/monitor', comingSoon: true },
 ];
 
 const defaultDocsLinks: DocItem[] = [
@@ -104,7 +104,7 @@ const defaultDocsLinks: DocItem[] = [
 function useDropdown() {
   const [isOpen, setIsOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLButtonElement>(null);
+  const triggerRef = useRef<HTMLButtonElement | HTMLAnchorElement>(null);
 
   const open = useCallback(() => setIsOpen(true), []);
   const close = useCallback(() => setIsOpen(false), []);
@@ -164,7 +164,7 @@ export default function Header({ settings }: { settings?: SiteSettings | null })
     menuItems: { href: string; comingSoon?: boolean }[],
     containerRef: React.RefObject<HTMLDivElement | null>,
     close: () => void,
-    triggerRef: React.RefObject<HTMLButtonElement | null>
+    triggerRef: React.RefObject<HTMLButtonElement | HTMLAnchorElement | null>
   ) => {
     const focusableItems = containerRef.current?.querySelectorAll<HTMLElement>(
       'a[role="menuitem"]:not([aria-disabled="true"])'
@@ -204,9 +204,9 @@ export default function Header({ settings }: { settings?: SiteSettings | null })
         <nav className="hidden md:flex flex-1 items-center gap-8 ml-6" aria-label="Main navigation">
           {/* Guides Dropdown */}
           <div className="relative group py-2" ref={guidesDropdown.ref}>
-            <button
-              ref={guidesDropdown.triggerRef}
-              onClick={guidesDropdown.toggle}
+            <Link
+              href="/guides"
+              ref={guidesDropdown.triggerRef as React.RefObject<HTMLAnchorElement | null>}
               onMouseEnter={guidesDropdown.open}
               aria-expanded={guidesDropdown.isOpen}
               aria-haspopup="true"
@@ -215,7 +215,7 @@ export default function Header({ settings }: { settings?: SiteSettings | null })
               <svg className="w-3.5 h-3.5 opacity-70" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7" /></svg>
               Guides
               <svg className={`w-4 h-4 opacity-70 transition-transform ${guidesDropdown.isOpen ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" /></svg>
-            </button>
+            </Link>
             {guidesDropdown.isOpen && (
               <div
                 className="absolute left-0 top-full pt-2 w-48 bg-transparent"
@@ -259,9 +259,9 @@ export default function Header({ settings }: { settings?: SiteSettings | null })
 
           {/* Products Mega Menu */}
           <div className="relative group py-2" ref={productsDropdown.ref}>
-            <button
-              ref={productsDropdown.triggerRef}
-              onClick={productsDropdown.toggle}
+            <Link
+              href="/#products"
+              ref={productsDropdown.triggerRef as React.RefObject<HTMLAnchorElement | null>}
               onMouseEnter={productsDropdown.open}
               aria-expanded={productsDropdown.isOpen}
               aria-haspopup="true"
@@ -270,7 +270,7 @@ export default function Header({ settings }: { settings?: SiteSettings | null })
               <svg className="w-3.5 h-3.5 opacity-70" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" /></svg>
               Products
               <svg className={`w-4 h-4 opacity-70 transition-transform ${productsDropdown.isOpen ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" /></svg>
-            </button>
+            </Link>
             {productsDropdown.isOpen && (
               <div
                 className="absolute left-1/2 -translate-x-1/2 top-full pt-2 w-[540px] bg-transparent"

--- a/apps/dejajs-www/components/guides/CloudGuide.tsx
+++ b/apps/dejajs-www/components/guides/CloudGuide.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import AnimateIn from '../home/AnimateIn';
 import SectionLabel from '../home/SectionLabel';
 import Logo from '../Logo';
-import { FeatureSection, VideoPlaceholder, FeatureCarousel } from './shared';
+import { FeatureSection, VideoPlaceholder, FeatureCarousel, BeforeYouStart } from './shared';
 import type { CarouselSlide } from './shared';
 
 /* ── Cloud Features Data ── */
@@ -238,15 +238,7 @@ export default function CloudGuide() {
       </section>
 
       {/* ── Prerequisites ── */}
-      <AnimateIn>
-        <div className="max-w-2xl mx-auto mb-8 p-5 rounded-xl border border-gray-800 bg-gray-900/50 text-center">
-          <p className="text-gray-300 text-sm leading-relaxed">
-            Make sure you&apos;ve completed the{' '}
-            <Link href="/guides/getting-started" className="text-deja-cyan hover:underline">Getting Started</Link>{' '}
-            guide — your account should be created and your server running.
-          </p>
-        </div>
-      </AnimateIn>
+      <BeforeYouStart />
 
       {/* ── Dashboard ── */}
       <FeatureSection

--- a/apps/dejajs-www/components/guides/CloudGuide.tsx
+++ b/apps/dejajs-www/components/guides/CloudGuide.tsx
@@ -1,112 +1,13 @@
 'use client';
 
-import { useState } from 'react';
-import Image from 'next/image';
 import Link from 'next/link';
 import AnimateIn from '../home/AnimateIn';
 import SectionLabel from '../home/SectionLabel';
 import Logo from '../Logo';
-import DocLink from '../DocLink';
+import { FeatureSection, VideoPlaceholder, FeatureCarousel } from './shared';
+import type { CarouselSlide } from './shared';
 
-/* ── Shared sub-components ── */
-
-function FeatureCard({ emoji, text }: { emoji: string; text: string }) {
-  return (
-    <div className="flex items-start gap-3 p-3 rounded-lg border border-gray-800/60 bg-gray-900/40 hover:border-deja-cyan/20 hover:bg-gray-900/60 transition-all">
-      <span className="text-lg shrink-0 mt-0.5">{emoji}</span>
-      <span className="text-sm text-gray-300">{text}</span>
-    </div>
-  );
-}
-
-function FeatureGrid({ items }: { items: { emoji: string; text: string }[] }) {
-  return (
-    <div className="grid sm:grid-cols-2 gap-2">
-      {items.map((item, i) => (
-        <AnimateIn key={item.text} delay={i * 0.05}>
-          <FeatureCard emoji={item.emoji} text={item.text} />
-        </AnimateIn>
-      ))}
-    </div>
-  );
-}
-
-function VideoPlaceholder() {
-  return (
-    <div className="rounded-2xl border border-gray-800 bg-gray-900/50 overflow-hidden shadow-2xl">
-      <div className="aspect-video flex flex-col items-center justify-center gap-3 bg-gray-900/80">
-        <div className="w-16 h-16 rounded-full border-2 border-deja-cyan/30 bg-deja-cyan/10 flex items-center justify-center">
-          <svg className="w-6 h-6 text-deja-cyan ml-1" fill="currentColor" viewBox="0 0 24 24">
-            <path d="M8 5v14l11-7z" />
-          </svg>
-        </div>
-        <p className="text-gray-400 text-sm">Video walkthrough coming soon</p>
-      </div>
-    </div>
-  );
-}
-
-function FeatureSection({
-  title,
-  desc,
-  features,
-  screenshot,
-  screenshotAlt,
-  flip = false,
-  docLink,
-  docLabel,
-  children,
-}: {
-  title: string;
-  desc: string;
-  features: { emoji: string; text: string }[];
-  screenshot: string;
-  screenshotAlt: string;
-  flip?: boolean;
-  docLink?: string;
-  docLabel?: string;
-  children?: React.ReactNode;
-}) {
-  return (
-    <section className="py-20">
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-16 items-center">
-        <AnimateIn direction={flip ? 'right' : 'left'} className={flip ? 'lg:order-2' : ''}>
-          <h2 className="text-3xl sm:text-4xl font-bold text-white mb-3">{title}</h2>
-          <p className="text-gray-400 leading-relaxed mb-6">{desc}</p>
-          <FeatureGrid items={features} />
-          {children}
-          {docLink && docLabel && (
-            <div className="mt-4">
-              <DocLink href={docLink}>{docLabel}</DocLink>
-            </div>
-          )}
-        </AnimateIn>
-        <AnimateIn direction={flip ? 'left' : 'right'} className={`flex justify-center ${flip ? 'lg:order-1' : ''}`}>
-          <div className="rounded-2xl overflow-hidden shadow-2xl w-full max-w-lg">
-            <Image src={screenshot} alt={screenshotAlt} width={1200} height={675} className="w-full h-auto" />
-          </div>
-        </AnimateIn>
-      </div>
-    </section>
-  );
-}
-
-/* ── Cloud Features Carousel ── */
-
-interface CarouselSlide {
-  id: string;
-  emoji: string;
-  title: string;
-  tagline: string;
-  desc: string;
-  desktopScreenshot: string;
-  features: { emoji: string; text: string }[];
-  docHref: string;
-  docLabel: string;
-  accentColor: string;
-  accentBg: string;
-  accentBorder: string;
-}
+/* ── Cloud Features Data ── */
 
 const cloudFeatures: CarouselSlide[] = [
   {
@@ -305,80 +206,6 @@ const cloudFeatures: CarouselSlide[] = [
   },
 ];
 
-function CloudFeaturesCarousel() {
-  const [activeIdx, setActiveIdx] = useState(0);
-  const active = cloudFeatures[activeIdx];
-
-  return (
-    <section className="py-20">
-      <div className="max-w-5xl mx-auto">
-        <AnimateIn>
-          <SectionLabel color="lime">Feature Reference</SectionLabel>
-          <h2 className="text-3xl sm:text-4xl font-bold text-white mt-4 mb-3">Everything in Cloud</h2>
-          <p className="text-gray-400 leading-relaxed mb-10">
-            Beyond the basics, Cloud gives you full control over every aspect of your layout.
-            Configure it here, control it from{' '}
-            <Link href="/guides/throttle" className="text-deja-cyan hover:underline">Throttle</Link>.
-          </p>
-        </AnimateIn>
-
-        {/* Tab buttons */}
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-12">
-          {cloudFeatures.map((slide, i) => (
-            <button
-              key={slide.id}
-              onClick={() => setActiveIdx(i)}
-              className={`flex flex-col items-center gap-2 px-4 py-4 rounded-xl text-sm font-semibold transition-all cursor-pointer ${
-                i === activeIdx
-                  ? `${slide.accentBg} border-2 ${slide.accentBorder} ${slide.accentColor} shadow-lg`
-                  : 'border-2 border-gray-800/60 text-gray-500 hover:border-gray-600 hover:text-gray-300 hover:bg-gray-900/50'
-              }`}
-            >
-              <span className="text-2xl">{slide.emoji}</span>
-              <span>{slide.title}</span>
-            </button>
-          ))}
-        </div>
-
-        {/* Active slide */}
-        <div key={active.id}>
-          <div className="mb-8">
-            <h3 className={`text-3xl font-bold ${active.accentColor} mb-2`}>{active.title}</h3>
-            <p className="text-xl text-white font-semibold">{active.tagline}</p>
-            <p className="text-gray-400 leading-relaxed mt-3 max-w-2xl">{active.desc}</p>
-          </div>
-
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-start">
-            <div className="rounded-2xl overflow-hidden shadow-2xl">
-              <Image
-                src={active.desktopScreenshot}
-                alt={`${active.title} desktop view`}
-                width={1200}
-                height={675}
-                className="w-full h-auto"
-              />
-            </div>
-
-            {/* Features */}
-            <div>
-              <FeatureGrid items={active.features} />
-              <div className="mt-6 flex flex-wrap gap-3">
-                <DocLink href={active.docHref}>{active.docLabel}</DocLink>
-              </div>
-
-              <div className={`mt-6 p-6 rounded-xl border-2 border-dashed ${active.accentBorder} ${active.accentBg} flex flex-col items-center gap-2`}>
-                <span className="text-4xl">{active.emoji}</span>
-                <p className={`text-sm font-medium ${active.accentColor}`}>Illustration coming soon</p>
-                <p className="text-xs text-gray-500 text-center">Custom graphic for {active.title.toLowerCase()}</p>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-  );
-}
-
 /* ── Main guide ── */
 
 export default function CloudGuide() {
@@ -528,7 +355,20 @@ export default function CloudGuide() {
       </div>
 
       {/* ── Feature Reference Carousel ── */}
-      <CloudFeaturesCarousel />
+      <FeatureCarousel
+        slides={cloudFeatures}
+        sectionLabel="Feature Reference"
+        sectionColor="lime"
+        title="Everything in Cloud"
+        description={
+          <>
+            Beyond the basics, Cloud gives you full control over every aspect of your layout.
+            Configure it here, control it from{' '}
+            <Link href="/guides/throttle" className="text-deja-cyan hover:underline">Throttle</Link>.
+          </>
+        }
+        tabColumns="sm:grid-cols-4"
+      />
 
       {/* ── What's Next ── */}
       <section className="py-16 border-t border-gray-800/50">

--- a/apps/dejajs-www/components/guides/GettingStartedGuide.tsx
+++ b/apps/dejajs-www/components/guides/GettingStartedGuide.tsx
@@ -1,55 +1,8 @@
 import Link from 'next/link';
 import Image from 'next/image';
-import CopyButton from '../home/CopyButton';
 import { mdiCellphoneLink, mdiLaptop, mdiUsb } from '@mdi/js';
 import ThrottleLaunchQR from '../home/ThrottleLaunchQR';
-
-function Step({ number, title, children }: { number: number; title: string; children: React.ReactNode }) {
-  return (
-    <div className="relative pl-14">
-      <div className="absolute left-0 top-0 w-10 h-10 rounded-full border border-deja-cyan/30 bg-deja-cyan/10 flex items-center justify-center shrink-0">
-        <span className="text-deja-cyan font-bold text-sm font-mono">0{number}</span>
-      </div>
-      <h3 className="text-white font-bold text-xl mb-3">{title}</h3>
-      <div className="text-gray-300 leading-relaxed space-y-3">{children}</div>
-    </div>
-  );
-}
-
-function CommandBlock({ command }: { command: string }) {
-  return (
-    <div className="rounded-lg border border-gray-700 bg-gray-950 overflow-hidden my-4">
-      <div className="flex items-center gap-1.5 px-3 py-2 border-b border-gray-800 bg-gray-900">
-        <span className="w-2.5 h-2.5 rounded-full bg-red-500/70" />
-        <span className="w-2.5 h-2.5 rounded-full bg-yellow-500/70" />
-        <span className="w-2.5 h-2.5 rounded-full bg-green-500/70" />
-        <span className="ml-2 text-gray-500 text-xs font-mono">bash</span>
-      </div>
-      <div className="flex items-center gap-2 px-4 py-3">
-        <span className="text-deja-lime/60 font-mono text-sm select-none shrink-0">$</span>
-        <span className="font-mono text-sm text-deja-lime flex-1 break-all">{command}</span>
-        <CopyButton text={command} />
-      </div>
-    </div>
-  );
-}
-
-function Callout({ emoji, children }: { emoji: string; children: React.ReactNode }) {
-  return (
-    <div className="flex gap-3 p-4 rounded-lg bg-deja-cyan/5 border border-deja-cyan/20 my-4">
-      <span className="text-lg shrink-0">{emoji}</span>
-      <div className="text-sm text-gray-300 leading-relaxed">{children}</div>
-    </div>
-  );
-}
-
-function MdiIcon({ path, className = '' }: { path: string; className?: string }) {
-  return (
-    <svg viewBox="0 0 24 24" className={className}>
-      <path d={path} fill="currentColor" />
-    </svg>
-  );
-}
+import { Callout, CommandBlock, Step, MdiIcon } from './shared';
 
 function AppIcon({ src, alt, bgColor, borderColor }: { src: string; alt: string; bgColor: string; borderColor: string }) {
   return (
@@ -167,7 +120,7 @@ export default function GettingStartedGuide() {
 
       {/* Steps */}
       <div className="space-y-12">
-        <Step number={1} title="Create Your Account">
+        <Step number={1} title="Create Your Account" color="cyan">
           <p>
             Head to <a href="https://cloud.dejajs.com" target="_blank" rel="noopener noreferrer" className="text-deja-cyan hover:underline">cloud.dejajs.com</a> and
             sign up with Google, GitHub, or email. It takes about 10 seconds.
@@ -175,16 +128,16 @@ export default function GettingStartedGuide() {
           <p>The onboarding wizard walks you through everything from here — you won&apos;t need to leave the browser until it&apos;s time to install the server.</p>
         </Step>
 
-        <Step number={2} title="Name Your Layout">
+        <Step number={2} title="Name Your Layout" color="cyan">
           <p>
             Give your railroad a name and we&apos;ll generate a unique Layout ID. Your layout is officially created when you install the server — no commitment until then.
           </p>
-          <Callout emoji="💡">
+          <Callout emoji="💡" color="cyan">
             <p>You can create multiple layouts later if you have more than one railroad (paid plans).</p>
           </Callout>
         </Step>
 
-        <Step number={3} title="Choose a Plan">
+        <Step number={3} title="Choose a Plan" color="cyan">
           <p>
             The <strong className="text-white">free Hobbyist plan</strong> gets you started with up to 5 locomotives — no credit card, no commitment.
             Upgrade anytime to unlock turnouts, effects, signals, and more.
@@ -220,7 +173,7 @@ export default function GettingStartedGuide() {
           <p className="text-xs text-gray-500">Paid plans include a 14-day free trial. See the <Link href="/pricing" className="text-deja-cyan hover:underline">full comparison</Link> for details.</p>
         </Step>
 
-        <Step number={4} title="Install the Server">
+        <Step number={4} title="Install the Server" color="cyan">
           <p>
             Open a terminal on the machine connected to your CommandStation and run one command:
           </p>
@@ -230,7 +183,7 @@ export default function GettingStartedGuide() {
             and connects automatically. While it installs, you can start adding locomotives
             to your roster right in the browser.
           </p>
-          <Callout emoji="🍓">
+          <Callout emoji="🍓" color="cyan">
             <p>
               <strong className="text-white">Raspberry Pi?</strong> DEJA Server runs great on a Pi 4 or 5.
               Just plug your CommandStation in via USB and run the command above.
@@ -243,13 +196,13 @@ export default function GettingStartedGuide() {
           </p>
         </Step>
 
-        <Step number={5} title="Add Your First Locomotive">
+        <Step number={5} title="Add Your First Locomotive" color="cyan">
           <p>
             While the server installs, add a locomotive to your roster.
             You just need the <strong className="text-white">DCC address</strong> (usually printed on the decoder)
             and a <strong className="text-white">name</strong>.
           </p>
-          <Callout emoji="🔢">
+          <Callout emoji="🔢" color="cyan">
             <p>
               Not sure of the address? Most new decoders default to <strong className="text-white">address 3</strong>.
               You can always change it later.
@@ -257,7 +210,7 @@ export default function GettingStartedGuide() {
           </Callout>
         </Step>
 
-        <Step number={6} title="Open the Throttle & Drive">
+        <Step number={6} title="Open the Throttle & Drive" color="cyan">
           <p>
             Once the server connects, open{' '}
             <a href="https://throttle.dejajs.com" target="_blank" rel="noopener noreferrer" className="text-deja-cyan hover:underline">throttle.dejajs.com</a>

--- a/apps/dejajs-www/components/guides/GettingStartedGuide.tsx
+++ b/apps/dejajs-www/components/guides/GettingStartedGuide.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { mdiCellphoneLink, mdiLaptop, mdiUsb } from '@mdi/js';
 import ThrottleLaunchQR from '../home/ThrottleLaunchQR';
-import { Callout, CommandBlock, Step, MdiIcon } from './shared';
+import { Callout, CommandBlock, Step, MdiIcon, VideoPlaceholder } from './shared';
 
 function AppIcon({ src, alt, bgColor, borderColor }: { src: string; alt: string; bgColor: string; borderColor: string }) {
   return (
@@ -62,6 +62,11 @@ export default function GettingStartedGuide() {
           cloud-synced. Here&apos;s how to get started.
         </p>
       </header>
+
+      {/* Video Walkthrough */}
+      <section className="mb-12">
+        <VideoPlaceholder />
+      </section>
 
       {/* How It Works */}
       <section className="mb-12">

--- a/apps/dejajs-www/components/guides/IoGuide.tsx
+++ b/apps/dejajs-www/components/guides/IoGuide.tsx
@@ -3,7 +3,7 @@
 import AnimateIn from '../home/AnimateIn';
 import SectionLabel from '../home/SectionLabel';
 import DocLink from '../DocLink';
-import { FeatureGrid, VideoPlaceholder, Callout } from './shared';
+import { FeatureGrid, VideoPlaceholder, Callout, BeforeYouStart } from './shared';
 
 const protocolColors: Record<string, string> = {
   amber: 'border-amber-400/30 bg-amber-400/5 text-amber-400',
@@ -48,6 +48,9 @@ export default function IoGuide() {
           <VideoPlaceholder />
         </AnimateIn>
       </section>
+
+      {/* ── Prerequisites ── */}
+      <BeforeYouStart />
 
       {/* ── 2. Architecture Diagram — How It Works ── */}
       <section className="mb-20">
@@ -283,7 +286,7 @@ export default function IoGuide() {
         </AnimateIn>
       </section>
 
-      {/* ── 5. Deploy Flow Video ── */}
+      {/* ── 5. Deploy Flow ── */}
       <section className="mb-20">
         <AnimateIn>
           <SectionLabel color="cyan">Deploy Flow</SectionLabel>
@@ -292,9 +295,6 @@ export default function IoGuide() {
           </h2>
         </AnimateIn>
         <AnimateIn delay={0.1}>
-          <VideoPlaceholder />
-        </AnimateIn>
-        <AnimateIn delay={0.15}>
           <Callout emoji="🚀" color="cyan">
             <p>
               Plug in a new device and it&apos;s auto-detected by the server.

--- a/apps/dejajs-www/components/guides/IoGuide.tsx
+++ b/apps/dejajs-www/components/guides/IoGuide.tsx
@@ -38,6 +38,13 @@ export default function IoGuide() {
         </AnimateIn>
       </header>
 
+      {/* ── Video Walkthrough ── */}
+      <section className="mb-20">
+        <AnimateIn>
+          <VideoPlaceholder />
+        </AnimateIn>
+      </section>
+
       {/* ── 2. Architecture Diagram — How It Works ── */}
       <section className="mb-20">
         <AnimateIn>

--- a/apps/dejajs-www/components/guides/IoGuide.tsx
+++ b/apps/dejajs-www/components/guides/IoGuide.tsx
@@ -5,7 +5,11 @@ import SectionLabel from '../home/SectionLabel';
 import DocLink from '../DocLink';
 import { FeatureGrid, VideoPlaceholder, Callout } from './shared';
 
-/* ── 🔌 IO Guide — Beyond the Throttle ── */
+const protocolColors: Record<string, string> = {
+  amber: 'border-amber-400/30 bg-amber-400/5 text-amber-400',
+  purple: 'border-purple-400/30 bg-purple-400/5 text-purple-400',
+  cyan: 'border-deja-cyan/30 bg-deja-cyan/5 text-deja-cyan',
+};
 
 export default function IoGuide() {
   return (
@@ -97,23 +101,16 @@ export default function IoGuide() {
                 { label: 'Serial USB', color: 'amber', icon: '🔌', desc: 'Direct wired connection' },
                 { label: 'MQTT WiFi', color: 'purple', icon: '📡', desc: 'Wireless via broker' },
                 { label: 'WebSocket', color: 'cyan', icon: '🌐', desc: 'Real-time bidirectional' },
-              ].map((proto) => {
-                const colorMap: Record<string, string> = {
-                  amber: 'border-amber-400/30 bg-amber-400/5 text-amber-400',
-                  purple: 'border-purple-400/30 bg-purple-400/5 text-purple-400',
-                  cyan: 'border-deja-cyan/30 bg-deja-cyan/5 text-deja-cyan',
-                };
-                return (
-                  <div
-                    key={proto.label}
-                    className={`rounded-lg border p-3 text-center ${colorMap[proto.color]}`}
-                  >
-                    <p className="text-lg mb-1">{proto.icon}</p>
-                    <p className="text-xs font-bold">{proto.label}</p>
-                    <p className="text-[10px] text-gray-500 mt-1">{proto.desc}</p>
-                  </div>
-                );
-              })}
+              ].map((proto) => (
+                <div
+                  key={proto.label}
+                  className={`rounded-lg border p-3 text-center ${protocolColors[proto.color]}`}
+                >
+                  <p className="text-lg mb-1">{proto.icon}</p>
+                  <p className="text-xs font-bold">{proto.label}</p>
+                  <p className="text-[10px] text-gray-500 mt-1">{proto.desc}</p>
+                </div>
+              ))}
             </div>
 
             {/* Arrow down */}

--- a/apps/dejajs-www/components/guides/IoGuide.tsx
+++ b/apps/dejajs-www/components/guides/IoGuide.tsx
@@ -1,0 +1,343 @@
+'use client';
+
+import AnimateIn from '../home/AnimateIn';
+import SectionLabel from '../home/SectionLabel';
+import DocLink from '../DocLink';
+import { FeatureGrid, VideoPlaceholder, Callout } from './shared';
+
+/* ── 🔌 IO Guide — Beyond the Throttle ── */
+
+export default function IoGuide() {
+  return (
+    <article className="max-w-4xl mx-auto">
+
+      {/* ── 1. Hero ── */}
+      <header className="mb-16">
+        <AnimateIn>
+          <SectionLabel color="magenta">DEJA IO</SectionLabel>
+        </AnimateIn>
+        <AnimateIn delay={0.1}>
+          <h1 className="text-4xl md:text-5xl font-bold text-white tracking-tight mt-4 mb-4">
+            Beyond the Throttle
+          </h1>
+        </AnimateIn>
+        <AnimateIn delay={0.15}>
+          <p className="text-gray-400 text-lg leading-relaxed mb-4">
+            DEJA.js isn&apos;t just a throttle — it&apos;s a full layout automation platform.
+            IO devices let you control turnouts, signals, lighting, sound, and sensors
+            from the same apps you already use to run trains.
+          </p>
+        </AnimateIn>
+        <AnimateIn delay={0.2}>
+          <p className="text-gray-400 leading-relaxed">
+            Connect an <strong className="text-white">Arduino over USB</strong> for wired reliability,
+            or a <strong className="text-white">Pico W over WiFi</strong> for wireless flexibility.
+            Configure everything in the <strong className="text-white">Cloud app</strong>,
+            then control it all from the <strong className="text-white">Throttle</strong> — no code required.
+          </p>
+        </AnimateIn>
+      </header>
+
+      {/* ── 2. Architecture Diagram — How It Works ── */}
+      <section className="mb-20">
+        <AnimateIn>
+          <h2 className="text-3xl font-bold text-white mb-3">How It Works</h2>
+        </AnimateIn>
+        <AnimateIn delay={0.05}>
+          <p className="text-gray-400 leading-relaxed mb-8">
+            DEJA.js connects your browser to your layout hardware through three
+            communication protocols — each optimized for different setups.
+          </p>
+        </AnimateIn>
+
+        {/* 🏗️ Diagram */}
+        <AnimateIn delay={0.1}>
+          <div className="rounded-2xl border border-gray-800 bg-gray-900/50 p-6 sm:p-8 overflow-hidden">
+
+            {/* Top — Browser / Apps */}
+            <div className="text-center mb-6">
+              <p className="text-xs text-gray-500 font-mono tracking-widest uppercase mb-3">
+                Your Phone / Browser
+              </p>
+              <div className="flex flex-wrap justify-center gap-2">
+                {['Throttle', 'Cloud', 'Monitor'].map((app) => (
+                  <span
+                    key={app}
+                    className="px-3 py-1 rounded-full border border-deja-cyan/30 bg-deja-cyan/5 text-deja-cyan text-xs font-semibold"
+                  >
+                    {app}
+                  </span>
+                ))}
+              </div>
+            </div>
+
+            {/* Arrow down */}
+            <div className="flex justify-center my-4">
+              <div className="w-px h-8 bg-gradient-to-b from-deja-cyan/40 to-gray-700" />
+            </div>
+
+            {/* Middle — DEJA Server */}
+            <div className="text-center mb-4">
+              <div className="inline-block px-6 py-3 rounded-xl border-2 border-deja-lime/40 bg-deja-lime/5">
+                <p className="text-deja-lime font-bold text-sm">🖥️ DEJA Server</p>
+                <p className="text-gray-500 text-xs mt-1">Node.js on your computer or Raspberry Pi</p>
+              </div>
+            </div>
+
+            {/* Three protocol branches */}
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 my-6">
+              {[
+                { label: 'Serial USB', color: 'amber', icon: '🔌', desc: 'Direct wired connection' },
+                { label: 'MQTT WiFi', color: 'purple', icon: '📡', desc: 'Wireless via broker' },
+                { label: 'WebSocket', color: 'cyan', icon: '🌐', desc: 'Real-time bidirectional' },
+              ].map((proto) => {
+                const colorMap: Record<string, string> = {
+                  amber: 'border-amber-400/30 bg-amber-400/5 text-amber-400',
+                  purple: 'border-purple-400/30 bg-purple-400/5 text-purple-400',
+                  cyan: 'border-deja-cyan/30 bg-deja-cyan/5 text-deja-cyan',
+                };
+                return (
+                  <div
+                    key={proto.label}
+                    className={`rounded-lg border p-3 text-center ${colorMap[proto.color]}`}
+                  >
+                    <p className="text-lg mb-1">{proto.icon}</p>
+                    <p className="text-xs font-bold">{proto.label}</p>
+                    <p className="text-[10px] text-gray-500 mt-1">{proto.desc}</p>
+                  </div>
+                );
+              })}
+            </div>
+
+            {/* Arrow down */}
+            <div className="flex justify-center my-4">
+              <div className="w-px h-8 bg-gradient-to-b from-gray-700 to-deja-lime/40" />
+            </div>
+
+            {/* Bottom — Your Layout */}
+            <div className="text-center">
+              <p className="text-xs text-gray-500 font-mono tracking-widest uppercase mb-3">
+                Your Layout
+              </p>
+              <div className="flex flex-wrap justify-center gap-2">
+                {['Turnouts', 'Lights', 'Signals', 'Sensors', 'Sounds'].map((hw) => (
+                  <span
+                    key={hw}
+                    className="px-3 py-1 rounded-full border border-deja-lime/30 bg-deja-lime/5 text-deja-lime text-xs font-semibold"
+                  >
+                    {hw}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
+        </AnimateIn>
+      </section>
+
+      {/* ── 3. Protocol Comparison Cards ── */}
+      <section className="mb-20">
+        <AnimateIn>
+          <h2 className="text-3xl font-bold text-white mb-8">Choose Your Protocol</h2>
+        </AnimateIn>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          {[
+            {
+              title: 'Serial USB',
+              color: 'amber',
+              icon: '🔌',
+              tagline: 'Direct & reliable',
+              device: 'Arduino',
+              connection: 'USB cable to server',
+              latency: 'Lowest latency',
+              border: 'border-amber-400/30 hover:border-amber-400/50',
+              accent: 'text-amber-400',
+              bg: 'bg-amber-400/5',
+            },
+            {
+              title: 'MQTT over WiFi',
+              color: 'purple',
+              icon: '📡',
+              tagline: 'Wireless & scalable',
+              device: 'Pico W',
+              connection: 'WiFi to MQTT broker',
+              latency: 'Low latency',
+              border: 'border-purple-400/30 hover:border-purple-400/50',
+              accent: 'text-purple-400',
+              bg: 'bg-purple-400/5',
+            },
+            {
+              title: 'WebSocket',
+              color: 'cyan',
+              icon: '🌐',
+              tagline: 'Real-time & flexible',
+              device: 'Any networked device',
+              connection: 'TCP port 8082',
+              latency: 'Persistent connection',
+              border: 'border-deja-cyan/30 hover:border-deja-cyan/50',
+              accent: 'text-deja-cyan',
+              bg: 'bg-deja-cyan/5',
+            },
+          ].map((proto, i) => (
+            <AnimateIn key={proto.title} delay={i * 0.08}>
+              <div className={`rounded-xl border ${proto.border} ${proto.bg} p-5 h-full transition-colors`}>
+                <p className="text-2xl mb-2">{proto.icon}</p>
+                <h3 className={`font-bold text-lg ${proto.accent} mb-1`}>{proto.title}</h3>
+                <p className="text-white text-sm font-medium mb-3">{proto.tagline}</p>
+                <div className="space-y-2 text-sm text-gray-400">
+                  <div className="flex items-center gap-2">
+                    <span className="text-gray-600">Device</span>
+                    <span className="text-gray-300">{proto.device}</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="text-gray-600">Link</span>
+                    <span className="text-gray-300">{proto.connection}</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="text-gray-600">Speed</span>
+                    <span className="text-gray-300">{proto.latency}</span>
+                  </div>
+                </div>
+              </div>
+            </AnimateIn>
+          ))}
+        </div>
+      </section>
+
+      {/* ── 4. Supported Devices ── */}
+      <section className="mb-20">
+        <AnimateIn>
+          <SectionLabel color="lime">Supported Hardware</SectionLabel>
+          <h2 className="text-3xl font-bold text-white mt-4 mb-8">Ready-Made Devices</h2>
+        </AnimateIn>
+
+        {/* Arduino + Pico W cards */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+          {/* 🟠 Arduino */}
+          <AnimateIn delay={0.05}>
+            <div className="rounded-xl border border-amber-400/30 bg-amber-400/5 p-5 h-full">
+              <div className="flex items-center gap-3 mb-3">
+                <span className="text-2xl">🔌</span>
+                <div>
+                  <h3 className="text-amber-400 font-bold text-lg">Arduino</h3>
+                  <p className="text-gray-500 text-xs">Serial USB &middot; Wired</p>
+                </div>
+              </div>
+              <FeatureGrid
+                items={[
+                  { emoji: '🔧', text: 'PCA9685 servo control for turnouts & signals' },
+                  { emoji: '💡', text: 'Digital outputs for LEDs & accessories' },
+                  { emoji: '🚦', text: 'Multi-aspect signal heads' },
+                  { emoji: '📟', text: 'Sensor inputs for block detection' },
+                ]}
+              />
+              <div className="mt-4">
+                <DocLink href="/docs/io/arduino-setup">Arduino Setup Guide</DocLink>
+              </div>
+            </div>
+          </AnimateIn>
+
+          {/* 🟣 Pico W */}
+          <AnimateIn delay={0.1}>
+            <div className="rounded-xl border border-purple-400/30 bg-purple-400/5 p-5 h-full">
+              <div className="flex items-center gap-3 mb-3">
+                <span className="text-2xl">📡</span>
+                <div>
+                  <h3 className="text-purple-400 font-bold text-lg">Pico W</h3>
+                  <p className="text-gray-500 text-xs">MQTT WiFi &middot; Wireless</p>
+                </div>
+              </div>
+              <FeatureGrid
+                items={[
+                  { emoji: '📶', text: 'WiFi connectivity — no wires to the server' },
+                  { emoji: '🔧', text: 'PCA9685 servo control over I2C' },
+                  { emoji: '💡', text: 'Digital pin outputs for LEDs & relays' },
+                  { emoji: '⚙️', text: 'Runtime configuration via MQTT commands' },
+                ]}
+              />
+              <div className="mt-4">
+                <DocLink href="/docs/io/pico-w-setup">Pico W Setup Guide</DocLink>
+              </div>
+            </div>
+          </AnimateIn>
+        </div>
+
+        {/* 🔵 Build Your Own teaser */}
+        <AnimateIn delay={0.15}>
+          <div className="rounded-xl border border-dashed border-deja-cyan/30 bg-deja-cyan/5 p-5">
+            <div className="flex items-start gap-3">
+              <span className="text-2xl shrink-0">🛠️</span>
+              <div>
+                <h3 className="text-deja-cyan font-bold text-lg mb-1">Build Your Own</h3>
+                <p className="text-gray-400 text-sm leading-relaxed mb-3">
+                  DEJA.js uses open protocols — any device that speaks Serial, MQTT, or WebSocket
+                  can join your layout. Send JSON commands and you&apos;re in.
+                </p>
+                <DocLink href="/docs/io/custom-devices">Custom Device Guide</DocLink>
+              </div>
+            </div>
+          </div>
+        </AnimateIn>
+      </section>
+
+      {/* ── 5. Deploy Flow Video ── */}
+      <section className="mb-20">
+        <AnimateIn>
+          <SectionLabel color="cyan">Deploy Flow</SectionLabel>
+          <h2 className="text-3xl font-bold text-white mt-4 mb-6">
+            Configure Once, Deploy Anywhere
+          </h2>
+        </AnimateIn>
+        <AnimateIn delay={0.1}>
+          <VideoPlaceholder />
+        </AnimateIn>
+        <AnimateIn delay={0.15}>
+          <Callout emoji="🚀" color="cyan">
+            <p>
+              Plug in a new device and it&apos;s auto-detected by the server.
+              Configure pins, servos, and outputs in the Cloud app, then deploy
+              with a single command — no re-flashing, no code changes.
+            </p>
+          </Callout>
+        </AnimateIn>
+      </section>
+
+      {/* ── 6. Docs Links ── */}
+      <section className="pt-8 border-t border-gray-800">
+        <AnimateIn>
+          <h2 className="text-2xl font-bold text-white mb-6">Dive Into the Docs</h2>
+        </AnimateIn>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-8">
+          {/* Get Started column */}
+          <AnimateIn delay={0.05}>
+            <div>
+              <h3 className="text-white font-semibold text-sm uppercase tracking-wider mb-3">
+                Get Started
+              </h3>
+              <div className="flex flex-col items-start gap-2">
+                <DocLink href="/docs/io">IO Overview</DocLink>
+                <DocLink href="/docs/io/arduino-setup">Arduino Setup</DocLink>
+                <DocLink href="/docs/io/pico-w-setup">Pico W Setup</DocLink>
+                <DocLink href="/docs/io/deploy">Deploy & Flash</DocLink>
+              </div>
+            </div>
+          </AnimateIn>
+
+          {/* Go Deeper column */}
+          <AnimateIn delay={0.1}>
+            <div>
+              <h3 className="text-white font-semibold text-sm uppercase tracking-wider mb-3">
+                Go Deeper
+              </h3>
+              <div className="flex flex-col items-start gap-2">
+                <DocLink href="/docs/io/command-reference">Command Reference</DocLink>
+                <DocLink href="/docs/io/protocols">Protocols</DocLink>
+                <DocLink href="/docs/io/configuration">Configuration</DocLink>
+                <DocLink href="/docs/io/custom-devices">Custom Devices</DocLink>
+              </div>
+            </div>
+          </AnimateIn>
+        </div>
+      </section>
+    </article>
+  );
+}

--- a/apps/dejajs-www/components/guides/ServerGuide.tsx
+++ b/apps/dejajs-www/components/guides/ServerGuide.tsx
@@ -1,37 +1,8 @@
 import Link from 'next/link';
 import Image from 'next/image';
-import CopyButton from '../home/CopyButton';
 import { mdiUsb } from '@mdi/js';
-
-function Step({ number, title, children }: { number: number; title: string; children: React.ReactNode }) {
-  return (
-    <div className="relative pl-14">
-      <div className="absolute left-0 top-0 w-10 h-10 rounded-full border border-deja-lime/30 bg-deja-lime/10 flex items-center justify-center shrink-0">
-        <span className="text-deja-lime font-bold text-sm font-mono">0{number}</span>
-      </div>
-      <h3 className="text-white font-bold text-xl mb-3">{title}</h3>
-      <div className="text-gray-300 leading-relaxed space-y-3">{children}</div>
-    </div>
-  );
-}
-
-function CommandBlock({ command }: { command: string }) {
-  return (
-    <div className="rounded-lg border border-gray-700 bg-gray-950 overflow-hidden my-4">
-      <div className="flex items-center gap-1.5 px-3 py-2 border-b border-gray-800 bg-gray-900">
-        <span className="w-2.5 h-2.5 rounded-full bg-red-500/70" />
-        <span className="w-2.5 h-2.5 rounded-full bg-yellow-500/70" />
-        <span className="w-2.5 h-2.5 rounded-full bg-green-500/70" />
-        <span className="ml-2 text-gray-500 text-xs font-mono">bash</span>
-      </div>
-      <div className="flex items-center gap-2 px-4 py-3">
-        <span className="text-deja-lime/60 font-mono text-sm select-none shrink-0">$</span>
-        <span className="font-mono text-sm text-deja-lime flex-1 break-all">{command}</span>
-        <CopyButton text={command} />
-      </div>
-    </div>
-  );
-}
+import { Callout, CommandBlock, Step, MdiIcon } from './shared';
+import DocLink from '../DocLink';
 
 function TerminalOutput({ children }: { children: React.ReactNode }) {
   return (
@@ -46,23 +17,6 @@ function TerminalOutput({ children }: { children: React.ReactNode }) {
         {children}
       </div>
     </div>
-  );
-}
-
-function Callout({ emoji, children }: { emoji: string; children: React.ReactNode }) {
-  return (
-    <div className="flex gap-3 p-4 rounded-lg bg-deja-lime/5 border border-deja-lime/20 my-4">
-      <span className="text-lg shrink-0">{emoji}</span>
-      <div className="text-sm text-gray-300 leading-relaxed">{children}</div>
-    </div>
-  );
-}
-
-function MdiIcon({ path, className = '' }: { path: string; className?: string }) {
-  return (
-    <svg viewBox="0 0 24 24" className={className}>
-      <path d={path} fill="currentColor" />
-    </svg>
   );
 }
 
@@ -115,7 +69,7 @@ export default function ServerGuide() {
         </div>
         <p className="text-xs text-gray-500 mt-3">
           For platform compatibility and system requirements, see the{' '}
-          <Link href="/docs/server/installation" className="text-deja-cyan hover:underline">Installation docs</Link>.
+          <DocLink href="/docs/server/installation">Installation</DocLink>.
         </p>
       </section>
 
@@ -247,7 +201,7 @@ export default function ServerGuide() {
           </Callout>
           <p className="text-sm text-gray-400">
             For the full setup details, see the{' '}
-            <Link href="/docs/server/remote-access" className="text-deja-lime hover:underline">Remote Access docs</Link>.
+            <DocLink href="/docs/server/remote-access">Remote Access</DocLink>.
           </p>
         </Step>
       </div>
@@ -336,7 +290,7 @@ export default function ServerGuide() {
             straight to your CommandStation. For example, type{' '}
             <code className="text-deja-lime font-mono text-xs">{'<1>'}</code> to turn track power on.
             See the{' '}
-            <Link href="/docs/server/cli" className="text-deja-cyan hover:underline">CLI Reference</Link>
+            <DocLink href="/docs/server/cli">CLI Reference</DocLink>
             {' '}for more details.
           </p>
         </div>
@@ -377,7 +331,7 @@ export default function ServerGuide() {
           </div>
           <p className="text-xs text-gray-500">
             For a complete guide to every message — startup sequence, DCC commands, shutdown, and common errors — see the{' '}
-            <Link href="/docs/server/cli#understanding-console-output" className="text-deja-cyan hover:underline">Console Output reference</Link>.
+            <DocLink href="/docs/server/cli#understanding-console-output">Console Output reference</DocLink>.
           </p>
         </div>
       </section>
@@ -412,7 +366,7 @@ export default function ServerGuide() {
         </div>
         <p className="text-xs text-gray-500 mt-4">
           For the full CLI reference with all options and flags, see the{' '}
-          <Link href="/docs/server/cli" className="text-deja-lime hover:underline">CLI Reference docs</Link>.
+          <DocLink href="/docs/server/cli">CLI Reference</DocLink>.
         </p>
       </section>
 
@@ -461,7 +415,7 @@ export default function ServerGuide() {
         </div>
         <p className="text-xs text-gray-500 mt-4">
           Still stuck? Check the{' '}
-          <Link href="/docs/server/troubleshooting" className="text-deja-lime hover:underline">full troubleshooting guide</Link>{' '}
+          <DocLink href="/docs/server/troubleshooting">Troubleshooting</DocLink>{' '}
           or reach out on{' '}
           <a href="https://discord.gg/dejajs" target="_blank" rel="noopener noreferrer" className="text-deja-lime hover:underline">Discord</a>.
         </p>

--- a/apps/dejajs-www/components/guides/ServerGuide.tsx
+++ b/apps/dejajs-www/components/guides/ServerGuide.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import { mdiUsb } from '@mdi/js';
-import { Callout, CommandBlock, Step, MdiIcon } from './shared';
+import { Callout, CommandBlock, Step, MdiIcon, BeforeYouStart } from './shared';
 import DocLink from '../DocLink';
 
 function TerminalOutput({ children }: { children: React.ReactNode }) {
@@ -50,28 +50,15 @@ export default function ServerGuide() {
       </div>
 
       {/* Prerequisites */}
-      <section className="mb-12 p-5 rounded-xl border border-gray-800 bg-gray-900/50">
-        <h2 className="text-white font-semibold mb-3">Before You Start</h2>
-        <p className="text-sm text-gray-300 mb-4">
-          This guide assumes you&apos;ve already{' '}
-          <a href="https://cloud.dejajs.com" target="_blank" rel="noopener noreferrer" className="text-deja-cyan hover:underline">signed up</a>
-          {' '}and completed the onboarding steps, which includes installing the server. If you haven&apos;t
-          done that yet, head to the{' '}
-          <Link href="/guides/getting-started" className="text-deja-cyan hover:underline">Getting Started guide</Link>
-          {' '}first — it only takes a few minutes.
-        </p>
-        <div className="flex items-start gap-3 p-3 rounded-lg bg-gray-900 border border-gray-800">
+      <BeforeYouStart>
+        <div className="flex items-start gap-3 p-3 mt-4 rounded-lg bg-gray-900 border border-gray-800 text-left">
           <MdiIcon path={mdiUsb} className="w-5 h-5 shrink-0 text-amber-400 mt-0.5" />
           <p className="text-sm text-gray-300">
             Make sure your <strong className="text-white">DCC-EX CommandStation is connected via USB</strong> to
-            the computer running the server. That&apos;s all you need.
+            the computer running the server.
           </p>
         </div>
-        <p className="text-xs text-gray-500 mt-3">
-          For platform compatibility and system requirements, see the{' '}
-          <DocLink href="/docs/server/installation">Installation</DocLink>.
-        </p>
-      </section>
+      </BeforeYouStart>
 
       {/* Steps */}
       <div className="space-y-12">

--- a/apps/dejajs-www/components/guides/ThrottleGuide.tsx
+++ b/apps/dejajs-www/components/guides/ThrottleGuide.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import AnimateIn from '../home/AnimateIn';
@@ -8,29 +7,10 @@ import SectionLabel from '../home/SectionLabel';
 import Logo from '../Logo';
 import PhoneMockup from '../architecture/PhoneMockup';
 import DocLink from '../DocLink';
+import { FeatureGrid, FeatureSection, VideoPlaceholder, FeatureCarousel } from './shared';
+import type { CarouselSlide } from './shared';
 
 /* ── Shared sub-components ── */
-
-function FeatureCard({ emoji, text }: { emoji: string; text: string }) {
-  return (
-    <div className="flex items-start gap-3 p-3 rounded-lg border border-gray-800/60 bg-gray-900/40 hover:border-deja-cyan/20 hover:bg-gray-900/60 transition-all">
-      <span className="text-lg shrink-0 mt-0.5">{emoji}</span>
-      <span className="text-sm text-gray-300">{text}</span>
-    </div>
-  );
-}
-
-function FeatureGrid({ items }: { items: { emoji: string; text: string }[] }) {
-  return (
-    <div className="grid sm:grid-cols-2 gap-2">
-      {items.map((item, i) => (
-        <AnimateIn key={item.text} delay={i * 0.05}>
-          <FeatureCard emoji={item.emoji} text={item.text} />
-        </AnimateIn>
-      ))}
-    </div>
-  );
-}
 
 function CloudNote({ children }: { children: React.ReactNode }) {
   return (
@@ -40,21 +20,6 @@ function CloudNote({ children }: { children: React.ReactNode }) {
         <div className="text-sm text-gray-300 leading-relaxed">{children}</div>
       </div>
     </AnimateIn>
-  );
-}
-
-function VideoPlaceholder() {
-  return (
-    <div className="rounded-2xl border border-gray-800 bg-gray-900/50 overflow-hidden shadow-2xl">
-      <div className="aspect-video flex flex-col items-center justify-center gap-3 bg-gray-900/80">
-        <div className="w-16 h-16 rounded-full border-2 border-deja-cyan/30 bg-deja-cyan/10 flex items-center justify-center">
-          <svg className="w-6 h-6 text-deja-cyan ml-1" fill="currentColor" viewBox="0 0 24 24">
-            <path d="M8 5v14l11-7z" />
-          </svg>
-        </div>
-        <p className="text-gray-400 text-sm">Video walkthrough coming soon</p>
-      </div>
-    </div>
   );
 }
 
@@ -135,23 +100,7 @@ function AnnotatedScreenshot({
   );
 }
 
-/* ── Layout Features Carousel ── */
-
-interface CarouselSlide {
-  id: string;
-  emoji: string;
-  title: string;
-  tagline: string;
-  desc: string;
-  mobileScreenshot: string;
-  desktopScreenshot: string;
-  features: { emoji: string; text: string }[];
-  docHref: string;
-  docLabel: string;
-  accentColor: string;
-  accentBg: string;
-  accentBorder: string;
-}
+/* ── Layout Features Data ── */
 
 const layoutFeatures: CarouselSlide[] = [
   {
@@ -257,157 +206,6 @@ const layoutFeatures: CarouselSlide[] = [
     accentBorder: 'border-purple-400/40',
   },
 ];
-
-function LayoutFeaturesCarousel() {
-  const [activeIdx, setActiveIdx] = useState(0);
-  const active = layoutFeatures[activeIdx];
-
-  return (
-    <section className="py-20">
-      <div className="max-w-5xl mx-auto">
-        <AnimateIn>
-          <SectionLabel color="lime">Layout Control</SectionLabel>
-          <h2 className="text-3xl sm:text-4xl font-bold text-white mt-4 mb-3">Control Your Entire Layout</h2>
-          <p className="text-gray-400 leading-relaxed mb-10">
-            Beyond driving trains, Throttle gives you control over every aspect of your layout.
-            These features are configured in{' '}
-            <Link href="/guides/cloud" className="text-deja-cyan hover:underline">DEJA Cloud</Link>{' '}
-            and controlled here in real time.
-          </p>
-        </AnimateIn>
-
-        {/* Tab buttons — large and bright */}
-        <div className="grid grid-cols-2 sm:grid-cols-5 gap-3 mb-12">
-          {layoutFeatures.map((slide, i) => (
-            <button
-              key={slide.id}
-              onClick={() => setActiveIdx(i)}
-              className={`flex flex-col items-center gap-2 px-4 py-4 rounded-xl text-sm font-semibold transition-all cursor-pointer ${
-                i === activeIdx
-                  ? `${slide.accentBg} border-2 ${slide.accentBorder} ${slide.accentColor} shadow-lg`
-                  : 'border-2 border-gray-800/60 text-gray-500 hover:border-gray-600 hover:text-gray-300 hover:bg-gray-900/50'
-              }`}
-            >
-              <span className="text-2xl">{slide.emoji}</span>
-              <span>{slide.title}</span>
-            </button>
-          ))}
-        </div>
-
-        {/* Active slide */}
-        <div key={active.id}>
-          {/* Tagline */}
-          <div className="mb-8">
-            <h3 className={`text-3xl font-bold ${active.accentColor} mb-2`}>{active.title}</h3>
-            <p className="text-xl text-white font-semibold">{active.tagline}</p>
-            <p className="text-gray-400 leading-relaxed mt-3 max-w-2xl">{active.desc}</p>
-          </div>
-
-          {/* Screenshots + features side by side */}
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-start">
-            {/* Screenshots — desktop + phone PiP */}
-            <div className="relative">
-              <div className="rounded-2xl border-2 border-gray-700 bg-gray-900 p-2 shadow-2xl">
-                <div className="mx-auto w-8 h-1 bg-gray-800 rounded-full mb-1" />
-                <div className="rounded-xl overflow-hidden">
-                  <Image
-                    src={active.desktopScreenshot}
-                    alt={`${active.title} desktop view`}
-                    width={1200}
-                    height={675}
-                    className="w-full h-auto"
-                  />
-                </div>
-              </div>
-              {/* Phone PiP overlay */}
-              <div className="absolute -bottom-4 -right-2 sm:-right-6">
-                <PhoneMockup
-                  src={active.mobileScreenshot}
-                  alt={`${active.title} mobile view`}
-                  className="w-[100px] sm:w-[120px]"
-                />
-              </div>
-            </div>
-
-            {/* Features */}
-            <div>
-              <FeatureGrid items={active.features} />
-              <div className="mt-6 flex flex-wrap gap-3">
-                <DocLink href={active.docHref}>{active.docLabel}</DocLink>
-              </div>
-
-              {/* Placeholder for custom graphic */}
-              <div className={`mt-6 p-6 rounded-xl border-2 border-dashed ${active.accentBorder} ${active.accentBg} flex flex-col items-center gap-2`}>
-                <span className="text-4xl">{active.emoji}</span>
-                <p className={`text-sm font-medium ${active.accentColor}`}>Illustration coming soon</p>
-                <p className="text-xs text-gray-500 text-center">Custom graphic for {active.title.toLowerCase()}</p>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-  );
-}
-
-/* ── Two-column feature section ── */
-
-function FeatureSection({
-  title,
-  desc,
-  features,
-  screenshot,
-  screenshotAlt,
-  screenshotDevice = 'mobile',
-  flip = false,
-  cloudNote,
-  docLink,
-  docLabel,
-  children,
-}: {
-  title: string;
-  desc: string;
-  features: { emoji: string; text: string }[];
-  screenshot: string;
-  screenshotAlt: string;
-  screenshotDevice?: 'mobile' | 'desktop';
-  flip?: boolean;
-  cloudNote?: React.ReactNode;
-  docLink?: string;
-  docLabel?: string;
-  children?: React.ReactNode;
-}) {
-  return (
-    <section className="py-20">
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-16 items-center">
-        <AnimateIn direction={flip ? 'right' : 'left'} className={flip ? 'lg:order-2' : ''}>
-          <h2 className="text-3xl sm:text-4xl font-bold text-white mb-3">{title}</h2>
-          <p className="text-gray-400 leading-relaxed mb-6">{desc}</p>
-          <FeatureGrid items={features} />
-          {cloudNote && <div className="mt-4">{cloudNote}</div>}
-          {children}
-          {docLink && docLabel && (
-            <div className="mt-4">
-              <DocLink href={docLink}>{docLabel}</DocLink>
-            </div>
-          )}
-        </AnimateIn>
-        <AnimateIn direction={flip ? 'left' : 'right'} className={`flex justify-center ${flip ? 'lg:order-1' : ''}`}>
-          {screenshotDevice === 'mobile' ? (
-            <PhoneMockup src={screenshot} alt={screenshotAlt} className="w-[220px]" />
-          ) : (
-            <div className="rounded-2xl border-2 border-gray-700 bg-gray-900 p-2 shadow-2xl w-full max-w-lg">
-              <div className="mx-auto w-8 h-1 bg-gray-800 rounded-full mb-1" />
-              <div className="rounded-xl overflow-hidden">
-                <Image src={screenshot} alt={screenshotAlt} width={1200} height={675} className="w-full h-auto" />
-              </div>
-            </div>
-          )}
-        </AnimateIn>
-      </div>
-    </section>
-  );
-}
 
 /* ── Main guide ── */
 
@@ -517,6 +315,9 @@ export default function ThrottleGuide() {
         ]}
         screenshot="/screenshots/throttle_mobile_home.png"
         screenshotAlt="Throttle home screen"
+        renderScreenshot={() => (
+          <PhoneMockup src="/screenshots/throttle_mobile_home.png" alt="Throttle home screen" className="w-[220px]" />
+        )}
         docLink="/docs/throttle/connect"
         docLabel="Connection setup reference"
       />
@@ -534,6 +335,9 @@ export default function ThrottleGuide() {
           ]}
           screenshot="/screenshots/throttle_mobile_home.png"
           screenshotAlt="Add locomotive"
+          renderScreenshot={() => (
+            <PhoneMockup src="/screenshots/throttle_mobile_home.png" alt="Add locomotive" className="w-[220px]" />
+          )}
           flip
           cloudNote={
             <CloudNote>
@@ -559,6 +363,9 @@ export default function ThrottleGuide() {
         ]}
         screenshot="/screenshots/throttle_mobile_home.png"
         screenshotAlt="Throttle list with locomotives"
+        renderScreenshot={() => (
+          <PhoneMockup src="/screenshots/throttle_mobile_home.png" alt="Throttle list with locomotives" className="w-[220px]" />
+        )}
         docLink="/docs/throttle/throttle-list"
         docLabel="Throttle list reference"
       />
@@ -578,6 +385,9 @@ export default function ThrottleGuide() {
           ]}
           screenshot="/screenshots/throttle_mobile_throttle.png"
           screenshotAlt="Throttle control screen"
+          renderScreenshot={() => (
+            <PhoneMockup src="/screenshots/throttle_mobile_throttle.png" alt="Throttle control screen" className="w-[220px]" />
+          )}
           flip
           docLink="/docs/throttle/throttle"
           docLabel="Throttle control reference"
@@ -596,6 +406,9 @@ export default function ThrottleGuide() {
         ]}
         screenshot="/screenshots/throttle_mobile_functions.png"
         screenshotAlt="Function speed dial expanded"
+        renderScreenshot={() => (
+          <PhoneMockup src="/screenshots/throttle_mobile_functions.png" alt="Function speed dial expanded" className="w-[220px]" />
+        )}
         cloudNote={
           <CloudNote>
             Function labels, icons, and visibility are configured per locomotive in{' '}
@@ -642,7 +455,46 @@ export default function ThrottleGuide() {
       </div>
 
       {/* ── Layout Features Carousel ── */}
-      <LayoutFeaturesCarousel />
+      <FeatureCarousel
+        slides={layoutFeatures}
+        sectionLabel="Layout Control"
+        sectionColor="lime"
+        title="Control Your Entire Layout"
+        description={
+          <>
+            Beyond driving trains, Throttle gives you control over every aspect of your layout.
+            These features are configured in{' '}
+            <Link href="/guides/cloud" className="text-deja-cyan hover:underline">DEJA Cloud</Link>{' '}
+            and controlled here in real time.
+          </>
+        }
+        tabColumns="sm:grid-cols-5"
+        renderScreenshot={(slide) => (
+          <div className="relative">
+            <div className="rounded-2xl border-2 border-gray-700 bg-gray-900 p-2 shadow-2xl">
+              <div className="mx-auto w-8 h-1 bg-gray-800 rounded-full mb-1" />
+              <div className="rounded-xl overflow-hidden">
+                <Image
+                  src={slide.desktopScreenshot}
+                  alt={`${slide.title} desktop view`}
+                  width={1200}
+                  height={675}
+                  className="w-full h-auto"
+                />
+              </div>
+            </div>
+            {slide.mobileScreenshot && (
+              <div className="absolute -bottom-4 -right-2 sm:-right-6">
+                <PhoneMockup
+                  src={slide.mobileScreenshot}
+                  alt={`${slide.title} mobile view`}
+                  className="w-[100px] sm:w-[120px]"
+                />
+              </div>
+            )}
+          </div>
+        )}
+      />
 
       {/* ── Settings ── */}
       <section className="py-20">

--- a/apps/dejajs-www/components/guides/ThrottleGuide.tsx
+++ b/apps/dejajs-www/components/guides/ThrottleGuide.tsx
@@ -7,7 +7,7 @@ import SectionLabel from '../home/SectionLabel';
 import Logo from '../Logo';
 import PhoneMockup from '../architecture/PhoneMockup';
 import DocLink from '../DocLink';
-import { FeatureGrid, FeatureSection, VideoPlaceholder, FeatureCarousel } from './shared';
+import { FeatureGrid, FeatureSection, VideoPlaceholder, FeatureCarousel, BeforeYouStart } from './shared';
 import type { CarouselSlide } from './shared';
 
 /* ── Shared sub-components ── */
@@ -240,15 +240,7 @@ export default function ThrottleGuide() {
       </section>
 
       {/* ── Prerequisites ── */}
-      <AnimateIn>
-        <div className="max-w-2xl mx-auto mb-8 p-5 rounded-xl border border-gray-800 bg-gray-900/50 text-center">
-          <p className="text-gray-300 text-sm leading-relaxed">
-            Make sure you&apos;ve completed the{' '}
-            <Link href="/guides/getting-started" className="text-deja-cyan hover:underline">Getting Started</Link>{' '}
-            guide — your server should be running and your command station connected.
-          </p>
-        </div>
-      </AnimateIn>
+      <BeforeYouStart />
 
       {/* ── Navigating the App ── */}
       <section className="bg-gray-900/50 border-y border-gray-800/50 py-20 -mx-6 px-6">

--- a/apps/dejajs-www/components/guides/shared/BeforeYouStart.tsx
+++ b/apps/dejajs-www/components/guides/shared/BeforeYouStart.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import Link from 'next/link';
+import AnimateIn from '../../home/AnimateIn';
+
+export default function BeforeYouStart({ children }: { children?: React.ReactNode }) {
+  return (
+    <AnimateIn>
+      <div className="max-w-2xl mx-auto mb-8 p-5 rounded-xl border border-gray-800 bg-gray-900/50 text-center">
+        <p className="text-gray-300 text-sm leading-relaxed">
+          Make sure you&apos;ve completed the{' '}
+          <Link href="/guides/getting-started" className="text-deja-cyan hover:underline">Getting Started</Link>{' '}
+          guide — your server should be running and your command station connected.
+        </p>
+        {children}
+      </div>
+    </AnimateIn>
+  );
+}

--- a/apps/dejajs-www/components/guides/shared/Callout.tsx
+++ b/apps/dejajs-www/components/guides/shared/Callout.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+const colorMap = {
+  lime: { bg: 'bg-deja-lime/5', border: 'border-deja-lime/20' },
+  cyan: { bg: 'bg-deja-cyan/5', border: 'border-deja-cyan/20' },
+};
+
+export default function Callout({
+  emoji,
+  children,
+  color = 'lime',
+}: {
+  emoji: string;
+  children: React.ReactNode;
+  color?: 'lime' | 'cyan';
+}) {
+  const { bg, border } = colorMap[color];
+  return (
+    <div className={`flex gap-3 p-4 rounded-lg ${bg} ${border} my-4`}>
+      <span className="text-lg shrink-0">{emoji}</span>
+      <div className="text-sm text-gray-300 leading-relaxed">{children}</div>
+    </div>
+  );
+}

--- a/apps/dejajs-www/components/guides/shared/CommandBlock.tsx
+++ b/apps/dejajs-www/components/guides/shared/CommandBlock.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import CopyButton from '../../home/CopyButton';
+
+export default function CommandBlock({ command }: { command: string }) {
+  return (
+    <div className="rounded-lg border border-gray-700 bg-gray-950 overflow-hidden my-4">
+      <div className="flex items-center gap-1.5 px-3 py-2 border-b border-gray-800 bg-gray-900">
+        <span className="w-2.5 h-2.5 rounded-full bg-red-500/70" />
+        <span className="w-2.5 h-2.5 rounded-full bg-yellow-500/70" />
+        <span className="w-2.5 h-2.5 rounded-full bg-green-500/70" />
+        <span className="ml-2 text-gray-500 text-xs font-mono">bash</span>
+      </div>
+      <div className="flex items-center gap-2 px-4 py-3">
+        <span className="text-deja-lime/60 font-mono text-sm select-none shrink-0">$</span>
+        <span className="font-mono text-sm text-deja-lime flex-1 break-all">{command}</span>
+        <CopyButton text={command} />
+      </div>
+    </div>
+  );
+}

--- a/apps/dejajs-www/components/guides/shared/FeatureCard.tsx
+++ b/apps/dejajs-www/components/guides/shared/FeatureCard.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function FeatureCard({ emoji, text }: { emoji: string; text: string }) {
+  return (
+    <div className="flex items-start gap-3 p-3 rounded-lg border border-gray-800/60 bg-gray-900/40 hover:border-deja-cyan/20 hover:bg-gray-900/60 transition-all">
+      <span className="text-lg shrink-0 mt-0.5">{emoji}</span>
+      <span className="text-sm text-gray-300">{text}</span>
+    </div>
+  );
+}

--- a/apps/dejajs-www/components/guides/shared/FeatureCarousel.tsx
+++ b/apps/dejajs-www/components/guides/shared/FeatureCarousel.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import React, { useState } from 'react';
+import Image from 'next/image';
+import AnimateIn from '../../home/AnimateIn';
+import SectionLabel from '../../home/SectionLabel';
+import DocLink from '../../DocLink';
+import FeatureGrid from './FeatureGrid';
+
+export interface CarouselSlide {
+  id: string;
+  emoji: string;
+  title: string;
+  tagline: string;
+  desc: string;
+  desktopScreenshot: string;
+  mobileScreenshot?: string;
+  features: { emoji: string; text: string }[];
+  docHref: string;
+  docLabel: string;
+  accentColor: string;
+  accentBg: string;
+  accentBorder: string;
+}
+
+export default function FeatureCarousel({
+  slides,
+  sectionLabel,
+  sectionColor = 'lime',
+  title,
+  description,
+  tabColumns = 'sm:grid-cols-4',
+  renderScreenshot,
+}: {
+  slides: CarouselSlide[];
+  sectionLabel: string;
+  sectionColor?: 'cyan' | 'magenta' | 'lime';
+  title: string;
+  description: React.ReactNode;
+  tabColumns?: string;
+  renderScreenshot?: (slide: CarouselSlide) => React.ReactNode;
+}) {
+  const [activeIdx, setActiveIdx] = useState(0);
+  const active = slides[activeIdx];
+
+  const defaultScreenshot = (slide: CarouselSlide) => (
+    <div className="rounded-2xl overflow-hidden shadow-2xl">
+      <Image
+        src={slide.desktopScreenshot}
+        alt={`${slide.title} desktop view`}
+        width={1200}
+        height={675}
+        className="w-full h-auto"
+      />
+    </div>
+  );
+
+  const screenshotRenderer = renderScreenshot ?? defaultScreenshot;
+
+  return (
+    <section className="py-20">
+      <div className="max-w-5xl mx-auto">
+        <AnimateIn>
+          <SectionLabel color={sectionColor}>{sectionLabel}</SectionLabel>
+          <h2 className="text-3xl sm:text-4xl font-bold text-white mt-4 mb-3">{title}</h2>
+          <div className="text-gray-400 leading-relaxed mb-10">{description}</div>
+        </AnimateIn>
+
+        {/* Tab buttons */}
+        <div className={`grid grid-cols-2 ${tabColumns} gap-3 mb-12`}>
+          {slides.map((slide, i) => (
+            <button
+              key={slide.id}
+              onClick={() => setActiveIdx(i)}
+              className={`flex flex-col items-center gap-2 px-4 py-4 rounded-xl text-sm font-semibold transition-all cursor-pointer ${
+                i === activeIdx
+                  ? `${slide.accentBg} border-2 ${slide.accentBorder} ${slide.accentColor} shadow-lg`
+                  : 'border-2 border-gray-800/60 text-gray-500 hover:border-gray-600 hover:text-gray-300 hover:bg-gray-900/50'
+              }`}
+            >
+              <span className="text-2xl">{slide.emoji}</span>
+              <span>{slide.title}</span>
+            </button>
+          ))}
+        </div>
+
+        {/* Active slide */}
+        <div key={active.id}>
+          <div className="mb-8">
+            <h3 className={`text-3xl font-bold ${active.accentColor} mb-2`}>{active.title}</h3>
+            <p className="text-xl text-white font-semibold">{active.tagline}</p>
+            <p className="text-gray-400 leading-relaxed mt-3 max-w-2xl">{active.desc}</p>
+          </div>
+
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-start">
+            {screenshotRenderer(active)}
+
+            <div>
+              <FeatureGrid items={active.features} />
+              <div className="mt-6 flex flex-wrap gap-3">
+                <DocLink href={active.docHref}>{active.docLabel}</DocLink>
+              </div>
+
+              <div className={`mt-6 p-6 rounded-xl border-2 border-dashed ${active.accentBorder} ${active.accentBg} flex flex-col items-center gap-2`}>
+                <span className="text-4xl">{active.emoji}</span>
+                <p className={`text-sm font-medium ${active.accentColor}`}>Illustration coming soon</p>
+                <p className="text-xs text-gray-500 text-center">Custom graphic for {active.title.toLowerCase()}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/dejajs-www/components/guides/shared/FeatureCarousel.tsx
+++ b/apps/dejajs-www/components/guides/shared/FeatureCarousel.tsx
@@ -23,6 +23,20 @@ export interface CarouselSlide {
   accentBorder: string;
 }
 
+function defaultScreenshot(slide: CarouselSlide) {
+  return (
+    <div className="rounded-2xl overflow-hidden shadow-2xl">
+      <Image
+        src={slide.desktopScreenshot}
+        alt={`${slide.title} desktop view`}
+        width={1200}
+        height={675}
+        className="w-full h-auto"
+      />
+    </div>
+  );
+}
+
 export default function FeatureCarousel({
   slides,
   sectionLabel,
@@ -42,19 +56,6 @@ export default function FeatureCarousel({
 }) {
   const [activeIdx, setActiveIdx] = useState(0);
   const active = slides[activeIdx];
-
-  const defaultScreenshot = (slide: CarouselSlide) => (
-    <div className="rounded-2xl overflow-hidden shadow-2xl">
-      <Image
-        src={slide.desktopScreenshot}
-        alt={`${slide.title} desktop view`}
-        width={1200}
-        height={675}
-        className="w-full h-auto"
-      />
-    </div>
-  );
-
   const screenshotRenderer = renderScreenshot ?? defaultScreenshot;
 
   return (

--- a/apps/dejajs-www/components/guides/shared/FeatureGrid.tsx
+++ b/apps/dejajs-www/components/guides/shared/FeatureGrid.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import AnimateIn from '../../home/AnimateIn';
+import FeatureCard from './FeatureCard';
+
+export default function FeatureGrid({ items }: { items: { emoji: string; text: string }[] }) {
+  return (
+    <div className="grid sm:grid-cols-2 gap-2">
+      {items.map((item, i) => (
+        <AnimateIn key={item.text} delay={i * 0.05}>
+          <FeatureCard emoji={item.emoji} text={item.text} />
+        </AnimateIn>
+      ))}
+    </div>
+  );
+}

--- a/apps/dejajs-www/components/guides/shared/FeatureSection.tsx
+++ b/apps/dejajs-www/components/guides/shared/FeatureSection.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import Image from 'next/image';
+import AnimateIn from '../../home/AnimateIn';
+import DocLink from '../../DocLink';
+import FeatureGrid from './FeatureGrid';
+
+export default function FeatureSection({
+  title,
+  desc,
+  features,
+  screenshot,
+  screenshotAlt,
+  screenshotDevice = 'desktop',
+  flip = false,
+  cloudNote,
+  docLink,
+  docLabel,
+  children,
+  renderScreenshot,
+}: {
+  title: string;
+  desc: string;
+  features: { emoji: string; text: string }[];
+  screenshot: string;
+  screenshotAlt: string;
+  screenshotDevice?: 'mobile' | 'desktop';
+  flip?: boolean;
+  cloudNote?: React.ReactNode;
+  docLink?: string;
+  docLabel?: string;
+  children?: React.ReactNode;
+  renderScreenshot?: () => React.ReactNode;
+}) {
+  const screenshotContent = renderScreenshot ? (
+    renderScreenshot()
+  ) : screenshotDevice === 'mobile' ? (
+    <div className="flex justify-center">
+      <div className="rounded-2xl overflow-hidden shadow-2xl w-full max-w-lg">
+        <Image src={screenshot} alt={screenshotAlt} width={400} height={800} className="w-full h-auto" />
+      </div>
+    </div>
+  ) : (
+    <div className="rounded-2xl overflow-hidden shadow-2xl w-full max-w-lg">
+      <Image src={screenshot} alt={screenshotAlt} width={1200} height={675} className="w-full h-auto" />
+    </div>
+  );
+
+  return (
+    <section className="py-20">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-16 items-center">
+        <AnimateIn direction={flip ? 'right' : 'left'} className={flip ? 'lg:order-2' : ''}>
+          <h2 className="text-3xl sm:text-4xl font-bold text-white mb-3">{title}</h2>
+          <p className="text-gray-400 leading-relaxed mb-6">{desc}</p>
+          <FeatureGrid items={features} />
+          {cloudNote && <div className="mt-4">{cloudNote}</div>}
+          {children}
+          {docLink && docLabel && (
+            <div className="mt-4">
+              <DocLink href={docLink}>{docLabel}</DocLink>
+            </div>
+          )}
+        </AnimateIn>
+        <AnimateIn direction={flip ? 'left' : 'right'} className={`flex justify-center ${flip ? 'lg:order-1' : ''}`}>
+          {screenshotContent}
+        </AnimateIn>
+      </div>
+    </section>
+  );
+}

--- a/apps/dejajs-www/components/guides/shared/MdiIcon.tsx
+++ b/apps/dejajs-www/components/guides/shared/MdiIcon.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function MdiIcon({ path, className = '' }: { path: string; className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" className={className}>
+      <path d={path} fill="currentColor" />
+    </svg>
+  );
+}

--- a/apps/dejajs-www/components/guides/shared/Step.tsx
+++ b/apps/dejajs-www/components/guides/shared/Step.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+const colorMap = {
+  lime: { border: 'border-deja-lime/30', bg: 'bg-deja-lime/10', text: 'text-deja-lime' },
+  cyan: { border: 'border-deja-cyan/30', bg: 'bg-deja-cyan/10', text: 'text-deja-cyan' },
+};
+
+export default function Step({
+  number,
+  title,
+  children,
+  color = 'lime',
+}: {
+  number: number;
+  title: string;
+  children: React.ReactNode;
+  color?: 'lime' | 'cyan';
+}) {
+  const { border, bg, text } = colorMap[color];
+  return (
+    <div className="relative pl-14">
+      <div className={`absolute left-0 top-0 w-10 h-10 rounded-full border ${border} ${bg} flex items-center justify-center shrink-0`}>
+        <span className={`${text} font-bold text-sm font-mono`}>0{number}</span>
+      </div>
+      <h3 className="text-white font-bold text-xl mb-3">{title}</h3>
+      <div className="text-gray-300 leading-relaxed space-y-3">{children}</div>
+    </div>
+  );
+}

--- a/apps/dejajs-www/components/guides/shared/Step.tsx
+++ b/apps/dejajs-www/components/guides/shared/Step.tsx
@@ -20,7 +20,7 @@ export default function Step({
   return (
     <div className="relative pl-14">
       <div className={`absolute left-0 top-0 w-10 h-10 rounded-full border ${border} ${bg} flex items-center justify-center shrink-0`}>
-        <span className={`${text} font-bold text-sm font-mono`}>0{number}</span>
+        <span className={`${text} font-bold text-sm font-mono`}>{String(number).padStart(2, '0')}</span>
       </div>
       <h3 className="text-white font-bold text-xl mb-3">{title}</h3>
       <div className="text-gray-300 leading-relaxed space-y-3">{children}</div>

--- a/apps/dejajs-www/components/guides/shared/VideoPlaceholder.tsx
+++ b/apps/dejajs-www/components/guides/shared/VideoPlaceholder.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export default function VideoPlaceholder() {
+  return (
+    <div className="rounded-2xl border border-gray-800 bg-gray-900/50 overflow-hidden shadow-2xl">
+      <div className="aspect-video flex flex-col items-center justify-center gap-3 bg-gray-900/80">
+        <div className="w-16 h-16 rounded-full border-2 border-deja-cyan/30 bg-deja-cyan/10 flex items-center justify-center">
+          <svg className="w-6 h-6 text-deja-cyan ml-1" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M8 5v14l11-7z" />
+          </svg>
+        </div>
+        <p className="text-gray-400 text-sm">Video walkthrough coming soon</p>
+      </div>
+    </div>
+  );
+}

--- a/apps/dejajs-www/components/guides/shared/index.ts
+++ b/apps/dejajs-www/components/guides/shared/index.ts
@@ -7,4 +7,5 @@ export { default as CommandBlock } from './CommandBlock';
 export { default as Step } from './Step';
 export { default as MdiIcon } from './MdiIcon';
 export { default as FeatureCarousel } from './FeatureCarousel';
+export { default as BeforeYouStart } from './BeforeYouStart';
 export type { CarouselSlide } from './FeatureCarousel';

--- a/apps/dejajs-www/components/guides/shared/index.ts
+++ b/apps/dejajs-www/components/guides/shared/index.ts
@@ -1,0 +1,10 @@
+export { default as FeatureCard } from './FeatureCard';
+export { default as FeatureGrid } from './FeatureGrid';
+export { default as FeatureSection } from './FeatureSection';
+export { default as VideoPlaceholder } from './VideoPlaceholder';
+export { default as Callout } from './Callout';
+export { default as CommandBlock } from './CommandBlock';
+export { default as Step } from './Step';
+export { default as MdiIcon } from './MdiIcon';
+export { default as FeatureCarousel } from './FeatureCarousel';
+export type { CarouselSlide } from './FeatureCarousel';

--- a/apps/dejajs-www/components/home/AnimateIn.tsx
+++ b/apps/dejajs-www/components/home/AnimateIn.tsx
@@ -17,7 +17,7 @@ export default function AnimateIn({
   direction = 'up',
 }: AnimateInProps) {
   const ref = useRef(null);
-  const isInView = useInView(ref, { once: true, margin: '-80px' });
+  const isInView = useInView(ref, { once: true, margin: '0px 0px -40px 0px' });
 
   const variants = {
     hidden: {

--- a/apps/dejajs-www/components/home/GuidesGrid.tsx
+++ b/apps/dejajs-www/components/home/GuidesGrid.tsx
@@ -49,9 +49,8 @@ const guides = [
     href: '/guides/io',
     desc: 'Hardware expansion with Arduino and Pico W — LEDs, servos, signals, sensors, and MQTT.',
     icon: '🔌',
-    comingSoon: true,
-    color: 'border-gray-700/30',
-    iconBg: 'bg-gray-800',
+    color: 'border-fuchsia-400/30 hover:border-fuchsia-400/60',
+    iconBg: 'bg-fuchsia-400/10',
   },
   {
     label: 'Monitor',

--- a/apps/dejajs-www/components/home/GuidesGrid.tsx
+++ b/apps/dejajs-www/components/home/GuidesGrid.tsx
@@ -32,9 +32,8 @@ const guides = [
     href: '/guides/server',
     desc: 'Installation, CLI reference, configuration, and running the DEJA Server on any platform.',
     icon: '💻',
-    comingSoon: true,
-    color: 'border-gray-700/30',
-    iconBg: 'bg-gray-800',
+    color: 'border-deja-lime/30 hover:border-deja-lime/60',
+    iconBg: 'bg-deja-lime/10',
   },
   {
     label: 'Cloud',

--- a/docs/io/arduino-setup.mdx
+++ b/docs/io/arduino-setup.mdx
@@ -1,0 +1,99 @@
+---
+title: Arduino Setup
+description: Flash DEJA IO firmware to an Arduino board and connect it to your server via USB.
+section: io
+order: 11
+---
+
+# Arduino Setup
+
+Connect a standard Arduino board to your DEJA Server via USB to control turnouts, signals, LEDs, relays, and sensors.
+
+## Hardware Requirements
+
+- **Arduino Uno, Mega, or Nano** (any ATmega-based board)
+- **USB cable** (Type-A to Type-B for Uno/Mega, Mini-USB for Nano)
+- **Adafruit PCA9685 16-Channel PWM Servo Driver** (optional, for servo-driven turnouts)
+- **Jumper wires** for connecting outputs and sensors
+
+### Wiring the PCA9685
+
+If using servo-driven turnouts, connect the PCA9685 to your Arduino via I2C:
+
+| PCA9685 Pin | Arduino Pin |
+|---|---|
+| VCC | 5V |
+| GND | GND |
+| SDA | A4 (Uno) / 20 (Mega) |
+| SCL | A5 (Uno) / 21 (Mega) |
+
+Power the servo rail separately with a 5–6V power supply — do not power servos from the Arduino's 5V pin.
+
+## Firmware Configuration
+
+Open `io/src/deja-arduino/config.h` (copy from `config.default.h` if it doesn't exist) and set your device identity and feature flags:
+
+```cpp
+// Device identity
+#define DEVICE_ID "my-arduino-device"
+
+// Feature toggles — enable what your hardware supports
+#define ENABLE_PWM true        // PCA9685 servo driver
+#define ENABLE_OUTPUTS true    // Digital output pins
+#define ENABLE_SIGNALS true    // Signal head outputs
+#define ENABLE_SENSORS true    // Sensor input pins
+#define ENABLE_TURNOUTS true   // Servo-driven turnouts
+
+// Pin assignments
+int OUTPINS[] = {8, 9, 10, 11};           // GPIO pins for digital outputs
+int SIGNALPINS[] = {4, 5, 6, 7};          // GPIO pins for signal heads
+int SENSORPINS[] = {A0, A1, A2};          // GPIO pins for sensors
+```
+
+### Turnout Configuration
+
+Turnouts are defined as `TurnoutPulser` objects with a servo channel, thrown angle, and closed angle:
+
+```cpp
+TurnoutPulser turnouts[] = {
+  TurnoutPulser(0, 45, 135),   // Servo channel 0: 45° closed, 135° thrown
+  TurnoutPulser(1, 50, 130),   // Servo channel 1: 50° closed, 130° thrown
+};
+```
+
+## Flashing the Firmware
+
+1. Open `io/src/deja-arduino/deja-arduino.ino` in the Arduino IDE
+2. Select your board type under **Tools → Board**
+3. Select the correct serial port under **Tools → Port**
+4. Click **Upload**
+
+Or use the DEJA deploy script:
+
+```bash
+cd io
+pnpm deploy
+```
+
+The deploy script auto-detects connected boards and can generate `config.h` from your Cloud device configuration.
+
+## Connecting to the Server
+
+1. Plug the Arduino into the server machine via USB
+2. In the [Cloud app](https://cloud.dejajs.com), register a device with type **deja-arduino** and your `DEVICE_ID`
+3. The DEJA Server auto-detects the serial port and connects at 115200 baud
+4. Open the [Monitor app](https://monitor.dejajs.com) to verify the device appears and responds to commands
+
+## Command Format
+
+Arduino devices receive JSON arrays over serial:
+
+```json
+[
+  { "action": "pin", "payload": { "pin": 8, "state": 1 } },
+  { "action": "servo", "payload": { "servo": 0, "value": 90, "current": 45 } },
+  { "action": "turnout", "payload": { "turnout": 0, "state": true } }
+]
+```
+
+See the [Command Reference](/docs/io/command-reference) for all supported actions.

--- a/docs/io/command-reference.mdx
+++ b/docs/io/command-reference.mdx
@@ -1,0 +1,119 @@
+---
+title: Command Reference
+description: Complete JSON command specification for all DEJA IO device actions.
+section: io
+order: 13
+---
+
+# Command Reference
+
+All DEJA IO devices receive JSON commands with an `action` and `payload`. The format differs slightly between Arduino (Serial) and Pico W (MQTT).
+
+## Actions
+
+### `pin` — Digital Output
+
+Toggle a digital GPIO pin on or off.
+
+```json
+{
+  "action": "pin",
+  "payload": { "pin": 8, "state": 1 }
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `pin` | number | GPIO pin number (must match device config) |
+| `state` | number | `1` = on (HIGH), `0` = off (LOW) |
+
+### `servo` — Servo Position
+
+Set a PCA9685 servo channel to a specific angle.
+
+```json
+{
+  "action": "servo",
+  "payload": { "servo": 0, "value": 90, "current": 45 }
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `servo` | number | PCA9685 channel (0–15) |
+| `value` | number | Target angle in degrees |
+| `current` | number | Current angle (Arduino only — used for smooth transition) |
+
+### `turnout` — Turnout Control
+
+Throw or close a configured turnout.
+
+```json
+{
+  "action": "turnout",
+  "payload": { "turnout": 0, "state": true }
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `turnout` | number | Turnout index (matches device config array position) |
+| `state` | boolean | `true` = thrown, `false` = closed |
+
+### `ialed` — Addressable LED Strip (Planned)
+
+Control individually addressable LED strips.
+
+```json
+{
+  "action": "ialed",
+  "payload": { "strip": 0, "pattern": 0, "r": 255, "g": 0, "b": 0 }
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `strip` | number | LED strip index |
+| `pattern` | number | Animation pattern ID |
+| `r`, `g`, `b` | number | RGB color values (0–255) |
+
+> This action is defined in the Arduino firmware but not yet fully implemented.
+
+## Format Differences
+
+### Arduino (Serial USB)
+
+Commands are sent as a **JSON array** over serial at 115200 baud:
+
+```json
+[
+  { "action": "pin", "payload": { "pin": 8, "state": 1 } },
+  { "action": "servo", "payload": { "servo": 0, "value": 90, "current": 45 } }
+]
+```
+
+Multiple commands can be batched in a single array.
+
+### Pico W (MQTT)
+
+Commands are sent as a **single JSON object** with a `device` field for filtering:
+
+```json
+{
+  "action": "pin",
+  "payload": { "pin": 8, "state": 1 },
+  "device": "my-pico-device"
+}
+```
+
+The `device` field is required — the Pico W ignores messages that don't match its `DEVICE_ID`.
+
+## Sensor Responses
+
+Arduino devices send sensor state changes back over serial:
+
+```json
+{ "sensor": 0, "state": 1 }
+```
+
+Sensor data is debounced (500ms minimum between state changes) and automatically routed to the DEJA Server for processing.

--- a/docs/io/configuration.mdx
+++ b/docs/io/configuration.mdx
@@ -1,0 +1,88 @@
+---
+title: Configuration Reference
+description: All configuration file formats for DEJA IO devices — Arduino config.h, Pico W settings.toml, and config.json.
+section: io
+order: 14
+---
+
+# Configuration Reference
+
+DEJA IO devices use different configuration formats depending on the platform. This reference covers all of them.
+
+## Arduino — `config.h`
+
+Compile-time configuration. The Arduino firmware reads these values at build time.
+
+### Feature Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `DEVICE_ID` | string | `"deja-arduino"` | Unique device identifier — must match your Cloud device entry |
+| `ENABLE_PWM` | bool | `true` | Enable PCA9685 servo driver support |
+| `ENABLE_OUTPUTS` | bool | `true` | Enable digital GPIO outputs |
+| `ENABLE_SIGNALS` | bool | `true` | Enable signal head control |
+| `ENABLE_SENSORS` | bool | `true` | Enable sensor input reading |
+| `ENABLE_TURNOUTS` | bool | `true` | Enable servo-driven turnouts |
+
+### Pin Arrays
+
+```cpp
+int OUTPINS[] = {8, 9, 10, 11};       // Digital output GPIO pins
+int SIGNALPINS[] = {4, 5, 6, 7};      // Signal head GPIO pins
+int SENSORPINS[] = {A0, A1, A2};      // Sensor input pins (analog or digital)
+```
+
+### Turnout Definitions
+
+```cpp
+TurnoutPulser turnouts[] = {
+  TurnoutPulser(channel, closedAngle, thrownAngle),
+};
+```
+
+- `channel` — PCA9685 servo channel (0–15)
+- `closedAngle` — servo angle for closed position (degrees)
+- `thrownAngle` — servo angle for thrown position (degrees)
+
+## Pico W — `settings.toml`
+
+Runtime environment configuration. Loaded by CircuitPython at boot.
+
+| Variable | Required | Description |
+|---|---|---|
+| `CIRCUITPY_WIFI_SSID` | ✅ | WiFi network name |
+| `CIRCUITPY_WIFI_PASSWORD` | ✅ | WiFi password |
+| `MQTT_BROKER` | ✅ | MQTT broker IP address |
+| `LAYOUT_ID` | ✅ | Your layout ID in DEJA Cloud |
+| `DEVICE_ID` | ✅ | Unique device identifier |
+| `TOPIC_ID` | No | MQTT topic prefix (default: `"DEJA"`) |
+| `ENABLE_CONFIG` | No | Load pin mapping from config.json (default: `"true"`) |
+| `ENABLE_PWM` | No | Enable PCA9685 servo support (default: `"true"`) |
+| `ENABLE_MQTT` | No | Enable MQTT communication (default: `"true"`) |
+
+## Pico W — `config.json`
+
+Pin mapping from logical pin numbers to physical CircuitPython GPIO names.
+
+```json
+{
+  "pins": {
+    "6": "GP6",
+    "7": "GP7",
+    "8": "GP8",
+    "9": "GP9"
+  }
+}
+```
+
+Keys are the logical pin numbers used in commands (`"pin": 8`). Values are CircuitPython GPIO names (`"GP8"`).
+
+## Layout-Specific Overrides
+
+Per-layout configs live under:
+
+```
+io/layouts/{layoutId}/deja-pico-w/{deviceId}/config.json
+```
+
+When the deploy script runs, it uses the layout-specific config instead of the default `io/src/deja-pico-w/config.json`.

--- a/docs/io/deploy.mdx
+++ b/docs/io/deploy.mdx
@@ -1,0 +1,69 @@
+---
+title: Deploy to Devices
+description: Use the DEJA deploy script to push configuration and firmware to your IO devices.
+section: io
+order: 16
+---
+
+# Deploy to Devices
+
+The DEJA IO deploy script fetches your device configuration from Firebase and generates the correct config files for each device type. It can also flash firmware to connected boards.
+
+## Running the Deploy Script
+
+```bash
+cd io
+pnpm deploy
+```
+
+The interactive script walks you through:
+
+1. **Board detection** — scans for connected Arduino and Pico W devices
+2. **Device selection** — choose which registered device to deploy to
+3. **Config generation** — fetches device config, effects, and turnouts from Firebase
+4. **File generation** — creates platform-specific config files
+5. **Deployment** — uploads to the device
+
+## What Gets Deployed
+
+### Arduino
+
+The script generates `config.h` with:
+
+- `DEVICE_ID` from your Cloud device entry
+- Feature flags based on what's configured (effects → `ENABLE_OUTPUTS`, turnouts → `ENABLE_TURNOUTS`, etc.)
+- Pin arrays from your device's pin mapping
+- Turnout servo definitions from your configured turnouts
+
+Then compiles and uploads via the Arduino CLI.
+
+### Pico W
+
+The script generates:
+
+- `settings.toml` with WiFi credentials, MQTT broker address, layout ID, and device ID
+- `config.json` with the pin mapping from your device configuration
+
+Then copies all files to the mounted CIRCUITPY drive.
+
+## Firebase Configuration Source
+
+The deploy script reads from Firestore:
+
+| Collection | Data |
+|---|---|
+| `layouts/{layoutId}/devices/{deviceId}` | Device type, connection, pin mapping |
+| `layouts/{layoutId}/effects` | Effects assigned to this device |
+| `layouts/{layoutId}/turnouts` | Turnouts assigned to this device |
+
+Your device must be registered in the Cloud app before deploying.
+
+## Layout-Specific Configs
+
+For layouts with customized wiring, place override configs at:
+
+```
+io/layouts/{layoutId}/deja-pico-w/{deviceId}/config.json
+```
+
+The deploy script checks for layout-specific configs first, falling back to the device's Cloud configuration.

--- a/docs/io/overview.mdx
+++ b/docs/io/overview.mdx
@@ -9,6 +9,8 @@ order: 8
 
 IO devices extend your layout beyond what the DCC-EX CommandStation handles directly. They control effects like lighting, servo-driven turnouts, sensors, and animated elements — anything that isn't powered through the DCC track bus.
 
+DEJA IO supports three communication protocols — **Serial USB**, **MQTT over WiFi**, and **WebSocket** — so you can pick the one that fits your layout. See the [IO Guide](/guides/io) for the full platform overview.
+
 ## Supported Hardware
 
 ### Arduino (USB Serial)
@@ -20,7 +22,7 @@ Standard Arduino boards (Uno, Mega, Nano) connect to the DEJA Server via USB. Th
 - **Signal heads** — for model railroad signal aspects
 - **Sensors** — for detecting train presence (block detection, occupancy)
 
-Arduino devices communicate over serial at 115200 baud.
+Arduino devices communicate over serial at 115200 baud. See [Arduino Setup](/docs/io/arduino-setup) for full instructions.
 
 ### Raspberry Pi Pico W (WiFi / MQTT)
 
@@ -31,37 +33,20 @@ Pico W devices support:
 - **Digital pin control** — LEDs, relays, and other outputs
 - **PWM servo control** — via Adafruit ServoKit over I2C
 
+See [Pico W Setup](/docs/io/pico-w-setup) for full instructions.
+
 ## Setting Up a Device
 
 1. **Register the device** — In the [Cloud app](https://cloud.dejajs.com), go to your layout's **Devices** section and add a new device entry with a unique device ID.
-2. **Flash the firmware** — Upload the appropriate DEJA firmware to your board:
-   - Arduino: Open the sketch in Arduino IDE, set your `DEVICE_ID` and pin configuration, then upload.
-   - Pico W: Copy the CircuitPython firmware files to the device and configure WiFi and MQTT settings.
-3. **Connect** — Plug in the Arduino via USB, or power on the Pico W and it will connect to your WiFi network automatically.
-4. **Verify** — Open the [Monitor app](https://monitor.dejajs.com) to see your device appear in the device serial monitors.
+2. **Flash the firmware** — See [Arduino Setup](/docs/io/arduino-setup) or [Pico W Setup](/docs/io/pico-w-setup).
+3. **Deploy configuration** — Run the [deploy script](/docs/io/deploy) to push your Cloud configuration to the device.
+4. **Verify** — Open the [Monitor app](https://monitor.dejajs.com) to see your device appear and respond to commands.
 
-## Per-Layout Configuration
+## Reference
 
-Each device has a JSON configuration file that maps logical pin numbers to physical GPIO pins. These config files live per-layout and per-device, so you can customize the wiring for each installation.
-
-For example, a Pico W controlling Eagle Nest lighting might map pins like this:
-
-```json
-{
-  "pins": {
-    "6": "GP6",
-    "7": "GP7",
-    "8": "GP8",
-    "9": "GP9"
-  }
-}
-```
-
-## 🔧 Advanced: DIY & Custom Integration
-
-Want to build your own devices or integrate custom software with DEJA.js?
-
-- **[Building Custom Devices](/docs/io/custom-devices)** — 🛠️ Build MQTT devices from scratch using any microcontroller with WiFi
-- **[WebSocket Integration](/docs/io/websocket-integration)** — 🌐 Connect scripts and applications directly to the DEJA Server via WebSocket
-
-These guides are for hardware enthusiasts who want to go beyond the standard firmware and build custom integrations.
+- [Command Reference](/docs/io/command-reference) — JSON command format for all device actions
+- [Protocol Details](/docs/io/protocols) — Serial, MQTT, and WebSocket connection specs
+- [Configuration Reference](/docs/io/configuration) — All config file formats
+- [Deploy to Devices](/docs/io/deploy) — Push configs from Cloud to hardware
+- [Building Custom Devices](/docs/io/custom-devices) — Build your own MQTT or WebSocket devices
+- [WebSocket Integration](/docs/io/websocket-integration) — Connect scripts and apps to the DEJA Server

--- a/docs/io/pico-w-setup.mdx
+++ b/docs/io/pico-w-setup.mdx
@@ -1,0 +1,109 @@
+---
+title: Pico W Setup
+description: Deploy DEJA IO firmware to a Raspberry Pi Pico W for wireless MQTT control.
+section: io
+order: 12
+---
+
+# Pico W Setup
+
+The Raspberry Pi Pico W connects to your layout wirelessly over WiFi and communicates via MQTT — ideal for devices placed inside scenery or buildings.
+
+## Hardware Requirements
+
+- **Raspberry Pi Pico W** (~$6)
+- **USB-C cable** for initial setup and power
+- **Adafruit PCA9685 16-Channel PWM Servo Driver** (optional, for servos)
+- **WiFi network** on the same network as your DEJA Server
+- **MQTT broker** (Mosquitto recommended, running on the server machine)
+
+### Wiring the PCA9685
+
+| PCA9685 Pin | Pico W Pin |
+|---|---|
+| VCC | 3V3 |
+| GND | GND |
+| SDA | GP0 |
+| SCL | GP1 |
+
+## Installing CircuitPython
+
+1. Download CircuitPython for Pico W from [circuitpython.org](https://circuitpython.org/board/raspberry_pi_pico_w/)
+2. Hold the **BOOTSEL** button on the Pico W while plugging in USB
+3. Drag the `.uf2` file onto the **RPI-RP2** drive that appears
+4. The Pico W reboots and mounts as **CIRCUITPY**
+
+## Configuration
+
+### WiFi and MQTT — `settings.toml`
+
+Create `settings.toml` on the CIRCUITPY drive:
+
+```toml
+CIRCUITPY_WIFI_SSID = "YourWiFiNetwork"
+CIRCUITPY_WIFI_PASSWORD = "YourWiFiPassword"
+ENABLE_CONFIG = "true"
+ENABLE_PWM = "true"
+ENABLE_MQTT = "true"
+MQTT_BROKER = "192.168.1.100"
+LAYOUT_ID = "your-layout-id"
+DEVICE_ID = "my-pico-device"
+TOPIC_ID = "DEJA"
+```
+
+### Pin Mapping — `config.json`
+
+Create `config.json` to map logical pin numbers to physical GPIO names:
+
+```json
+{
+  "pins": {
+    "8": "GP8",
+    "9": "GP9",
+    "10": "GP10",
+    "11": "GP11"
+  }
+}
+```
+
+## Deploying the Firmware
+
+Copy all files from `io/src/deja-pico-w/` to the CIRCUITPY drive:
+
+- `code.py` — main application
+- `config.json` — pin mapping
+- `lib/` — Adafruit libraries (MQTT, motor, servo, LED animation)
+
+Or use the DEJA deploy script:
+
+```bash
+cd io
+pnpm deploy
+```
+
+The script generates `settings.toml` and `config.json` from your Cloud device configuration and copies everything to the mounted Pico W.
+
+## MQTT Topics
+
+Your Pico W subscribes and publishes to topics based on its identity:
+
+- **Subscribe:** `DEJA/{layoutId}/{deviceId}` — receives commands
+- **Publish:** `DEJA/{layoutId}/{deviceId}/messages` — sends status
+
+## Command Format
+
+Pico W devices receive JSON objects over MQTT:
+
+```json
+{
+  "action": "pin",
+  "payload": { "pin": 8, "state": 1 },
+  "device": "my-pico-device"
+}
+```
+
+The `device` field filters messages — only commands matching this device's ID are processed. See the [Command Reference](/docs/io/command-reference) for all supported actions.
+
+## Layout-Specific Configs
+
+Store per-layout device configs under `io/layouts/{layoutId}/deja-pico-w/{deviceId}/config.json`. The deploy script uses these instead of the default config when deploying to a specific layout.

--- a/docs/io/protocols.mdx
+++ b/docs/io/protocols.mdx
@@ -1,0 +1,128 @@
+---
+title: Protocol Details
+description: Connection details for Serial, MQTT, and WebSocket communication with DEJA IO devices.
+section: io
+order: 15
+---
+
+# Protocol Details
+
+DEJA IO supports three communication protocols. All use JSON messages.
+
+## Serial USB
+
+Direct wired connection between an Arduino and the DEJA Server.
+
+| Parameter | Value |
+|---|---|
+| Baud rate | 115200 |
+| Data bits | 8 |
+| Stop bits | 1 |
+| Parity | None |
+| Encoding | UTF-8 JSON |
+
+### How It Works
+
+1. Arduino connects via USB to the server machine
+2. DEJA Server auto-detects the serial port
+3. Server opens the port at 115200 baud via the `serialport` Node.js package
+4. JSON commands are written to the port; responses are read line-by-line
+5. Auto-reconnect with exponential backoff (1s → 30s max) on disconnect
+
+### Port Detection
+
+The server lists available serial ports and matches them to registered devices. You can also manually specify a port path in your device configuration.
+
+## MQTT over WiFi
+
+Wireless publish/subscribe messaging via an MQTT broker (Mosquitto recommended).
+
+| Parameter | Value |
+|---|---|
+| Default port | 1883 (unencrypted) |
+| Protocol | MQTT v3.1.1 |
+| QoS | 0 (at most once) |
+| Encoding | UTF-8 JSON |
+
+### Topic Structure
+
+```
+{topicId}/{layoutId}/{deviceId}          ← device subscribes (receives commands)
+{topicId}/{layoutId}/{deviceId}/messages ← device publishes (sends status)
+```
+
+Default `topicId` is `DEJA`. Example for a device on the "tam" layout:
+
+```
+DEJA/tam/tj-eagle-nest-pico          ← commands IN
+DEJA/tam/tj-eagle-nest-pico/messages ← status OUT
+```
+
+### Device Filtering
+
+Multiple devices can share the same MQTT topic prefix. Each message includes a `device` field, and devices only process messages matching their own `DEVICE_ID`.
+
+### Broker Setup
+
+Install Mosquitto on your server machine:
+
+```bash
+# macOS
+brew install mosquitto
+
+# Linux (Debian/Ubuntu)
+sudo apt install mosquitto mosquitto-clients
+
+# Start the broker
+mosquitto -d
+```
+
+Set `MQTT_BROKER` in your `.env` to the server's IP address (e.g., `mqtt://192.168.1.100`).
+
+## WebSocket
+
+Real-time bidirectional communication over TCP.
+
+| Parameter | Value |
+|---|---|
+| Default port | 8082 (configurable via `VITE_WS_PORT`) |
+| Protocol | WebSocket (RFC 6455) |
+| Encoding | UTF-8 JSON |
+
+### Connection
+
+Connect to `ws://{serverHost}:8082`. On connection, the server sends an acknowledgment:
+
+```json
+{ "action": "ack", "payload": { "layoutId": "tam", "serverId": "DEJA.js" } }
+```
+
+### Device Monitoring
+
+Subscribe to a device's serial I/O stream:
+
+```json
+{ "action": "subscribe-device", "deviceId": "my-arduino" }
+```
+
+The server forwards serial data for that device:
+
+```json
+{
+  "action": "serial-data",
+  "payload": {
+    "deviceId": "my-arduino",
+    "data": "{ \"sensor\": 0, \"state\": 1 }",
+    "timestamp": "2026-04-03T12:00:00Z",
+    "direction": "incoming"
+  }
+}
+```
+
+Unsubscribe when done:
+
+```json
+{ "action": "unsubscribe-device", "deviceId": "my-arduino" }
+```
+
+See the [WebSocket Integration](/docs/io/websocket-integration) guide for full message reference and code examples.

--- a/docs/superpowers/plans/2026-04-03-io-guide.md
+++ b/docs/superpowers/plans/2026-04-03-io-guide.md
@@ -1,0 +1,1994 @@
+# 🔌 DEJA IO Guide & Shared Guide Components — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract shared guide components from duplicated inline definitions, refactor all existing guides to consume them, build the IO Guide page, create IO MDX docs, and update site navigation.
+
+**Architecture:** Components-first refactor. Extract 9 shared components into `components/guides/shared/`, then refactor 4 existing guides to import them (removing inline duplicates). Build the IO Guide on the shared foundation. Create MDX docs for detailed reference content. Update navigation to activate the IO guide.
+
+**Tech Stack:** Next.js App Router, React Server/Client Components, TypeScript, Tailwind CSS, MDX
+
+**Spec:** `docs/superpowers/specs/2026-04-03-io-guide-design.md`
+
+---
+
+## Task 1: Create shared FeatureCard and FeatureGrid components
+
+**Files:**
+- Create: `apps/dejajs-www/components/guides/shared/FeatureCard.tsx`
+- Create: `apps/dejajs-www/components/guides/shared/FeatureGrid.tsx`
+
+These are exact duplicates across ThrottleGuide and CloudGuide — no differences to reconcile.
+
+- [ ] **Step 1: Create `FeatureCard.tsx`**
+
+```tsx
+import React from 'react';
+
+export default function FeatureCard({ emoji, text }: { emoji: string; text: string }) {
+  return (
+    <div className="flex items-start gap-3 p-3 rounded-lg border border-gray-800/60 bg-gray-900/40 hover:border-deja-cyan/20 hover:bg-gray-900/60 transition-all">
+      <span className="text-lg shrink-0 mt-0.5">{emoji}</span>
+      <span className="text-sm text-gray-300">{text}</span>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Create `FeatureGrid.tsx`**
+
+```tsx
+import React from 'react';
+import AnimateIn from '../../home/AnimateIn';
+import FeatureCard from './FeatureCard';
+
+export default function FeatureGrid({ items }: { items: { emoji: string; text: string }[] }) {
+  return (
+    <div className="grid sm:grid-cols-2 gap-2">
+      {items.map((item, i) => (
+        <AnimateIn key={item.text} delay={i * 0.05}>
+          <FeatureCard emoji={item.emoji} text={item.text} />
+        </AnimateIn>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/dejajs-www/components/guides/shared/FeatureCard.tsx apps/dejajs-www/components/guides/shared/FeatureGrid.tsx
+git commit -m "feat(www): ✨ extract shared FeatureCard and FeatureGrid components"
+```
+
+---
+
+## Task 2: Create shared VideoPlaceholder component
+
+**Files:**
+- Create: `apps/dejajs-www/components/guides/shared/VideoPlaceholder.tsx`
+
+Exact duplicate across ThrottleGuide, CloudGuide, and ServerGuide.
+
+- [ ] **Step 1: Create `VideoPlaceholder.tsx`**
+
+```tsx
+import React from 'react';
+
+export default function VideoPlaceholder() {
+  return (
+    <div className="rounded-2xl border border-gray-800 bg-gray-900/50 overflow-hidden shadow-2xl">
+      <div className="aspect-video flex flex-col items-center justify-center gap-3 bg-gray-900/80">
+        <div className="w-16 h-16 rounded-full border-2 border-deja-cyan/30 bg-deja-cyan/10 flex items-center justify-center">
+          <svg className="w-6 h-6 text-deja-cyan ml-1" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M8 5v14l11-7z" />
+          </svg>
+        </div>
+        <p className="text-gray-400 text-sm">Video walkthrough coming soon</p>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/dejajs-www/components/guides/shared/VideoPlaceholder.tsx
+git commit -m "feat(www): ✨ extract shared VideoPlaceholder component"
+```
+
+---
+
+## Task 3: Create shared Callout, CommandBlock, Step, and MdiIcon components
+
+**Files:**
+- Create: `apps/dejajs-www/components/guides/shared/Callout.tsx`
+- Create: `apps/dejajs-www/components/guides/shared/CommandBlock.tsx`
+- Create: `apps/dejajs-www/components/guides/shared/Step.tsx`
+- Create: `apps/dejajs-www/components/guides/shared/MdiIcon.tsx`
+
+These exist in ServerGuide and GettingStartedGuide. Step and Callout differ only in accent color (`deja-lime` vs `deja-cyan`), so they need a color prop.
+
+- [ ] **Step 1: Create `MdiIcon.tsx`** (exact duplicate, no differences)
+
+```tsx
+import React from 'react';
+
+export default function MdiIcon({ path, className = '' }: { path: string; className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" className={className}>
+      <path d={path} fill="currentColor" />
+    </svg>
+  );
+}
+```
+
+- [ ] **Step 2: Create `CommandBlock.tsx`** (exact duplicate, no differences)
+
+```tsx
+import React from 'react';
+import CopyButton from '../../home/CopyButton';
+
+export default function CommandBlock({ command }: { command: string }) {
+  return (
+    <div className="rounded-lg border border-gray-700 bg-gray-950 overflow-hidden my-4">
+      <div className="flex items-center gap-1.5 px-3 py-2 border-b border-gray-800 bg-gray-900">
+        <span className="w-2.5 h-2.5 rounded-full bg-red-500/70" />
+        <span className="w-2.5 h-2.5 rounded-full bg-yellow-500/70" />
+        <span className="w-2.5 h-2.5 rounded-full bg-green-500/70" />
+        <span className="ml-2 text-gray-500 text-xs font-mono">bash</span>
+      </div>
+      <div className="flex items-center gap-2 px-4 py-3">
+        <span className="text-deja-lime/60 font-mono text-sm select-none shrink-0">$</span>
+        <span className="font-mono text-sm text-deja-lime flex-1 break-all">{command}</span>
+        <CopyButton text={command} />
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Create `Callout.tsx`** (differs by accent color)
+
+```tsx
+import React from 'react';
+
+const colorMap = {
+  lime: { bg: 'bg-deja-lime/5', border: 'border-deja-lime/20' },
+  cyan: { bg: 'bg-deja-cyan/5', border: 'border-deja-cyan/20' },
+};
+
+export default function Callout({
+  emoji,
+  children,
+  color = 'lime',
+}: {
+  emoji: string;
+  children: React.ReactNode;
+  color?: 'lime' | 'cyan';
+}) {
+  const { bg, border } = colorMap[color];
+  return (
+    <div className={`flex gap-3 p-4 rounded-lg ${bg} ${border} my-4`}>
+      <span className="text-lg shrink-0">{emoji}</span>
+      <div className="text-sm text-gray-300 leading-relaxed">{children}</div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Create `Step.tsx`** (differs by accent color)
+
+```tsx
+import React from 'react';
+
+const colorMap = {
+  lime: { border: 'border-deja-lime/30', bg: 'bg-deja-lime/10', text: 'text-deja-lime' },
+  cyan: { border: 'border-deja-cyan/30', bg: 'bg-deja-cyan/10', text: 'text-deja-cyan' },
+};
+
+export default function Step({
+  number,
+  title,
+  children,
+  color = 'lime',
+}: {
+  number: number;
+  title: string;
+  children: React.ReactNode;
+  color?: 'lime' | 'cyan';
+}) {
+  const { border, bg, text } = colorMap[color];
+  return (
+    <div className="relative pl-14">
+      <div className={`absolute left-0 top-0 w-10 h-10 rounded-full border ${border} ${bg} flex items-center justify-center shrink-0`}>
+        <span className={`${text} font-bold text-sm font-mono`}>0{number}</span>
+      </div>
+      <h3 className="text-white font-bold text-xl mb-3">{title}</h3>
+      <div className="text-gray-300 leading-relaxed space-y-3">{children}</div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/dejajs-www/components/guides/shared/MdiIcon.tsx apps/dejajs-www/components/guides/shared/CommandBlock.tsx apps/dejajs-www/components/guides/shared/Callout.tsx apps/dejajs-www/components/guides/shared/Step.tsx
+git commit -m "feat(www): ✨ extract shared Callout, CommandBlock, Step, and MdiIcon components"
+```
+
+---
+
+## Task 4: Create shared FeatureSection component
+
+**Files:**
+- Create: `apps/dejajs-www/components/guides/shared/FeatureSection.tsx`
+
+ThrottleGuide's version is a superset of CloudGuide's — it adds `screenshotDevice` (mobile/desktop) and `cloudNote` props. The shared version uses ThrottleGuide's version with all props optional where appropriate. CloudGuide's simpler screenshot rendering is the default (`screenshotDevice` defaults to `'desktop'`).
+
+- [ ] **Step 1: Create `FeatureSection.tsx`**
+
+```tsx
+import React from 'react';
+import Image from 'next/image';
+import AnimateIn from '../../home/AnimateIn';
+import DocLink from '../../DocLink';
+import FeatureGrid from './FeatureGrid';
+
+export default function FeatureSection({
+  title,
+  desc,
+  features,
+  screenshot,
+  screenshotAlt,
+  screenshotDevice = 'desktop',
+  flip = false,
+  cloudNote,
+  docLink,
+  docLabel,
+  children,
+  renderScreenshot,
+}: {
+  title: string;
+  desc: string;
+  features: { emoji: string; text: string }[];
+  screenshot: string;
+  screenshotAlt: string;
+  screenshotDevice?: 'mobile' | 'desktop';
+  flip?: boolean;
+  cloudNote?: React.ReactNode;
+  docLink?: string;
+  docLabel?: string;
+  children?: React.ReactNode;
+  renderScreenshot?: () => React.ReactNode;
+}) {
+  const screenshotContent = renderScreenshot ? (
+    renderScreenshot()
+  ) : screenshotDevice === 'mobile' ? (
+    <div className="flex justify-center">
+      {/* Mobile devices should use PhoneMockup — pass via renderScreenshot prop */}
+      <div className="rounded-2xl overflow-hidden shadow-2xl w-full max-w-lg">
+        <Image src={screenshot} alt={screenshotAlt} width={400} height={800} className="w-full h-auto" />
+      </div>
+    </div>
+  ) : (
+    <div className="rounded-2xl overflow-hidden shadow-2xl w-full max-w-lg">
+      <Image src={screenshot} alt={screenshotAlt} width={1200} height={675} className="w-full h-auto" />
+    </div>
+  );
+
+  return (
+    <section className="py-20">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-16 items-center">
+        <AnimateIn direction={flip ? 'right' : 'left'} className={flip ? 'lg:order-2' : ''}>
+          <h2 className="text-3xl sm:text-4xl font-bold text-white mb-3">{title}</h2>
+          <p className="text-gray-400 leading-relaxed mb-6">{desc}</p>
+          <FeatureGrid items={features} />
+          {cloudNote && <div className="mt-4">{cloudNote}</div>}
+          {children}
+          {docLink && docLabel && (
+            <div className="mt-4">
+              <DocLink href={docLink}>{docLabel}</DocLink>
+            </div>
+          )}
+        </AnimateIn>
+        <AnimateIn direction={flip ? 'left' : 'right'} className={`flex justify-center ${flip ? 'lg:order-1' : ''}`}>
+          {screenshotContent}
+        </AnimateIn>
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/dejajs-www/components/guides/shared/FeatureSection.tsx
+git commit -m "feat(www): ✨ extract shared FeatureSection component"
+```
+
+---
+
+## Task 5: Create shared FeatureCarousel component
+
+**Files:**
+- Create: `apps/dejajs-www/components/guides/shared/FeatureCarousel.tsx`
+
+This is the most complex extraction. ThrottleGuide's carousel has `mobileScreenshot` + `desktopScreenshot` with PhoneMockup PiP overlay. CloudGuide's carousel has only `desktopScreenshot` with a plain image. The shared component accepts a `renderScreenshot` prop to handle this difference.
+
+- [ ] **Step 1: Create `FeatureCarousel.tsx`**
+
+```tsx
+'use client';
+
+import React, { useState } from 'react';
+import Image from 'next/image';
+import AnimateIn from '../../home/AnimateIn';
+import SectionLabel from '../../home/SectionLabel';
+import DocLink from '../../DocLink';
+import FeatureGrid from './FeatureGrid';
+
+export interface CarouselSlide {
+  id: string;
+  emoji: string;
+  title: string;
+  tagline: string;
+  desc: string;
+  desktopScreenshot: string;
+  mobileScreenshot?: string;
+  features: { emoji: string; text: string }[];
+  docHref: string;
+  docLabel: string;
+  accentColor: string;
+  accentBg: string;
+  accentBorder: string;
+}
+
+export default function FeatureCarousel({
+  slides,
+  sectionLabel,
+  sectionColor = 'lime',
+  title,
+  description,
+  tabColumns = 'sm:grid-cols-4',
+  renderScreenshot,
+}: {
+  slides: CarouselSlide[];
+  sectionLabel: string;
+  sectionColor?: 'cyan' | 'magenta' | 'lime';
+  title: string;
+  description: React.ReactNode;
+  tabColumns?: string;
+  renderScreenshot?: (slide: CarouselSlide) => React.ReactNode;
+}) {
+  const [activeIdx, setActiveIdx] = useState(0);
+  const active = slides[activeIdx];
+
+  const defaultScreenshot = (slide: CarouselSlide) => (
+    <div className="rounded-2xl overflow-hidden shadow-2xl">
+      <Image
+        src={slide.desktopScreenshot}
+        alt={`${slide.title} desktop view`}
+        width={1200}
+        height={675}
+        className="w-full h-auto"
+      />
+    </div>
+  );
+
+  const screenshotRenderer = renderScreenshot ?? defaultScreenshot;
+
+  return (
+    <section className="py-20">
+      <div className="max-w-5xl mx-auto">
+        <AnimateIn>
+          <SectionLabel color={sectionColor}>{sectionLabel}</SectionLabel>
+          <h2 className="text-3xl sm:text-4xl font-bold text-white mt-4 mb-3">{title}</h2>
+          <div className="text-gray-400 leading-relaxed mb-10">{description}</div>
+        </AnimateIn>
+
+        {/* Tab buttons */}
+        <div className={`grid grid-cols-2 ${tabColumns} gap-3 mb-12`}>
+          {slides.map((slide, i) => (
+            <button
+              key={slide.id}
+              onClick={() => setActiveIdx(i)}
+              className={`flex flex-col items-center gap-2 px-4 py-4 rounded-xl text-sm font-semibold transition-all cursor-pointer ${
+                i === activeIdx
+                  ? `${slide.accentBg} border-2 ${slide.accentBorder} ${slide.accentColor} shadow-lg`
+                  : 'border-2 border-gray-800/60 text-gray-500 hover:border-gray-600 hover:text-gray-300 hover:bg-gray-900/50'
+              }`}
+            >
+              <span className="text-2xl">{slide.emoji}</span>
+              <span>{slide.title}</span>
+            </button>
+          ))}
+        </div>
+
+        {/* Active slide */}
+        <div key={active.id}>
+          <div className="mb-8">
+            <h3 className={`text-3xl font-bold ${active.accentColor} mb-2`}>{active.title}</h3>
+            <p className="text-xl text-white font-semibold">{active.tagline}</p>
+            <p className="text-gray-400 leading-relaxed mt-3 max-w-2xl">{active.desc}</p>
+          </div>
+
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-start">
+            {screenshotRenderer(active)}
+
+            <div>
+              <FeatureGrid items={active.features} />
+              <div className="mt-6 flex flex-wrap gap-3">
+                <DocLink href={active.docHref}>{active.docLabel}</DocLink>
+              </div>
+
+              <div className={`mt-6 p-6 rounded-xl border-2 border-dashed ${active.accentBorder} ${active.accentBg} flex flex-col items-center gap-2`}>
+                <span className="text-4xl">{active.emoji}</span>
+                <p className={`text-sm font-medium ${active.accentColor}`}>Illustration coming soon</p>
+                <p className="text-xs text-gray-500 text-center">Custom graphic for {active.title.toLowerCase()}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/dejajs-www/components/guides/shared/FeatureCarousel.tsx
+git commit -m "feat(www): ✨ extract shared FeatureCarousel component"
+```
+
+---
+
+## Task 6: Create barrel export for shared components
+
+**Files:**
+- Create: `apps/dejajs-www/components/guides/shared/index.ts`
+
+- [ ] **Step 1: Create `index.ts`**
+
+```ts
+export { default as FeatureCard } from './FeatureCard';
+export { default as FeatureGrid } from './FeatureGrid';
+export { default as FeatureSection } from './FeatureSection';
+export { default as VideoPlaceholder } from './VideoPlaceholder';
+export { default as Callout } from './Callout';
+export { default as CommandBlock } from './CommandBlock';
+export { default as Step } from './Step';
+export { default as MdiIcon } from './MdiIcon';
+export { default as FeatureCarousel } from './FeatureCarousel';
+export type { CarouselSlide } from './FeatureCarousel';
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/dejajs-www/components/guides/shared/index.ts
+git commit -m "feat(www): ✨ add barrel export for shared guide components"
+```
+
+---
+
+## Task 7: Refactor ThrottleGuide to use shared components
+
+**Files:**
+- Modify: `apps/dejajs-www/components/guides/ThrottleGuide.tsx`
+
+Replace inline `FeatureCard`, `FeatureGrid`, `FeatureSection`, `VideoPlaceholder` definitions and `LayoutFeaturesCarousel` with imports from shared.
+
+- [ ] **Step 1: Replace inline component definitions with imports**
+
+At the top of the file, add:
+```tsx
+import { FeatureGrid, FeatureSection, VideoPlaceholder, FeatureCarousel } from './shared';
+import type { CarouselSlide } from './shared';
+```
+
+Remove these inline function definitions:
+- `FeatureCard` (lines 14–21)
+- `FeatureGrid` (lines 23–33)
+- `FeatureSection` (lines 355–410) — note: ThrottleGuide uses `PhoneMockup` for mobile screenshots, so the `FeatureSection` usages that pass `screenshotDevice='mobile'` should instead use the `renderScreenshot` prop to render the PhoneMockup directly.
+- `VideoPlaceholder` (lines 46–59)
+
+- [ ] **Step 2: Replace `LayoutFeaturesCarousel` with shared `FeatureCarousel`**
+
+Remove the `LayoutFeaturesCarousel` function definition (lines 261–351). Keep the `layoutFeatures` data array (lines 156–259) — it's ThrottleGuide-specific.
+
+Replace the `<LayoutFeaturesCarousel />` call in the main component with:
+
+```tsx
+<FeatureCarousel
+  slides={layoutFeatures}
+  sectionLabel="Layout Control"
+  sectionColor="lime"
+  title="Control Your Entire Layout"
+  description={
+    <>
+      Beyond driving trains, Throttle gives you control over every aspect of your layout.
+      These features are configured in{' '}
+      <Link href="/guides/cloud" className="text-deja-cyan hover:underline">DEJA Cloud</Link>{' '}
+      and controlled here in real time.
+    </>
+  }
+  tabColumns="sm:grid-cols-5"
+  renderScreenshot={(slide) => (
+    <div className="relative">
+      <div className="rounded-2xl border-2 border-gray-700 bg-gray-900 p-2 shadow-2xl">
+        <div className="mx-auto w-8 h-1 bg-gray-800 rounded-full mb-1" />
+        <div className="rounded-xl overflow-hidden">
+          <Image
+            src={slide.desktopScreenshot}
+            alt={`${slide.title} desktop view`}
+            width={1200}
+            height={675}
+            className="w-full h-auto"
+          />
+        </div>
+      </div>
+      {slide.mobileScreenshot && (
+        <div className="absolute -bottom-4 -right-2 sm:-right-6">
+          <PhoneMockup
+            src={slide.mobileScreenshot}
+            alt={`${slide.title} mobile view`}
+            className="w-[100px] sm:w-[120px]"
+          />
+        </div>
+      )}
+    </div>
+  )}
+/>
+```
+
+- [ ] **Step 3: Update `FeatureSection` usages that use PhoneMockup**
+
+For each `<FeatureSection>` call in ThrottleGuide that passes `screenshotDevice="mobile"`, convert to use the `renderScreenshot` prop instead:
+
+```tsx
+<FeatureSection
+  title="..."
+  desc="..."
+  features={[...]}
+  screenshot="/screenshots/..."
+  screenshotAlt="..."
+  docLink="/docs/..."
+  docLabel="..."
+  renderScreenshot={() => (
+    <PhoneMockup src="/screenshots/..." alt="..." className="w-[220px]" />
+  )}
+>
+```
+
+For `FeatureSection` calls using `screenshotDevice="desktop"` (or no device prop), they work as-is with the shared component since `'desktop'` is the default.
+
+- [ ] **Step 4: Verify the build compiles**
+
+Run: `pnpm --filter=dejajs-www build`
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/dejajs-www/components/guides/ThrottleGuide.tsx
+git commit -m "refactor(www): 🔄 ThrottleGuide uses shared guide components"
+```
+
+---
+
+## Task 8: Refactor CloudGuide to use shared components
+
+**Files:**
+- Modify: `apps/dejajs-www/components/guides/CloudGuide.tsx`
+
+- [ ] **Step 1: Replace inline component definitions with imports**
+
+At the top of the file, add:
+```tsx
+import { FeatureGrid, FeatureSection, VideoPlaceholder, FeatureCarousel } from './shared';
+import type { CarouselSlide } from './shared';
+```
+
+Remove these inline function definitions:
+- `FeatureCard` (lines 13–20)
+- `FeatureGrid` (lines 22–32)
+- `VideoPlaceholder` (lines 34–47)
+- `FeatureSection` (lines 49–92)
+
+- [ ] **Step 2: Replace `CloudFeaturesCarousel` with shared `FeatureCarousel`**
+
+Remove the `CloudFeaturesCarousel` function definition (lines 308–380). Keep the `cloudFeatures` data array (lines 111–306).
+
+Replace the `<CloudFeaturesCarousel />` call with:
+
+```tsx
+<FeatureCarousel
+  slides={cloudFeatures}
+  sectionLabel="Feature Reference"
+  sectionColor="lime"
+  title="Everything in Cloud"
+  description={
+    <>
+      Beyond the basics, Cloud gives you full control over every aspect of your layout.
+      Configure it here, control it from{' '}
+      <Link href="/guides/throttle" className="text-deja-cyan hover:underline">Throttle</Link>.
+    </>
+  }
+  tabColumns="sm:grid-cols-4"
+/>
+```
+
+CloudGuide uses the default `renderScreenshot` (plain desktop image), so no custom renderer needed.
+
+- [ ] **Step 3: Verify the build compiles**
+
+Run: `pnpm --filter=dejajs-www build`
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/dejajs-www/components/guides/CloudGuide.tsx
+git commit -m "refactor(www): 🔄 CloudGuide uses shared guide components"
+```
+
+---
+
+## Task 9: Refactor ServerGuide to use shared components + DocLink standardization
+
+**Files:**
+- Modify: `apps/dejajs-www/components/guides/ServerGuide.tsx`
+
+- [ ] **Step 1: Replace inline component definitions with imports**
+
+At the top of the file, add:
+```tsx
+import { Callout, CommandBlock, Step, MdiIcon, VideoPlaceholder } from './shared';
+import DocLink from '../DocLink';
+```
+
+Remove these inline function definitions:
+- `Step` (lines 6–16)
+- `CommandBlock` (lines 18–34)
+- `Callout` (lines 52–59)
+- `MdiIcon` (lines 61–67)
+- `VideoPlaceholder` if defined inline (check for it)
+
+Remove the `CopyButton` import if it's no longer used directly (it's now imported inside `CommandBlock`).
+
+- [ ] **Step 2: Add `color="lime"` to all `Step` and `Callout` usages**
+
+ServerGuide used `deja-lime` styling. Since the shared components default to `'lime'`, no changes are needed for `Step` or `Callout` — the defaults match.
+
+- [ ] **Step 3: Replace plain `<Link>` doc references with `<DocLink>`**
+
+Find all plain `<Link>` elements that point to `/docs/...` paths and replace them with `<DocLink>`. For example:
+
+Before:
+```tsx
+<Link href="/docs/server/installation" className="text-deja-cyan hover:underline">Installation docs</Link>
+```
+
+After:
+```tsx
+<DocLink href="/docs/server/installation">Installation</DocLink>
+```
+
+Apply this to all doc-pointing links in ServerGuide. Links to non-doc pages (like `/guides/getting-started` or `/pricing`) should remain as plain `<Link>` elements since they aren't doc references.
+
+- [ ] **Step 4: Verify the build compiles**
+
+Run: `pnpm --filter=dejajs-www build`
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/dejajs-www/components/guides/ServerGuide.tsx
+git commit -m "refactor(www): 🔄 ServerGuide uses shared components + DocLink standardization"
+```
+
+---
+
+## Task 10: Refactor GettingStartedGuide to use shared components + DocLink standardization
+
+**Files:**
+- Modify: `apps/dejajs-www/components/guides/GettingStartedGuide.tsx`
+
+- [ ] **Step 1: Replace inline component definitions with imports**
+
+At the top of the file, add:
+```tsx
+import { Callout, CommandBlock, Step, MdiIcon } from './shared';
+import DocLink from '../DocLink';
+```
+
+Remove these inline function definitions:
+- `Step` (lines 7–17)
+- `CommandBlock` (lines 19–35)
+- `Callout` (lines 37–44)
+- `MdiIcon` (lines 46–52)
+
+Remove the `CopyButton` import if no longer used directly.
+
+- [ ] **Step 2: Add `color="cyan"` to all `Step` and `Callout` usages**
+
+GettingStartedGuide used `deja-cyan` styling. Since the shared components default to `'lime'`, add `color="cyan"` to every `<Step>` and `<Callout>` usage in this guide. For example:
+
+Before:
+```tsx
+<Step number={1} title="Create your account">
+```
+
+After:
+```tsx
+<Step number={1} title="Create your account" color="cyan">
+```
+
+Same for `<Callout>`:
+Before:
+```tsx
+<Callout emoji="💡">
+```
+
+After:
+```tsx
+<Callout emoji="💡" color="cyan">
+```
+
+- [ ] **Step 3: Replace plain `<Link>` doc references with `<DocLink>`**
+
+Same pattern as ServerGuide — replace all doc-pointing `<Link>` elements with `<DocLink>`. Keep non-doc links as plain `<Link>`.
+
+- [ ] **Step 4: Verify the build compiles**
+
+Run: `pnpm --filter=dejajs-www build`
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/dejajs-www/components/guides/GettingStartedGuide.tsx
+git commit -m "refactor(www): 🔄 GettingStartedGuide uses shared components + DocLink standardization"
+```
+
+---
+
+## Task 11: Build the IO Guide page component
+
+**Files:**
+- Create: `apps/dejajs-www/components/guides/IoGuide.tsx`
+
+This is the main guide component. It targets evaluators and positions DEJA IO as a full layout automation platform.
+
+- [ ] **Step 1: Create `IoGuide.tsx` with hero section**
+
+```tsx
+'use client';
+
+import React from 'react';
+import Image from 'next/image';
+import AnimateIn from '../home/AnimateIn';
+import SectionLabel from '../home/SectionLabel';
+import DocLink from '../DocLink';
+import { FeatureCard, FeatureGrid, VideoPlaceholder, Callout } from './shared';
+
+export default function IoGuide() {
+  return (
+    <div className="max-w-4xl mx-auto">
+      {/* Hero */}
+      <section className="py-8 sm:py-12">
+        <AnimateIn>
+          <SectionLabel color="magenta">DEJA IO</SectionLabel>
+          <h1 className="text-4xl sm:text-5xl font-bold text-white mt-4 mb-4">
+            Beyond the Throttle
+          </h1>
+          <p className="text-xl text-gray-300 leading-relaxed max-w-2xl mb-3">
+            DEJA.js isn&apos;t just a throttle — it&apos;s a full layout automation platform. IO devices
+            let you control turnouts, signals, lights, effects, and sensors across your entire layout
+            from your phone.
+          </p>
+          <p className="text-gray-400 leading-relaxed max-w-2xl">
+            Connect Arduino boards via USB or Raspberry Pi Pico W over WiFi. Configure everything
+            in the Cloud app, deploy to your devices, and control it all from Throttle.
+          </p>
+        </AnimateIn>
+      </section>
+
+      {/* Architecture diagram */}
+      <section className="py-12">
+        <AnimateIn>
+          <h2 className="text-3xl font-bold text-white mb-3">How It Works</h2>
+          <p className="text-gray-400 mb-8">
+            Three communication protocols connect your devices to the DEJA platform — pick the one
+            that fits your layout.
+          </p>
+        </AnimateIn>
+        <AnimateIn delay={0.1}>
+          <div className="rounded-2xl border border-gray-800 bg-gray-900/50 p-6 sm:p-8">
+            <div className="text-center space-y-6">
+              {/* Top: Frontend apps */}
+              <div>
+                <p className="text-xs text-deja-cyan font-mono tracking-wider uppercase mb-3">Your Phone / Browser</p>
+                <div className="flex justify-center gap-3 flex-wrap">
+                  {['🚂 Throttle', '☁️ Cloud', '📊 Monitor'].map((app) => (
+                    <span key={app} className="px-3 py-1.5 rounded-lg bg-deja-cyan/10 border border-deja-cyan/20 text-sm text-deja-cyan font-medium">
+                      {app}
+                    </span>
+                  ))}
+                </div>
+              </div>
+
+              {/* Arrow down */}
+              <div className="text-gray-600 text-2xl">↕</div>
+
+              {/* Middle: DEJA Server */}
+              <div className="inline-block px-6 py-3 rounded-xl bg-deja-lime/10 border-2 border-deja-lime/30">
+                <p className="text-deja-lime font-bold text-lg">💻 DEJA Server</p>
+                <p className="text-gray-400 text-xs mt-1">Firebase • WebSocket • Serial • MQTT</p>
+              </div>
+
+              {/* Three protocol branches */}
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                <div className="rounded-xl border border-amber-400/20 bg-amber-400/5 p-4">
+                  <p className="text-amber-400 font-bold text-sm mb-1">🔌 Serial USB</p>
+                  <p className="text-gray-400 text-xs">115200 baud • Direct</p>
+                  <div className="text-gray-600 my-2">↓</div>
+                  <p className="text-gray-300 text-sm">Arduino</p>
+                </div>
+                <div className="rounded-xl border border-purple-400/20 bg-purple-400/5 p-4">
+                  <p className="text-purple-400 font-bold text-sm mb-1">📡 MQTT WiFi</p>
+                  <p className="text-gray-400 text-xs">Wireless • Scalable</p>
+                  <div className="text-gray-600 my-2">↓</div>
+                  <p className="text-gray-300 text-sm">Pico W</p>
+                </div>
+                <div className="rounded-xl border border-deja-cyan/20 bg-deja-cyan/5 p-4">
+                  <p className="text-deja-cyan font-bold text-sm mb-1">🌐 WebSocket</p>
+                  <p className="text-gray-400 text-xs">Real-time • Monitoring</p>
+                  <div className="text-gray-600 my-2">↓</div>
+                  <p className="text-gray-300 text-sm">Custom Devices</p>
+                </div>
+              </div>
+
+              {/* Arrow down */}
+              <div className="text-gray-600 text-2xl">↓</div>
+
+              {/* Bottom: Physical hardware */}
+              <div>
+                <p className="text-xs text-gray-500 font-mono tracking-wider uppercase mb-3">Your Layout</p>
+                <div className="flex justify-center gap-3 flex-wrap">
+                  {['🔀 Turnouts', '💡 Lights', '🚦 Signals', '📡 Sensors', '🔊 Sounds'].map((hw) => (
+                    <span key={hw} className="px-3 py-1.5 rounded-lg bg-gray-800 border border-gray-700 text-sm text-gray-300">
+                      {hw}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </AnimateIn>
+      </section>
+
+      {/* Protocol comparison cards */}
+      <section className="py-12">
+        <AnimateIn>
+          <h2 className="text-3xl font-bold text-white mb-3">Choose Your Protocol</h2>
+          <p className="text-gray-400 mb-8">
+            Each protocol has strengths — pick the one that matches your layout and hardware.
+          </p>
+        </AnimateIn>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <AnimateIn delay={0.05}>
+            <div className="rounded-xl border border-amber-400/20 bg-gray-900/50 p-5 h-full">
+              <div className="text-2xl mb-3">🔌</div>
+              <h3 className="text-amber-400 font-bold text-lg mb-1">Serial USB</h3>
+              <p className="text-gray-300 text-sm font-medium mb-3">Direct & reliable</p>
+              <div className="space-y-2 text-sm text-gray-400">
+                <p><span className="text-gray-300 font-medium">Best for:</span> Workbench setups, single-board installs</p>
+                <p><span className="text-gray-300 font-medium">Hardware:</span> Arduino Uno, Mega, Nano</p>
+                <p><span className="text-gray-300 font-medium">Connection:</span> USB cable to server</p>
+                <p><span className="text-gray-300 font-medium">Latency:</span> Lowest — direct serial</p>
+              </div>
+            </div>
+          </AnimateIn>
+          <AnimateIn delay={0.1}>
+            <div className="rounded-xl border border-purple-400/20 bg-gray-900/50 p-5 h-full">
+              <div className="text-2xl mb-3">📡</div>
+              <h3 className="text-purple-400 font-bold text-lg mb-1">MQTT over WiFi</h3>
+              <p className="text-gray-300 text-sm font-medium mb-3">Wireless & scalable</p>
+              <div className="space-y-2 text-sm text-gray-400">
+                <p><span className="text-gray-300 font-medium">Best for:</span> Devices in scenery, multi-device layouts</p>
+                <p><span className="text-gray-300 font-medium">Hardware:</span> Raspberry Pi Pico W</p>
+                <p><span className="text-gray-300 font-medium">Connection:</span> WiFi to MQTT broker</p>
+                <p><span className="text-gray-300 font-medium">Latency:</span> Low — local network</p>
+              </div>
+            </div>
+          </AnimateIn>
+          <AnimateIn delay={0.15}>
+            <div className="rounded-xl border border-deja-cyan/20 bg-gray-900/50 p-5 h-full">
+              <div className="text-2xl mb-3">🌐</div>
+              <h3 className="text-deja-cyan font-bold text-lg mb-1">WebSocket</h3>
+              <p className="text-gray-300 text-sm font-medium mb-3">Real-time & flexible</p>
+              <div className="space-y-2 text-sm text-gray-400">
+                <p><span className="text-gray-300 font-medium">Best for:</span> Custom apps, monitoring, dashboards</p>
+                <p><span className="text-gray-300 font-medium">Hardware:</span> Any networked device</p>
+                <p><span className="text-gray-300 font-medium">Connection:</span> TCP on port 8082</p>
+                <p><span className="text-gray-300 font-medium">Latency:</span> Low — persistent connection</p>
+              </div>
+            </div>
+          </AnimateIn>
+        </div>
+      </section>
+
+      {/* Supported devices */}
+      <section className="py-12">
+        <AnimateIn>
+          <SectionLabel color="lime">Supported Hardware</SectionLabel>
+          <h2 className="text-3xl font-bold text-white mt-4 mb-3">Ready-Made Devices</h2>
+          <p className="text-gray-400 mb-8">
+            Flash our firmware onto affordable hardware and start controlling your layout.
+          </p>
+        </AnimateIn>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+          <AnimateIn delay={0.05}>
+            <div className="rounded-xl border border-amber-400/20 bg-gray-900/50 p-6 h-full">
+              <div className="flex items-center gap-3 mb-4">
+                <span className="text-3xl">🔌</span>
+                <div>
+                  <h3 className="text-white font-bold text-lg">Arduino</h3>
+                  <p className="text-amber-400 text-sm font-medium">Serial USB • Wired</p>
+                </div>
+              </div>
+              <p className="text-gray-400 text-sm leading-relaxed mb-4">
+                Standard Arduino boards (Uno, Mega, Nano) connect via USB and drive servos, LEDs, relays,
+                signal heads, and sensors. Compile-time configuration via header file.
+              </p>
+              <FeatureGrid items={[
+                { emoji: '⚙️', text: 'PCA9685 16-channel servo driver support' },
+                { emoji: '💡', text: 'Digital outputs for LEDs and relays' },
+                { emoji: '🚦', text: 'Signal head aspects' },
+                { emoji: '📡', text: 'Sensor input with debounce' },
+              ]} />
+              <div className="mt-4">
+                <DocLink href="/docs/io/arduino-setup">Arduino setup</DocLink>
+              </div>
+            </div>
+          </AnimateIn>
+          <AnimateIn delay={0.1}>
+            <div className="rounded-xl border border-purple-400/20 bg-gray-900/50 p-6 h-full">
+              <div className="flex items-center gap-3 mb-4">
+                <span className="text-3xl">📡</span>
+                <div>
+                  <h3 className="text-white font-bold text-lg">Raspberry Pi Pico W</h3>
+                  <p className="text-purple-400 text-sm font-medium">MQTT • WiFi</p>
+                </div>
+              </div>
+              <p className="text-gray-400 text-sm leading-relaxed mb-4">
+                Wireless placement anywhere on your layout. Connects to your WiFi network and communicates
+                via MQTT. Runtime configuration — no recompilation needed.
+              </p>
+              <FeatureGrid items={[
+                { emoji: '📶', text: 'WiFi — no cables to the server' },
+                { emoji: '⚙️', text: 'PCA9685 servo driver over I2C' },
+                { emoji: '💡', text: 'Digital pin control for outputs' },
+                { emoji: '🔧', text: 'Runtime config via settings.toml' },
+              ]} />
+              <div className="mt-4">
+                <DocLink href="/docs/io/pico-w-setup">Pico W setup</DocLink>
+              </div>
+            </div>
+          </AnimateIn>
+        </div>
+
+        {/* Build your own teaser */}
+        <AnimateIn delay={0.15}>
+          <div className="mt-6 rounded-xl border border-deja-cyan/20 bg-deja-cyan/5 p-6">
+            <div className="flex items-start gap-4">
+              <span className="text-3xl shrink-0">🛠️</span>
+              <div>
+                <h3 className="text-white font-bold text-lg mb-1">Build Your Own</h3>
+                <p className="text-gray-400 text-sm leading-relaxed mb-3">
+                  DEJA IO uses open protocols — Serial, MQTT, and WebSocket with simple JSON commands.
+                  Connect any microcontroller with WiFi or USB to your layout.
+                </p>
+                <DocLink href="/docs/io/custom-devices">Custom device guide</DocLink>
+              </div>
+            </div>
+          </div>
+        </AnimateIn>
+      </section>
+
+      {/* Deploy flow video */}
+      <section className="py-12">
+        <AnimateIn>
+          <SectionLabel color="cyan">Deploy Flow</SectionLabel>
+          <h2 className="text-3xl font-bold text-white mt-4 mb-3">Configure Once, Deploy Anywhere</h2>
+          <p className="text-gray-400 mb-8">
+            Set up your devices in the Cloud app, hit deploy, and your hardware comes online
+            with the right configuration. No manual file editing required.
+          </p>
+        </AnimateIn>
+        <AnimateIn delay={0.1}>
+          <VideoPlaceholder />
+        </AnimateIn>
+        <AnimateIn delay={0.15}>
+          <Callout emoji="🚀" color="cyan">
+            The deploy script auto-detects connected boards, fetches your device configuration from
+            the cloud, generates the right config files, and flashes your hardware — all in one command.
+          </Callout>
+        </AnimateIn>
+      </section>
+
+      {/* Docs links */}
+      <section className="py-12">
+        <AnimateIn>
+          <h2 className="text-3xl font-bold text-white mb-3">Dive Into the Docs</h2>
+          <p className="text-gray-400 mb-8">
+            Everything you need to set up devices, understand protocols, and build custom integrations.
+          </p>
+        </AnimateIn>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <AnimateIn delay={0.05}>
+            <div className="space-y-3">
+              <h3 className="text-white font-semibold text-sm uppercase tracking-wider">Get Started</h3>
+              <div className="flex flex-col gap-2">
+                <DocLink href="/docs/io">IO overview</DocLink>
+                <DocLink href="/docs/io/arduino-setup">Arduino setup</DocLink>
+                <DocLink href="/docs/io/pico-w-setup">Pico W setup</DocLink>
+                <DocLink href="/docs/io/deploy">Deploy to devices</DocLink>
+              </div>
+            </div>
+          </AnimateIn>
+          <AnimateIn delay={0.1}>
+            <div className="space-y-3">
+              <h3 className="text-white font-semibold text-sm uppercase tracking-wider">Go Deeper</h3>
+              <div className="flex flex-col gap-2">
+                <DocLink href="/docs/io/command-reference">Command reference</DocLink>
+                <DocLink href="/docs/io/protocols">Protocol details</DocLink>
+                <DocLink href="/docs/io/configuration">Configuration format</DocLink>
+                <DocLink href="/docs/io/custom-devices">Build custom devices</DocLink>
+              </div>
+            </div>
+          </AnimateIn>
+        </div>
+      </section>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/dejajs-www/components/guides/IoGuide.tsx
+git commit -m "feat(www): 🔌 add IO Guide page component"
+```
+
+---
+
+## Task 12: Create the IO Guide route page
+
+**Files:**
+- Create: `apps/dejajs-www/app/guides/io/page.tsx`
+
+Follows the exact pattern of `app/guides/server/page.tsx` and `app/guides/cloud/page.tsx`.
+
+- [ ] **Step 1: Create `page.tsx`**
+
+```tsx
+import type { Metadata } from 'next';
+import IoGuide from '../../../components/guides/IoGuide';
+
+export const metadata: Metadata = {
+  title: 'IO Guide — DEJA.js',
+  description: 'Control your entire layout with DEJA IO — Arduino, Pico W, Serial, MQTT, and WebSocket hardware integration.',
+};
+
+export default function IoGuidePage() {
+  return <IoGuide />;
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/dejajs-www/app/guides/io/page.tsx
+git commit -m "feat(www): 🔌 add IO Guide route page"
+```
+
+---
+
+## Task 13: Update site navigation to activate IO Guide
+
+**Files:**
+- Modify: `apps/dejajs-www/app/guides/page.tsx` (guides index)
+- Modify: `apps/dejajs-www/components/GuidesSidebar.tsx` (sidebar nav)
+- Modify: `apps/dejajs-www/components/home/GuidesGrid.tsx` (homepage grid)
+
+- [ ] **Step 1: Update guides index — activate IO guide**
+
+In `apps/dejajs-www/app/guides/page.tsx`, find the IO guide entry (lines 51–58):
+
+```tsx
+  {
+    label: 'IO',
+    href: '/guides/io',
+    desc: 'Hardware expansion with Arduino and Pico W — LEDs, servos, signals, sensors, and MQTT.',
+    icon: '🔌',
+    comingSoon: true,
+    color: 'border-gray-700/30',
+    iconBg: 'bg-gray-800',
+  },
+```
+
+Replace with:
+
+```tsx
+  {
+    label: 'IO',
+    href: '/guides/io',
+    desc: 'Hardware expansion with Arduino and Pico W — LEDs, servos, signals, sensors, and MQTT.',
+    icon: '🔌',
+    color: 'border-fuchsia-400/30 hover:border-fuchsia-400/60',
+    iconBg: 'bg-fuchsia-400/10',
+  },
+```
+
+- [ ] **Step 2: Update sidebar — activate IO guide**
+
+In `apps/dejajs-www/components/GuidesSidebar.tsx`, find the IO entry (line 22):
+
+```tsx
+  { title: 'IO', href: '/guides/io', desc: 'Hardware expansion & MQTT', comingSoon: true },
+```
+
+Replace with:
+
+```tsx
+  { title: 'IO', href: '/guides/io', desc: 'Hardware expansion & MQTT' },
+```
+
+Also fix the Server guide entry (line 20) which is incorrectly marked as comingSoon (the Server guide exists):
+
+```tsx
+  { title: 'Server', href: '/guides/server', desc: 'Installation & CLI reference', comingSoon: true },
+```
+
+Replace with:
+
+```tsx
+  { title: 'Server', href: '/guides/server', desc: 'Installation & CLI reference' },
+```
+
+- [ ] **Step 3: Update homepage grid — activate IO guide**
+
+In `apps/dejajs-www/components/home/GuidesGrid.tsx`, find the IO guide entry (lines 48–55):
+
+```tsx
+  {
+    label: 'IO',
+    href: '/guides/io',
+    desc: 'Hardware expansion with Arduino and Pico W — LEDs, servos, signals, sensors, and MQTT.',
+    icon: '🔌',
+    comingSoon: true,
+    color: 'border-gray-700/30',
+    iconBg: 'bg-gray-800',
+  },
+```
+
+Replace with:
+
+```tsx
+  {
+    label: 'IO',
+    href: '/guides/io',
+    desc: 'Hardware expansion with Arduino and Pico W — LEDs, servos, signals, sensors, and MQTT.',
+    icon: '🔌',
+    color: 'border-fuchsia-400/30 hover:border-fuchsia-400/60',
+    iconBg: 'bg-fuchsia-400/10',
+  },
+```
+
+- [ ] **Step 4: Verify the build compiles**
+
+Run: `pnpm --filter=dejajs-www build`
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/dejajs-www/app/guides/page.tsx apps/dejajs-www/components/GuidesSidebar.tsx apps/dejajs-www/components/home/GuidesGrid.tsx
+git commit -m "feat(www): 🔌 activate IO Guide in site navigation"
+```
+
+---
+
+## Task 14: Create IO MDX docs — arduino-setup, pico-w-setup, configuration
+
+**Files:**
+- Create: `docs/io/arduino-setup.mdx`
+- Create: `docs/io/pico-w-setup.mdx`
+- Create: `docs/io/configuration.mdx`
+
+Content is derived from the existing firmware source code at `io/src/deja-arduino/` and `io/src/deja-pico-w/`.
+
+- [ ] **Step 1: Create `arduino-setup.mdx`**
+
+```mdx
+---
+title: Arduino Setup
+description: Flash DEJA IO firmware to an Arduino board and connect it to your server via USB.
+section: io
+order: 11
+---
+
+# Arduino Setup
+
+Connect a standard Arduino board to your DEJA Server via USB to control turnouts, signals, LEDs, relays, and sensors.
+
+## Hardware Requirements
+
+- **Arduino Uno, Mega, or Nano** (any ATmega-based board)
+- **USB cable** (Type-A to Type-B for Uno/Mega, Mini-USB for Nano)
+- **Adafruit PCA9685 16-Channel PWM Servo Driver** (optional, for servo-driven turnouts)
+- **Jumper wires** for connecting outputs and sensors
+
+### Wiring the PCA9685
+
+If using servo-driven turnouts, connect the PCA9685 to your Arduino via I2C:
+
+| PCA9685 Pin | Arduino Pin |
+|---|---|
+| VCC | 5V |
+| GND | GND |
+| SDA | A4 (Uno) / 20 (Mega) |
+| SCL | A5 (Uno) / 21 (Mega) |
+
+Power the servo rail separately with a 5–6V power supply — do not power servos from the Arduino's 5V pin.
+
+## Firmware Configuration
+
+Open `io/src/deja-arduino/config.h` (copy from `config.default.h` if it doesn't exist) and set your device identity and feature flags:
+
+```cpp
+// Device identity
+#define DEVICE_ID "my-arduino-device"
+
+// Feature toggles — enable what your hardware supports
+#define ENABLE_PWM true        // PCA9685 servo driver
+#define ENABLE_OUTPUTS true    // Digital output pins
+#define ENABLE_SIGNALS true    // Signal head outputs
+#define ENABLE_SENSORS true    // Sensor input pins
+#define ENABLE_TURNOUTS true   // Servo-driven turnouts
+
+// Pin assignments
+int OUTPINS[] = {8, 9, 10, 11};           // GPIO pins for digital outputs
+int SIGNALPINS[] = {4, 5, 6, 7};          // GPIO pins for signal heads
+int SENSORPINS[] = {A0, A1, A2};          // GPIO pins for sensors
+```
+
+### Turnout Configuration
+
+Turnouts are defined as `TurnoutPulser` objects with a servo channel, thrown angle, and closed angle:
+
+```cpp
+TurnoutPulser turnouts[] = {
+  TurnoutPulser(0, 45, 135),   // Servo channel 0: 45° closed, 135° thrown
+  TurnoutPulser(1, 50, 130),   // Servo channel 1: 50° closed, 130° thrown
+};
+```
+
+## Flashing the Firmware
+
+1. Open `io/src/deja-arduino/deja-arduino.ino` in the Arduino IDE
+2. Select your board type under **Tools → Board**
+3. Select the correct serial port under **Tools → Port**
+4. Click **Upload**
+
+Or use the DEJA deploy script:
+
+```bash
+cd io
+pnpm deploy
+```
+
+The deploy script auto-detects connected boards and can generate `config.h` from your Cloud device configuration.
+
+## Connecting to the Server
+
+1. Plug the Arduino into the server machine via USB
+2. In the [Cloud app](https://cloud.dejajs.com), register a device with type **deja-arduino** and your `DEVICE_ID`
+3. The DEJA Server auto-detects the serial port and connects at 115200 baud
+4. Open the [Monitor app](https://monitor.dejajs.com) to verify the device appears and responds to commands
+
+## Command Format
+
+Arduino devices receive JSON arrays over serial:
+
+```json
+[
+  { "action": "pin", "payload": { "pin": 8, "state": 1 } },
+  { "action": "servo", "payload": { "servo": 0, "value": 90, "current": 45 } },
+  { "action": "turnout", "payload": { "turnout": 0, "state": true } }
+]
+```
+
+See the [Command Reference](/docs/io/command-reference) for all supported actions.
+```
+
+- [ ] **Step 2: Create `pico-w-setup.mdx`**
+
+```mdx
+---
+title: Pico W Setup
+description: Deploy DEJA IO firmware to a Raspberry Pi Pico W for wireless MQTT control.
+section: io
+order: 12
+---
+
+# Pico W Setup
+
+The Raspberry Pi Pico W connects to your layout wirelessly over WiFi and communicates via MQTT — ideal for devices placed inside scenery or buildings.
+
+## Hardware Requirements
+
+- **Raspberry Pi Pico W** (~$6)
+- **USB-C cable** for initial setup and power
+- **Adafruit PCA9685 16-Channel PWM Servo Driver** (optional, for servos)
+- **WiFi network** on the same network as your DEJA Server
+- **MQTT broker** (Mosquitto recommended, running on the server machine)
+
+### Wiring the PCA9685
+
+| PCA9685 Pin | Pico W Pin |
+|---|---|
+| VCC | 3V3 |
+| GND | GND |
+| SDA | GP0 |
+| SCL | GP1 |
+
+## Installing CircuitPython
+
+1. Download CircuitPython for Pico W from [circuitpython.org](https://circuitpython.org/board/raspberry_pi_pico_w/)
+2. Hold the **BOOTSEL** button on the Pico W while plugging in USB
+3. Drag the `.uf2` file onto the **RPI-RP2** drive that appears
+4. The Pico W reboots and mounts as **CIRCUITPY**
+
+## Configuration
+
+### WiFi and MQTT — `settings.toml`
+
+Create `settings.toml` on the CIRCUITPY drive:
+
+```toml
+CIRCUITPY_WIFI_SSID = "YourWiFiNetwork"
+CIRCUITPY_WIFI_PASSWORD = "YourWiFiPassword"
+ENABLE_CONFIG = "true"
+ENABLE_PWM = "true"
+ENABLE_MQTT = "true"
+MQTT_BROKER = "192.168.1.100"
+LAYOUT_ID = "your-layout-id"
+DEVICE_ID = "my-pico-device"
+TOPIC_ID = "DEJA"
+```
+
+### Pin Mapping — `config.json`
+
+Create `config.json` to map logical pin numbers to physical GPIO names:
+
+```json
+{
+  "pins": {
+    "8": "GP8",
+    "9": "GP9",
+    "10": "GP10",
+    "11": "GP11"
+  }
+}
+```
+
+## Deploying the Firmware
+
+Copy all files from `io/src/deja-pico-w/` to the CIRCUITPY drive:
+
+- `code.py` — main application
+- `config.json` — pin mapping
+- `lib/` — Adafruit libraries (MQTT, motor, servo, LED animation)
+
+Or use the DEJA deploy script:
+
+```bash
+cd io
+pnpm deploy
+```
+
+The script generates `settings.toml` and `config.json` from your Cloud device configuration and copies everything to the mounted Pico W.
+
+## MQTT Topics
+
+Your Pico W subscribes and publishes to topics based on its identity:
+
+- **Subscribe:** `DEJA/{layoutId}/{deviceId}` — receives commands
+- **Publish:** `DEJA/{layoutId}/{deviceId}/messages` — sends status
+
+## Command Format
+
+Pico W devices receive JSON objects over MQTT:
+
+```json
+{
+  "action": "pin",
+  "payload": { "pin": 8, "state": 1 },
+  "device": "my-pico-device"
+}
+```
+
+The `device` field filters messages — only commands matching this device's ID are processed. See the [Command Reference](/docs/io/command-reference) for all supported actions.
+
+## Layout-Specific Configs
+
+Store per-layout device configs under `io/layouts/{layoutId}/deja-pico-w/{deviceId}/config.json`. The deploy script uses these instead of the default config when deploying to a specific layout.
+```
+
+- [ ] **Step 3: Create `configuration.mdx`**
+
+```mdx
+---
+title: Configuration Reference
+description: All configuration file formats for DEJA IO devices — Arduino config.h, Pico W settings.toml, and config.json.
+section: io
+order: 14
+---
+
+# Configuration Reference
+
+DEJA IO devices use different configuration formats depending on the platform. This reference covers all of them.
+
+## Arduino — `config.h`
+
+Compile-time configuration. The Arduino firmware reads these values at build time.
+
+### Feature Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `DEVICE_ID` | string | `"deja-arduino"` | Unique device identifier — must match your Cloud device entry |
+| `ENABLE_PWM` | bool | `true` | Enable PCA9685 servo driver support |
+| `ENABLE_OUTPUTS` | bool | `true` | Enable digital GPIO outputs |
+| `ENABLE_SIGNALS` | bool | `true` | Enable signal head control |
+| `ENABLE_SENSORS` | bool | `true` | Enable sensor input reading |
+| `ENABLE_TURNOUTS` | bool | `true` | Enable servo-driven turnouts |
+
+### Pin Arrays
+
+```cpp
+int OUTPINS[] = {8, 9, 10, 11};       // Digital output GPIO pins
+int SIGNALPINS[] = {4, 5, 6, 7};      // Signal head GPIO pins
+int SENSORPINS[] = {A0, A1, A2};      // Sensor input pins (analog or digital)
+```
+
+### Turnout Definitions
+
+```cpp
+TurnoutPulser turnouts[] = {
+  TurnoutPulser(channel, closedAngle, thrownAngle),
+};
+```
+
+- `channel` — PCA9685 servo channel (0–15)
+- `closedAngle` — servo angle for closed position (degrees)
+- `thrownAngle` — servo angle for thrown position (degrees)
+
+## Pico W — `settings.toml`
+
+Runtime environment configuration. Loaded by CircuitPython at boot.
+
+| Variable | Required | Description |
+|---|---|---|
+| `CIRCUITPY_WIFI_SSID` | ✅ | WiFi network name |
+| `CIRCUITPY_WIFI_PASSWORD` | ✅ | WiFi password |
+| `MQTT_BROKER` | ✅ | MQTT broker IP address |
+| `LAYOUT_ID` | ✅ | Your layout ID in DEJA Cloud |
+| `DEVICE_ID` | ✅ | Unique device identifier |
+| `TOPIC_ID` | No | MQTT topic prefix (default: `"DEJA"`) |
+| `ENABLE_CONFIG` | No | Load pin mapping from config.json (default: `"true"`) |
+| `ENABLE_PWM` | No | Enable PCA9685 servo support (default: `"true"`) |
+| `ENABLE_MQTT` | No | Enable MQTT communication (default: `"true"`) |
+
+## Pico W — `config.json`
+
+Pin mapping from logical pin numbers to physical CircuitPython GPIO names.
+
+```json
+{
+  "pins": {
+    "6": "GP6",
+    "7": "GP7",
+    "8": "GP8",
+    "9": "GP9"
+  }
+}
+```
+
+Keys are the logical pin numbers used in commands (`"pin": 8`). Values are CircuitPython GPIO names (`"GP8"`).
+
+## Layout-Specific Overrides
+
+Per-layout configs live under:
+
+```
+io/layouts/{layoutId}/deja-pico-w/{deviceId}/config.json
+```
+
+When the deploy script runs, it uses the layout-specific config instead of the default `io/src/deja-pico-w/config.json`.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/io/arduino-setup.mdx docs/io/pico-w-setup.mdx docs/io/configuration.mdx
+git commit -m "docs(io): 📝 add Arduino setup, Pico W setup, and configuration reference"
+```
+
+---
+
+## Task 15: Create IO MDX docs — command-reference, protocols, deploy
+
+**Files:**
+- Create: `docs/io/command-reference.mdx`
+- Create: `docs/io/protocols.mdx`
+- Create: `docs/io/deploy.mdx`
+
+- [ ] **Step 1: Create `command-reference.mdx`**
+
+```mdx
+---
+title: Command Reference
+description: Complete JSON command specification for all DEJA IO device actions.
+section: io
+order: 13
+---
+
+# Command Reference
+
+All DEJA IO devices receive JSON commands with an `action` and `payload`. The format differs slightly between Arduino (Serial) and Pico W (MQTT).
+
+## Actions
+
+### `pin` — Digital Output
+
+Toggle a digital GPIO pin on or off.
+
+```json
+{
+  "action": "pin",
+  "payload": { "pin": 8, "state": 1 }
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `pin` | number | GPIO pin number (must match device config) |
+| `state` | number | `1` = on (HIGH), `0` = off (LOW) |
+
+### `servo` — Servo Position
+
+Set a PCA9685 servo channel to a specific angle.
+
+```json
+{
+  "action": "servo",
+  "payload": { "servo": 0, "value": 90, "current": 45 }
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `servo` | number | PCA9685 channel (0–15) |
+| `value` | number | Target angle in degrees |
+| `current` | number | Current angle (Arduino only — used for smooth transition) |
+
+### `turnout` — Turnout Control
+
+Throw or close a configured turnout.
+
+```json
+{
+  "action": "turnout",
+  "payload": { "turnout": 0, "state": true }
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `turnout` | number | Turnout index (matches device config array position) |
+| `state` | boolean | `true` = thrown, `false` = closed |
+
+### `ialed` — Addressable LED Strip (Planned)
+
+Control individually addressable LED strips.
+
+```json
+{
+  "action": "ialed",
+  "payload": { "strip": 0, "pattern": 0, "r": 255, "g": 0, "b": 0 }
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `strip` | number | LED strip index |
+| `pattern` | number | Animation pattern ID |
+| `r`, `g`, `b` | number | RGB color values (0–255) |
+
+> This action is defined in the Arduino firmware but not yet fully implemented.
+
+## Format Differences
+
+### Arduino (Serial USB)
+
+Commands are sent as a **JSON array** over serial at 115200 baud:
+
+```json
+[
+  { "action": "pin", "payload": { "pin": 8, "state": 1 } },
+  { "action": "servo", "payload": { "servo": 0, "value": 90, "current": 45 } }
+]
+```
+
+Multiple commands can be batched in a single array.
+
+### Pico W (MQTT)
+
+Commands are sent as a **single JSON object** with a `device` field for filtering:
+
+```json
+{
+  "action": "pin",
+  "payload": { "pin": 8, "state": 1 },
+  "device": "my-pico-device"
+}
+```
+
+The `device` field is required — the Pico W ignores messages that don't match its `DEVICE_ID`.
+
+## Sensor Responses
+
+Arduino devices send sensor state changes back over serial:
+
+```json
+{ "sensor": 0, "state": 1 }
+```
+
+Sensor data is debounced (500ms minimum between state changes) and automatically routed to the DEJA Server for processing.
+```
+
+- [ ] **Step 2: Create `protocols.mdx`**
+
+```mdx
+---
+title: Protocol Details
+description: Connection details for Serial, MQTT, and WebSocket communication with DEJA IO devices.
+section: io
+order: 15
+---
+
+# Protocol Details
+
+DEJA IO supports three communication protocols. All use JSON messages.
+
+## Serial USB
+
+Direct wired connection between an Arduino and the DEJA Server.
+
+| Parameter | Value |
+|---|---|
+| Baud rate | 115200 |
+| Data bits | 8 |
+| Stop bits | 1 |
+| Parity | None |
+| Encoding | UTF-8 JSON |
+
+### How It Works
+
+1. Arduino connects via USB to the server machine
+2. DEJA Server auto-detects the serial port
+3. Server opens the port at 115200 baud via the `serialport` Node.js package
+4. JSON commands are written to the port; responses are read line-by-line
+5. Auto-reconnect with exponential backoff (1s → 30s max) on disconnect
+
+### Port Detection
+
+The server lists available serial ports and matches them to registered devices. You can also manually specify a port path in your device configuration.
+
+## MQTT over WiFi
+
+Wireless publish/subscribe messaging via an MQTT broker (Mosquitto recommended).
+
+| Parameter | Value |
+|---|---|
+| Default port | 1883 (unencrypted) |
+| Protocol | MQTT v3.1.1 |
+| QoS | 0 (at most once) |
+| Encoding | UTF-8 JSON |
+
+### Topic Structure
+
+```
+{topicId}/{layoutId}/{deviceId}          ← device subscribes (receives commands)
+{topicId}/{layoutId}/{deviceId}/messages ← device publishes (sends status)
+```
+
+Default `topicId` is `DEJA`. Example for a device on the "tam" layout:
+
+```
+DEJA/tam/tj-eagle-nest-pico          ← commands IN
+DEJA/tam/tj-eagle-nest-pico/messages ← status OUT
+```
+
+### Device Filtering
+
+Multiple devices can share the same MQTT topic prefix. Each message includes a `device` field, and devices only process messages matching their own `DEVICE_ID`.
+
+### Broker Setup
+
+Install Mosquitto on your server machine:
+
+```bash
+# macOS
+brew install mosquitto
+
+# Linux (Debian/Ubuntu)
+sudo apt install mosquitto mosquitto-clients
+
+# Start the broker
+mosquitto -d
+```
+
+Set `MQTT_BROKER` in your `.env` to the server's IP address (e.g., `mqtt://192.168.1.100`).
+
+## WebSocket
+
+Real-time bidirectional communication over TCP.
+
+| Parameter | Value |
+|---|---|
+| Default port | 8082 (configurable via `VITE_WS_PORT`) |
+| Protocol | WebSocket (RFC 6455) |
+| Encoding | UTF-8 JSON |
+
+### Connection
+
+Connect to `ws://{serverHost}:8082`. On connection, the server sends an acknowledgment:
+
+```json
+{ "action": "ack", "payload": { "layoutId": "tam", "serverId": "DEJA.js" } }
+```
+
+### Device Monitoring
+
+Subscribe to a device's serial I/O stream:
+
+```json
+{ "action": "subscribe-device", "deviceId": "my-arduino" }
+```
+
+The server forwards serial data for that device:
+
+```json
+{
+  "action": "serial-data",
+  "payload": {
+    "deviceId": "my-arduino",
+    "data": "{ \"sensor\": 0, \"state\": 1 }",
+    "timestamp": "2026-04-03T12:00:00Z",
+    "direction": "incoming"
+  }
+}
+```
+
+Unsubscribe when done:
+
+```json
+{ "action": "unsubscribe-device", "deviceId": "my-arduino" }
+```
+
+See the [WebSocket Integration](/docs/io/websocket-integration) guide for full message reference and code examples.
+```
+
+- [ ] **Step 3: Create `deploy.mdx`**
+
+```mdx
+---
+title: Deploy to Devices
+description: Use the DEJA deploy script to push configuration and firmware to your IO devices.
+section: io
+order: 16
+---
+
+# Deploy to Devices
+
+The DEJA IO deploy script fetches your device configuration from Firebase and generates the correct config files for each device type. It can also flash firmware to connected boards.
+
+## Running the Deploy Script
+
+```bash
+cd io
+pnpm deploy
+```
+
+The interactive script walks you through:
+
+1. **Board detection** — scans for connected Arduino and Pico W devices
+2. **Device selection** — choose which registered device to deploy to
+3. **Config generation** — fetches device config, effects, and turnouts from Firebase
+4. **File generation** — creates platform-specific config files
+5. **Deployment** — uploads to the device
+
+## What Gets Deployed
+
+### Arduino
+
+The script generates `config.h` with:
+
+- `DEVICE_ID` from your Cloud device entry
+- Feature flags based on what's configured (effects → `ENABLE_OUTPUTS`, turnouts → `ENABLE_TURNOUTS`, etc.)
+- Pin arrays from your device's pin mapping
+- Turnout servo definitions from your configured turnouts
+
+Then compiles and uploads via the Arduino CLI.
+
+### Pico W
+
+The script generates:
+
+- `settings.toml` with WiFi credentials, MQTT broker address, layout ID, and device ID
+- `config.json` with the pin mapping from your device configuration
+
+Then copies all files to the mounted CIRCUITPY drive.
+
+## Firebase Configuration Source
+
+The deploy script reads from Firestore:
+
+| Collection | Data |
+|---|---|
+| `layouts/{layoutId}/devices/{deviceId}` | Device type, connection, pin mapping |
+| `layouts/{layoutId}/effects` | Effects assigned to this device |
+| `layouts/{layoutId}/turnouts` | Turnouts assigned to this device |
+
+Your device must be registered in the Cloud app before deploying.
+
+## Layout-Specific Configs
+
+For layouts with customized wiring, place override configs at:
+
+```
+io/layouts/{layoutId}/deja-pico-w/{deviceId}/config.json
+```
+
+The deploy script checks for layout-specific configs first, falling back to the device's Cloud configuration.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/io/command-reference.mdx docs/io/protocols.mdx docs/io/deploy.mdx
+git commit -m "docs(io): 📝 add command reference, protocol details, and deploy guide"
+```
+
+---
+
+## Task 16: Update existing IO overview.mdx
+
+**Files:**
+- Modify: `docs/io/overview.mdx`
+
+Align the existing overview with the new guide messaging and link to the new docs.
+
+- [ ] **Step 1: Update `overview.mdx`**
+
+Replace the full content of `docs/io/overview.mdx` with:
+
+```mdx
+---
+title: IO Devices
+description: Extend your layout with wireless lights, servos, sensors, and animations using Arduino and Raspberry Pi Pico W hardware devices.
+section: io
+order: 8
+---
+
+# IO Devices
+
+IO devices extend your layout beyond what the DCC-EX CommandStation handles directly. They control effects like lighting, servo-driven turnouts, sensors, and animated elements — anything that isn't powered through the DCC track bus.
+
+DEJA IO supports three communication protocols — **Serial USB**, **MQTT over WiFi**, and **WebSocket** — so you can pick the one that fits your layout. See the [IO Guide](/guides/io) for the full platform overview.
+
+## Supported Hardware
+
+### Arduino (USB Serial)
+
+Standard Arduino boards (Uno, Mega, Nano) connect to the DEJA Server via USB. They can drive:
+
+- **PWM servos** via an Adafruit PCA9685 16-channel servo driver board — for turnout motors and animated elements
+- **Digital outputs** — for LEDs, relays, and on/off devices
+- **Signal heads** — for model railroad signal aspects
+- **Sensors** — for detecting train presence (block detection, occupancy)
+
+Arduino devices communicate over serial at 115200 baud. See [Arduino Setup](/docs/io/arduino-setup) for full instructions.
+
+### Raspberry Pi Pico W (WiFi / MQTT)
+
+The Pico W connects to your layout wirelessly over WiFi and communicates via MQTT. This is ideal for devices placed inside scenery or buildings where running USB cables is impractical.
+
+Pico W devices support:
+
+- **Digital pin control** — LEDs, relays, and other outputs
+- **PWM servo control** — via Adafruit ServoKit over I2C
+
+See [Pico W Setup](/docs/io/pico-w-setup) for full instructions.
+
+## Setting Up a Device
+
+1. **Register the device** — In the [Cloud app](https://cloud.dejajs.com), go to your layout's **Devices** section and add a new device entry with a unique device ID.
+2. **Flash the firmware** — See [Arduino Setup](/docs/io/arduino-setup) or [Pico W Setup](/docs/io/pico-w-setup).
+3. **Deploy configuration** — Run the [deploy script](/docs/io/deploy) to push your Cloud configuration to the device.
+4. **Verify** — Open the [Monitor app](https://monitor.dejajs.com) to see your device appear and respond to commands.
+
+## Reference
+
+- [Command Reference](/docs/io/command-reference) — JSON command format for all device actions
+- [Protocol Details](/docs/io/protocols) — Serial, MQTT, and WebSocket connection specs
+- [Configuration Reference](/docs/io/configuration) — All config file formats
+- [Deploy to Devices](/docs/io/deploy) — Push configs from Cloud to hardware
+- [Building Custom Devices](/docs/io/custom-devices) — Build your own MQTT or WebSocket devices
+- [WebSocket Integration](/docs/io/websocket-integration) — Connect scripts and apps to the DEJA Server
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/io/overview.mdx
+git commit -m "docs(io): 📝 update IO overview with new doc links and guide messaging"
+```
+
+---
+
+## Task 17: Final build verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run full build**
+
+Run: `pnpm --filter=dejajs-www build`
+Expected: Build succeeds with zero errors.
+
+- [ ] **Step 2: Run lint**
+
+Run: `pnpm --filter=dejajs-www lint`
+Expected: No lint errors.
+
+- [ ] **Step 3: Spot-check in browser**
+
+Start the dev server and verify:
+- `/guides` — IO guide card is active (not "Soon"), fuchsia accent color
+- `/guides/io` — IO Guide renders with all sections
+- `/guides/throttle` — Throttle guide still renders correctly with shared components
+- `/guides/cloud` — Cloud guide still renders correctly with shared components
+- `/guides/server` — Server guide renders with DocLink components
+- `/guides/getting-started` — Getting Started guide renders with DocLink components
+- Homepage — GuidesGrid shows IO as active
+
+- [ ] **Step 4: Commit any fixes from verification**
+
+```bash
+git add -A
+git commit -m "fix(www): 🐛 address build/lint issues from guide refactor"
+```

--- a/docs/superpowers/specs/2026-04-03-io-guide-design.md
+++ b/docs/superpowers/specs/2026-04-03-io-guide-design.md
@@ -1,0 +1,261 @@
+# 🔌 DEJA IO Guide & Shared Guide Components — Design Spec
+
+**Date:** 2026-04-03
+**Branch:** `io-guide`
+**Status:** Draft
+
+---
+
+## 1. Goals
+
+1. **Create the DEJA IO Guide** — a showcase page targeting DCC hobbyists evaluating DEJA.js, positioning it as a full layout automation platform (not just a throttle app).
+2. **Extract shared guide components** — deduplicate ~9 components currently defined inline across 4 existing guides into a shared library under `components/guides/shared/`.
+3. **Refactor all existing guides** (Getting Started, Throttle, Server, Cloud) to consume the shared components.
+4. **Standardize doc links** — all guides and site pages use the existing `DocLink` component consistently (ServerGuide and GettingStartedGuide currently use plain `<Link>` elements).
+5. **Create IO MDX docs** — detailed reference documentation for setup, commands, protocols, and custom device integration.
+
+---
+
+## 2. Target Audience
+
+**Primary (Guide):** DCC hobbyists evaluating DEJA.js who want to see what IO capabilities set it apart from competing throttle apps.
+
+**Secondary (Docs):** Existing users setting up devices (Audience A) and tinkerers building custom integrations (Audience D) — served by linked MDX docs, not the guide itself.
+
+**Core message:** "DEJA.js is a full layout automation platform, not just a throttle — IO devices make your whole layout smart."
+
+---
+
+## 3. Shared Guide Components
+
+### 3.1 Components to Extract
+
+All components below are currently defined inline in 2–4 guide files. Extract each into `components/guides/shared/` with a barrel export via `index.ts`.
+
+| Component | Source Guides | Props |
+|---|---|---|
+| **`VideoPlaceholder`** | Cloud, Throttle, Server | `title: string`, `subtitle?: string`, `aspectRatio?: string` |
+| **`FeatureCard`** | Cloud, Throttle | `emoji: string`, `title: string`, `description: string`, `accentColor?: string` |
+| **`FeatureGrid`** | Cloud, Throttle | `children: ReactNode`, `columns?: number` |
+| **`FeatureSection`** | Cloud, Throttle | `title: string`, `description: string`, `screenshot?: string`, `features?: string[]`, `docHref?: string`, `docLabel?: string`, `accentColor: string`, `flip?: boolean`, `children?: ReactNode` |
+| **`Callout`** | Server, Getting Started | `variant: 'info' \| 'warning' \| 'tip' \| 'success'`, `title?: string`, `children: ReactNode` |
+| **`CommandBlock`** | Server, Getting Started | `command: string`, `description?: string`, `copyable?: boolean` |
+| **`Step`** | Server, Getting Started | `number: number`, `title: string`, `children: ReactNode` |
+| **`MdiIcon`** | Server, Getting Started | `icon: string`, `size?: number`, `className?: string` |
+| **`GuideFeatureCarousel`** | Cloud, Throttle | `features: FeatureItem[]`, `accentColor: string` |
+
+### 3.2 File Structure
+
+```
+components/guides/shared/
+├── VideoPlaceholder.tsx
+├── FeatureCard.tsx
+├── FeatureGrid.tsx
+├── FeatureSection.tsx
+├── Callout.tsx
+├── CommandBlock.tsx
+├── Step.tsx
+├── MdiIcon.tsx
+├── GuideFeatureCarousel.tsx
+└── index.ts
+```
+
+### 3.3 `DocLink` Standardization
+
+The existing `DocLink` component (`components/DocLink.tsx`) — book icon + "docs" label — is already used correctly in ThrottleGuide and CloudGuide. **ServerGuide and GettingStartedGuide** currently use plain `<Link>` elements with inline classes for doc references. Refactor these to use `DocLink` for visual consistency across all guides and the site.
+
+### 3.4 Feature Data Shape
+
+Standardize the carousel feature data structure used by `GuideFeatureCarousel`:
+
+```typescript
+interface GuideFeature {
+  id: string
+  emoji: string
+  title: string
+  tagline: string
+  description: string
+  screenshot?: string
+  features: string[]
+  docHref?: string
+  docLabel?: string
+  accentColor: string
+  accentBg: string
+  accentBorder: string
+}
+```
+
+---
+
+## 4. Existing Guide Refactors
+
+Each existing guide gets updated to import from `components/guides/shared/` instead of defining components inline. No content changes — purely mechanical extraction.
+
+| Guide | Components to Replace | DocLink Fix |
+|---|---|---|
+| **ThrottleGuide** | FeatureCard, FeatureGrid, FeatureSection, VideoPlaceholder, GuideFeatureCarousel | Already using DocLink ✅ |
+| **CloudGuide** | FeatureCard, FeatureGrid, FeatureSection, VideoPlaceholder, GuideFeatureCarousel | Already using DocLink ✅ |
+| **ServerGuide** | Callout, CommandBlock, Step, MdiIcon, VideoPlaceholder | Replace plain `<Link>` with `DocLink` |
+| **GettingStartedGuide** | Callout, CommandBlock, Step, MdiIcon | Replace plain `<Link>` with `DocLink` |
+
+---
+
+## 5. IO Guide Design
+
+### 5.1 Page Location
+
+- Route: `/guides/io`
+- Page: `apps/dejajs-www/app/guides/io/page.tsx`
+- Component: `apps/dejajs-www/components/guides/IoGuide.tsx`
+
+### 5.2 Content Structure
+
+#### Hero Section
+- **Headline:** Positions DEJA IO as "beyond the throttle" — full layout automation
+- **Subline:** Turnouts, signals, lights, effects, sensors — all from your phone
+- **Visual:** High-level architecture diagram showing phone → DEJA server → devices → physical layout hardware
+
+#### Protocol Architecture Diagram
+- Animated/interactive diagram showing the 3 communication paths converging at the DEJA server:
+  - **Serial USB** — Arduino, direct wired connection
+  - **MQTT over WiFi** — Pico W, wireless throughout the layout
+  - **WebSocket** — real-time browser monitoring & control
+- Shows how all protocols feed into the unified DEJA server, which coordinates everything
+
+#### Protocol Comparison Cards
+- 3 side-by-side cards (Serial / MQTT / WebSocket), each showing:
+  - Protocol name + icon
+  - "Best for" one-liner
+  - Hardware it pairs with
+  - Connection type (wired/wireless)
+  - Key characteristic (latency, range, simplicity)
+- Evaluator-focused — "which fits my layout" not "how to configure"
+
+#### Supported Devices Section
+- **Arduino** card — Serial USB connection, supports turnouts, signals, digital outputs, sensors. Compile-time configuration. Cheap, reliable, wired.
+- **Raspberry Pi Pico W** card — MQTT over WiFi, supports turnouts, digital outputs. Runtime configuration via `settings.toml` + `config.json`. Wireless, flexible placement.
+- **Build Your Own** teaser — "Use Serial, MQTT, or WebSocket with your own hardware. Full command reference in the docs." Links to `custom-devices.mdx` via `DocLink`.
+
+#### Deploy Flow Video/Animation (Showpiece Section)
+- Short walkthrough video or animated sequence showing the end-to-end deploy experience:
+  1. Configure device + effects in the Cloud app
+  2. Run deploy command
+  3. Device comes online and responds to commands
+- Uses `VideoPlaceholder` initially, replaced with actual video content when available
+- This is the primary "wow" moment for evaluators
+
+#### Docs Links Section
+- Grid of `DocLink` components linking to all IO MDX docs
+- Organized by audience: "Get Started" (setup guides) and "Go Deeper" (reference/custom)
+
+### 5.3 Update Guides Index & Homepage
+
+- Add IO to the guides index page (`app/guides/page.tsx`) — remove "Coming Soon" status
+- Update `GuidesGrid.tsx` on homepage to include IO guide card
+- Update `GuidesSidebar.tsx` to include IO navigation entry
+
+---
+
+## 6. IO MDX Documentation
+
+Detailed docs for setup and reference audiences, linked from the IO Guide via `DocLink`.
+
+### 6.1 Docs Structure
+
+```
+docs/io/
+├── overview.mdx              # Updated — align with guide messaging
+├── arduino-setup.mdx         # NEW — hardware, wiring, flashing firmware
+├── pico-w-setup.mdx          # NEW — hardware, WiFi config, CircuitPython deploy
+├── command-reference.mdx     # NEW — full JSON command format for all protocols
+├── protocols.mdx             # NEW — Serial, MQTT, WebSocket connection details
+├── configuration.mdx         # NEW — config.h, settings.toml, config.json format
+├── deploy.mdx                # NEW — deploy script, Firebase → device flow
+└── custom-devices.mdx        # NEW — build your own device integration guide
+```
+
+### 6.2 Doc Content Summaries
+
+**`arduino-setup.mdx`** — Hardware requirements (Arduino Uno/Mega, PCA9685 servo driver, wiring diagrams). Installing firmware. Configuring `config.h` feature flags and pin arrays. Connecting via USB.
+
+**`pico-w-setup.mdx`** — Hardware requirements (Raspberry Pi Pico W, PCA9685). Installing CircuitPython. Configuring `settings.toml` (WiFi, MQTT broker, device ID). Pin mapping via `config.json`. Deploying files to the device.
+
+**`command-reference.mdx`** — Complete JSON command specification for all actions:
+- `pin` — digital output control (`{ "action": "pin", "payload": { "pin": 8, "state": 1 } }`)
+- `servo` — servo position (`{ "action": "servo", "payload": { "servo": 0, "value": 90 } }`)
+- `turnout` — turnout throw/close (`{ "action": "turnout", "payload": { "turnout": 0, "state": true } }`)
+- `ialed` — addressable LED strip (planned)
+- Format differences: Arduino receives JSON arrays, Pico W receives JSON objects with `device` field
+
+**`protocols.mdx`** — Connection details for each protocol:
+- Serial: baud rate (115200), port detection, JSON framing
+- MQTT: broker config, topic format (`{topicId}/{layoutId}/{deviceId}`), subscribe/publish patterns, device filtering
+- WebSocket: port (8082), `subscribe-device`/`unsubscribe-device` actions, `serial-data` event format
+
+**`configuration.mdx`** — All config file formats:
+- Arduino `config.h`: feature flags (`ENABLE_PWM`, `ENABLE_OUTPUTS`, etc.), pin arrays, turnout definitions
+- Pico W `settings.toml`: environment variables (WiFi, MQTT, device identity)
+- Pico W `config.json`: logical-to-physical pin mapping
+- Layout-specific overrides under `io/layouts/{layoutId}/`
+
+**`deploy.mdx`** — Using the deploy toolchain:
+- `io/scripts/deploy.ts` interactive deploy flow
+- Firebase → device config fetch (device + effects + turnouts)
+- Arduino: generates `config.h`, compiles, uploads via USB
+- Pico W: generates `settings.toml` + `config.json`, copies to CircuitPython mount
+- Auto-detection of connected boards
+
+**`custom-devices.mdx`** — Integration guide for custom hardware:
+- Supported protocols and when to use each
+- Message format specification (JSON schema for each action)
+- MQTT topic conventions and device filtering
+- WebSocket handshake and subscription protocol
+- Example: minimal Arduino sketch that responds to `pin` commands
+- Example: minimal Python script that connects via MQTT
+
+---
+
+## 7. Future Protocol/Device Considerations
+
+Not included in the guide or docs — captured here for roadmap planning.
+
+### 7.1 High Value
+
+| Protocol/Device | Why | Effort |
+|---|---|---|
+| **WiFi Arduino (ESP32)** | Already in progress. Cheap, WiFi+BLE, huge maker community. Bridges wired Arduino and wireless Pico W. | Medium |
+| **DCC-EX EX-IOExpander** | DCC-EX's own IO expansion protocol. Existing hardware compatibility with the DCC-EX user base. | Medium |
+| **LCC/OpenLCB (NMRA S-9.7)** | NMRA standard layout bus. Serious model railroaders invest in LCC nodes. Major credibility signal. | High |
+| **JMRI Integration** | Bridge/import path from the most-used DCC software. Lowers switching cost for evaluators. | Medium |
+| **Bluetooth Low Energy (BLE)** | No WiFi network needed. Direct phone-to-device for simple or portable layouts. | Medium |
+| **LocoNet (Digitrax)** | Widely used proprietary bus. Many existing layouts have LocoNet infrastructure. | High |
+
+### 7.2 Lower Priority
+
+| Protocol/Device | Why |
+|---|---|
+| **XpressNet (Lenz/Roco)** | European market equivalent of LocoNet |
+| **BiDiB** | German-origin, gaining EU traction, excellent feedback capabilities |
+| **Home Assistant / MQTT Bridge** | Smart home crossover audience — layout-as-smart-home |
+
+---
+
+## 8. Approach & Phasing
+
+**Approach A: Components-First Refactor**
+
+1. **Phase 1 — Extract shared components** into `components/guides/shared/`
+2. **Phase 2 — Refactor existing guides** to consume shared components + standardize `DocLink` usage
+3. **Phase 3 — Build IO Guide** page and component using the shared library
+4. **Phase 4 — Create IO MDX docs** with full reference content
+5. **Phase 5 — Update site navigation** (guides index, homepage grid, sidebar)
+
+---
+
+## 9. Out of Scope
+
+- Video/animation production for the deploy flow (use `VideoPlaceholder` for now)
+- Actual ESP32/WiFi Arduino firmware
+- Implementation of any future protocols from Section 7
+- Changes to the DEJA server, IO firmware, or deploy scripts
+- Storybook stories for shared components (nice to have, not required)


### PR DESCRIPTION
## Summary

- 🧩 **Extract 10 shared guide components** into `components/guides/shared/` — FeatureCard, FeatureGrid, FeatureSection, FeatureCarousel, VideoPlaceholder, Callout, CommandBlock, Step, MdiIcon, BeforeYouStart
- 🔄 **Refactor all 4 existing guides** (Throttle, Cloud, Server, Getting Started) to use shared components, eliminating ~300+ lines of duplication
- 🔌 **New IO Guide** (`/guides/io`) — showcases DEJA IO as a full layout automation platform with architecture diagrams, protocol comparison cards, device cards, and deploy flow section
- 📝 **7 new IO MDX docs** — arduino-setup, pico-w-setup, command-reference, protocols, configuration, deploy, plus updated overview
- 🔗 **DocLink standardization** — ServerGuide and GettingStartedGuide now use the shared DocLink component for all doc references
- 🗺️ **Navigation updates** — IO and Server guides activated in header dropdown, sidebar, guides index, and homepage grid. Guides/Products nav buttons now link to /guides and /#products.
- 🎬 **Video walkthrough** as first section in all guides
- 🐛 **AnimateIn fix** — last-section fade-in on all pages now works correctly

## Test plan

- [ ] Visit `/guides` — IO guide card is active with fuchsia accent
- [ ] Visit `/guides/io` — all 6 sections render (hero, video, architecture, protocols, devices, docs)
- [ ] Visit `/guides/throttle` — shared components render identically to before
- [ ] Visit `/guides/cloud` — shared components render identically to before
- [ ] Visit `/guides/server` — DocLink components replace inline links, BeforeYouStart renders
- [ ] Visit `/guides/getting-started` — cyan Step/Callout colors, VideoPlaceholder added
- [ ] Visit `/guides/architecture` — last section fully fades in on scroll
- [ ] Click "Guides" in header nav — navigates to /guides, dropdown opens on hover
- [ ] Homepage GuidesGrid shows IO and Server as active (not "Soon")

🤖 Generated with [Claude Code](https://claude.com/claude-code)