### PR TITLE
🌍 chore(apps): bind vite dev servers to 0.0.0.0 for LAN access

### DIFF
--- a/apps/cloud/vite.config.ts
+++ b/apps/cloud/vite.config.ts
@@ -46,7 +46,8 @@ export default defineConfig({
   },
   server: {
     port: 3011,
-        
-    cors: true
+    // 🌍 Bind to 0.0.0.0 so phones/tablets on the same wifi can connect
+    host: true,
+    cors: true,
   },
 })

--- a/apps/monitor/vite.config.ts
+++ b/apps/monitor/vite.config.ts
@@ -45,8 +45,9 @@ export default defineConfig({
   },
   server: {
     port: 3031,
-        
+    // 🌍 Bind to 0.0.0.0 so phones/tablets on the same wifi can connect
+    host: true,
     // CORS configuration for development
-    cors: true
+    cors: true,
   },
 })

--- a/apps/throttle/vite.config.ts
+++ b/apps/throttle/vite.config.ts
@@ -43,6 +43,8 @@ export default defineConfig({
   },
   server: {
     port: 3041,
-    cors: true
+    // 🌍 Bind to 0.0.0.0 so phones/tablets on the same wifi can connect
+    host: true,
+    cors: true,
   },
 })


### PR DESCRIPTION
## Summary

Flips `server.host` to `true` in the cloud, throttle, and monitor Vite configs so the dev servers bind to `0.0.0.0` instead of `127.0.0.1`. This makes the running dev apps reachable from other devices on the same wifi network (phones, tablets, other laptops) using the Mac's LAN IP + port. 🚂📱

### Why

Previously Vite only listened on loopback, so testing the apps on a phone over the same wifi wasn't possible without extra tooling. Binding to all interfaces is the standard way to expose a dev server to the LAN and unblocks real-device testing for the throttle/cloud/monitor UIs.

### Changes

- `apps/cloud/vite.config.ts` — `host: true` + cleanup of stray whitespace
- `apps/throttle/vite.config.ts` — `host: true`
- `apps/monitor/vite.config.ts` — `host: true` + cleanup of stray whitespace

### How to use from a phone

1. Start the app(s): `pnpm --filter=deja-throttle dev` (etc.)
2. Get the Mac's LAN IP: `ipconfig getifaddr en0`
3. On the phone (same wifi), visit `http://<mac-ip>:3041` for throttle, `:3011` cloud, `:3031` monitor

> 💡 Pin the Mac's IP via a DHCP reservation in your router so the URL stays stable across reconnects.

## Test plan

- [ ] `pnpm --filter=deja-throttle dev` starts and prints both `Local:` and `Network:` URLs
- [ ] `pnpm --filter=deja-cloud dev` starts and prints both `Local:` and `Network:` URLs
- [ ] `pnpm --filter=deja-monitor dev` starts and prints both `Local:` and `Network:` URLs
- [ ] Load throttle from a phone on the same wifi using `http://<mac-lan-ip>:3041` — UI loads, Firebase/MQTT connect
- [ ] Load cloud from a phone using `:3011` — UI loads, Firebase data renders
- [ ] Load monitor from a phone using `:3031` — UI loads, data renders
- [ ] `pnpm build` still succeeds across all three apps (no regression from the config change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)