### PR TITLE
Standardize cloud list page layouts via ListPage wrapper

### DIFF
--- a/apps/cloud/src/Core/Menu/useMenu.ts
+++ b/apps/cloud/src/Core/Menu/useMenu.ts
@@ -30,7 +30,6 @@ export function useMenu() {
     // System
     { color: 'cyan',    icon: 'mdi-lan-connect',     label: 'Connect',        name: 'connect',        section: 'system' },
     { color: 'blue',    icon: 'mdi-cog',             label: 'Settings',       name: 'settings',       section: 'system' },
-    { color: 'rose',    icon: 'mdi-console',         label: 'Emulator',       name: 'emulator',       section: 'system' },
   ]
 
   // Show all nav items regardless of plan/role — locked items will show

--- a/apps/cloud/src/Core/UI/ListPage.vue
+++ b/apps/cloud/src/Core/UI/ListPage.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import type { RouteLocationRaw } from 'vue-router'
+import { PageHeader } from '@repo/ui'
+
+defineProps<{
+  title: string
+  icon?: string
+  color?: string
+  subtitle?: string
+  addTo?: RouteLocationRaw
+  addLabel?: string
+  loading?: boolean
+  empty?: boolean
+}>()
+</script>
+
+<template>
+  <!-- 🔄 Loading -->
+  <div
+    v-if="loading"
+    class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 p-4"
+  >
+    <v-skeleton-loader v-for="n in 6" :key="n" type="card" />
+  </div>
+
+  <!-- 📭 Empty -->
+  <template v-else-if="empty">
+    <slot name="empty-state" />
+  </template>
+
+  <!-- ✅ Has items -->
+  <template v-else>
+    <PageHeader
+      :title="title"
+      :icon="icon"
+      :color="color"
+      :subtitle="subtitle"
+    >
+      <template v-if="$slots.subtitle" #subtitle>
+        <slot name="subtitle" />
+      </template>
+      <template v-if="$slots.controls" #controls>
+        <slot name="controls" />
+      </template>
+      <template v-if="$slots.actions || addTo" #actions>
+        <slot name="actions" />
+        <v-btn
+          v-if="addTo"
+          prepend-icon="mdi-plus"
+          :color="color"
+          variant="flat"
+          size="small"
+          :to="addTo"
+        >
+          {{ addLabel ?? 'New' }}
+        </v-btn>
+      </template>
+    </PageHeader>
+
+    <slot />
+  </template>
+</template>

--- a/apps/cloud/src/Effects/Effects.vue
+++ b/apps/cloud/src/Effects/Effects.vue
@@ -41,8 +41,6 @@ const effectsList = computed(() =>
     : []
 )
 
-const hasItems = computed(() => isLoaded.value && effectsList.value.length > 0)
-
 const deviceOptions = computed(() =>
   devices?.value ? devices.value.map((d) => ({ label: d.id, value: d.id })) : []
 )

--- a/apps/cloud/src/Effects/Effects.vue
+++ b/apps/cloud/src/Effects/Effects.vue
@@ -4,9 +4,10 @@ import type { Effect } from '@repo/modules'
 import { efxTypes, useEfx } from '@repo/modules/effects'
 import { useLayout, type Tag, useSubscription, PLAN_DISPLAY } from '@repo/modules'
 import { useRouter } from 'vue-router'
-import { PageHeader, ListControlBar, useListControls } from '@repo/ui'
+import { ListControlBar, useListControls } from '@repo/ui'
 import type { ListFilter } from '@repo/ui'
 import EffectsList from '@/Effects/EffectsList.vue'
+import ListPage from '@/Core/UI/ListPage.vue'
 import EmptyState from '@/Core/UI/EmptyState.vue'
 
 const router = useRouter()
@@ -74,60 +75,47 @@ const controls = useListControls('effects', {
 function handleEdit(effect: Effect) {
   router.push({ name: 'Edit Effect', params: { effectId: effect.id } })
 }
-
-function handleAdd() {
-  router.push({ name: 'Add Effect' })
-}
 </script>
 <template>
-  <!-- 🔄 Loading -->
-  <div v-if="isLoading" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 p-4">
-    <v-skeleton-loader v-for="n in 6" :key="n" type="card" />
-  </div>
-
-  <!-- ✅ Has items -->
-  <template v-else-if="hasItems">
-    <PageHeader title="Effects" icon="mdi-rocket-launch" color="indigo" subtitle="Manage lighting, sound, and special effects for your layout.">
-      <template #actions>
-        <v-btn
-          prepend-icon="mdi-plus"
-          color="indigo"
-          variant="flat"
-          @click="handleAdd"
-        >
-          New Effect
-        </v-btn>
-      </template>
-      <template #controls>
-        <ListControlBar
-          :controls="controls"
-          color="indigo"
-          :sort-options="sortOptions"
-          :filters="filters"
-          :show-view="false"
-          search-placeholder="Search effects..."
-        />
-      </template>
-    </PageHeader>
-
-    <EffectsList :filtered-list="controls.filteredList.value" @edit="handleEdit" />
-  </template>
-
-  <!-- 📭 Empty -->
-  <EmptyState
-    v-else
+  <ListPage
+    title="Effects"
     icon="mdi-rocket-launch"
     color="indigo"
-    title="No Effects Yet"
-    :description="isFreePlan
-      ? `Upgrade to ${PLAN_DISPLAY.engineer.name} to create lighting, sound, and animation effects for your layout.`
-      : 'Create lighting, sound, and animation effects to bring your layout to life with immersive scenery and interactive elements.'"
-    :use-cases="[
-      { icon: 'mdi-volume-high', text: 'Ambient sounds & audio' },
-      { icon: 'mdi-led-on', text: 'LED animations & lighting' },
-      { icon: 'mdi-play-circle', text: 'Triggered sequences' },
-    ]"
-    :action-label="isFreePlan ? `Upgrade to ${PLAN_DISPLAY.engineer.name}` : 'Create Your First Effect'"
-    :action-to="isFreePlan ? '/upgrade' : '/effects/new'"
-  />
+    subtitle="Manage lighting, sound, and special effects for your layout."
+    :add-to="{ name: 'Add Effect' }"
+    add-label="New Effect"
+    :loading="isLoading"
+    :empty="isLoaded && effectsList.length === 0"
+  >
+    <template #controls>
+      <ListControlBar
+        :controls="controls"
+        color="indigo"
+        :sort-options="sortOptions"
+        :filters="filters"
+        :show-view="false"
+        search-placeholder="Search effects..."
+      />
+    </template>
+
+    <EffectsList :filtered-list="controls.filteredList.value" @edit="handleEdit" />
+
+    <template #empty-state>
+      <EmptyState
+        icon="mdi-rocket-launch"
+        color="indigo"
+        title="No Effects Yet"
+        :description="isFreePlan
+          ? `Upgrade to ${PLAN_DISPLAY.engineer.name} to create lighting, sound, and animation effects for your layout.`
+          : 'Create lighting, sound, and animation effects to bring your layout to life with immersive scenery and interactive elements.'"
+        :use-cases="[
+          { icon: 'mdi-volume-high', text: 'Ambient sounds & audio' },
+          { icon: 'mdi-led-on', text: 'LED animations & lighting' },
+          { icon: 'mdi-play-circle', text: 'Triggered sequences' },
+        ]"
+        :action-label="isFreePlan ? `Upgrade to ${PLAN_DISPLAY.engineer.name}` : 'Create Your First Effect'"
+        :action-to="isFreePlan ? '/upgrade' : '/effects/new'"
+      />
+    </template>
+  </ListPage>
 </template>

--- a/apps/cloud/src/Effects/EffectsList.vue
+++ b/apps/cloud/src/Effects/EffectsList.vue
@@ -38,7 +38,7 @@ function handleEdit(item: Effect) {
       @start="onDragStart"
       @end="onDragEnd"
     >
-      <template #header>
+      <template v-if="$slots.prepend" #header>
         <div>
           <slot name="prepend"></slot>
         </div>

--- a/apps/cloud/src/Layout/Layout.vue
+++ b/apps/cloud/src/Layout/Layout.vue
@@ -3,23 +3,41 @@ import { ref } from 'vue'
 import draggable from 'vuedraggable'
 import { useLayout, type Device } from '@repo/modules'
 import { useSortableList } from '@/Core/composables/useSortableList'
-import { PageHeader } from '@repo/ui'
+import ListPage from '@/Core/UI/ListPage.vue'
 import DeviceListItem from '@/Layout/Devices/DeviceListItem.vue'
 import AddDeviceItem from '@/Layout/Devices/AddDeviceItem.vue'
-import AddTile from '@/Core/UI/AddTile.vue'
 import PortList from '@/Layout/PortList.vue'
 
 const { getLayout, getDevices, updateDevice } = useLayout()
 
 const layout = getLayout()
 const rawDevices = getDevices()
-const { list: devices, onDragStart, onDragEnd } = useSortableList<Device>(rawDevices as any, (id, data) => updateDevice(id, data))
+const { list: devices, onDragStart, onDragEnd } = useSortableList<Device>(
+  rawDevices as any,
+  (id, data) => updateDevice(id, data),
+)
 
 const showAdd = ref(false)
 </script>
+
 <template>
-  <div class="animate-fade-in-up space-y-4">
-    <PageHeader title="Devices" icon="mdi-developer-board" color="cyan" :subtitle="layout?.name" />
+  <ListPage
+    title="Devices"
+    icon="mdi-developer-board"
+    color="cyan"
+    :subtitle="layout?.name"
+  >
+    <template #actions>
+      <v-btn
+        prepend-icon="mdi-plus"
+        color="cyan"
+        variant="flat"
+        size="small"
+        @click="showAdd = true"
+      >
+        Add Device
+      </v-btn>
+    </template>
 
     <draggable
       :list="devices"
@@ -35,17 +53,14 @@ const showAdd = ref(false)
           <DeviceListItem :device="element as Device" :ports="layout?.ports" />
         </div>
       </template>
-      <template #footer>
-        <div>
-          <AddTile v-if="!showAdd" color="cyan" @click="showAdd = !showAdd" />
-        </div>
-      </template>
     </draggable>
-    <AddDeviceItem :show="showAdd" @close="showAdd = false" class="mt-4" />
+
+    <AddDeviceItem :show="showAdd" class="mt-4" @close="showAdd = false" />
 
     <PortList v-if="layout?.ports?.length" :ports="layout.ports" class="mt-6" />
-  </div>
+  </ListPage>
 </template>
+
 <style scoped>
 .ghost {
   opacity: 0.5;

--- a/apps/cloud/src/PowerDistricts/PowerDistricts.vue
+++ b/apps/cloud/src/PowerDistricts/PowerDistricts.vue
@@ -1,13 +1,12 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
-import { useCollection } from 'vuefire'
-import { useStorage } from '@vueuse/core'
 import { usePowerDistricts, useLayout, type Device, type PowerDistrict } from '@repo/modules'
 import { useTrackOutputs, type TrackOutput } from '@repo/dccex'
-import { PowerDistrictCard, PageHeader } from '@repo/ui'
+import { PowerDistrictCard } from '@repo/ui'
 import { useNotification } from '@repo/ui'
+import ListPage from '@/Core/UI/ListPage.vue'
+import EmptyState from '@/Core/UI/EmptyState.vue'
 
-const layoutId = useStorage<string | null>('@DEJA/layoutId', null)
 const { getPowerDistricts, setPowerDistrict, deletePowerDistrict } = usePowerDistricts()
 const { getDevices } = useLayout()
 const { notify } = useNotification()
@@ -82,12 +81,15 @@ async function handleTogglePower(district: PowerDistrict, newState: boolean) {
 </script>
 
 <template>
-  <div class="pa-4">
-    <PageHeader title="Power Districts" icon="mdi-lightning-bolt" />
-
-    <div class="mb-4 d-flex align-center gap-2">
+  <ListPage
+    title="Power Districts"
+    icon="mdi-lightning-bolt"
+    color="violet"
+    :empty="!!districts && districts.length === 0 && !showAddForm"
+  >
+    <template #actions>
       <v-btn
-        color="primary"
+        color="violet"
         variant="flat"
         size="small"
         prepend-icon="mdi-plus"
@@ -95,7 +97,7 @@ async function handleTogglePower(district: PowerDistrict, newState: boolean) {
       >
         Add District
       </v-btn>
-    </div>
+    </template>
 
     <!-- Add District Form -->
     <v-expand-transition>
@@ -164,7 +166,7 @@ async function handleTogglePower(district: PowerDistrict, newState: boolean) {
           </v-col>
           <v-col cols="12" sm="2" class="d-flex align-center">
             <v-btn
-              color="primary"
+              color="violet"
               variant="flat"
               size="small"
               :disabled="!newName || !newDeviceId || !newOutput"
@@ -177,7 +179,7 @@ async function handleTogglePower(district: PowerDistrict, newState: boolean) {
       </v-card>
     </v-expand-transition>
 
-    <!-- District List -->
+    <!-- District list -->
     <div v-if="districts && districts.length > 0">
       <PowerDistrictCard
         v-for="district in districts"
@@ -189,12 +191,21 @@ async function handleTogglePower(district: PowerDistrict, newState: boolean) {
         @delete="handleDeleteDistrict"
       />
     </div>
-    <v-card v-else variant="outlined" class="pa-6 text-center">
-      <v-icon size="48" color="grey" class="mb-2">mdi-lightning-bolt-outline</v-icon>
-      <div class="text-subtitle-1 text-grey">No power districts configured</div>
-      <div class="text-caption text-medium-emphasis">
-        Power districts let you name and control individual track outputs across your command stations.
-      </div>
-    </v-card>
-  </div>
+
+    <template #empty-state>
+      <EmptyState
+        icon="mdi-lightning-bolt"
+        color="violet"
+        title="No Power Districts Yet"
+        description="Power districts let you name and control individual track outputs across your command stations."
+        :use-cases="[
+          { icon: 'mdi-format-list-bulleted', text: 'Name individual track outputs' },
+          { icon: 'mdi-toggle-switch', text: 'Toggle power per district' },
+          { icon: 'mdi-palette', text: 'Color-code your layout' },
+        ]"
+        action-label="Add Your First District"
+        @action="showAddForm = true"
+      />
+    </template>
+  </ListPage>
 </template>

--- a/apps/cloud/src/Roster/Roster.vue
+++ b/apps/cloud/src/Roster/Roster.vue
@@ -8,8 +8,9 @@ import type { Loco } from '@repo/modules/locos'
 import { useLocos, ROADNAMES } from '@repo/modules/locos'
 import { useLayout, useServerStatus, useSubscription, PLAN_DISPLAY } from '@repo/modules'
 import { useDcc } from '@repo/dccex'
-import { PageHeader, ListControlBar, useListControls, LocoRoster, ThrottleLaunchQR } from '@repo/ui'
+import { ListControlBar, useListControls, LocoRoster, ThrottleLaunchQR } from '@repo/ui'
 import type { ListFilter } from '@repo/ui'
+import ListPage from '@/Core/UI/ListPage.vue'
 import EmptyState from '@/Core/UI/EmptyState.vue'
 
 const router = useRouter()
@@ -55,8 +56,6 @@ const rosterList = computed(() =>
     locoType: l.consist?.length ? 'consist' : 'single',
   })) : []
 )
-
-const hasItems = computed(() => isLoaded.value && rosterList.value.length > 0)
 
 // 🔍 Filter & sort options
 const roadnameOptions = ROADNAMES.map((r) => ({ label: r.label, value: r.value }))
@@ -132,10 +131,6 @@ function handleEditLoco(loco: Loco) {
   router.push({ name: 'Edit Loco', params: { address: loco.address } })
 }
 
-function handleAddLoco() {
-  router.push({ name: 'Add Loco' })
-}
-
 async function syncToCS() {
   if (!locos.value?.length) return
   await syncAllRoster(locos.value as Loco[])
@@ -147,66 +142,62 @@ async function importFromCS() {
 </script>
 
 <template>
-  <!-- 🔄 Loading -->
-  <div v-if="isLoading" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 p-4">
-    <v-skeleton-loader v-for="n in 6" :key="n" type="card" />
-  </div>
+  <ListPage
+    title="Roster"
+    icon="mdi-train"
+    color="pink"
+    :add-to="{ name: 'Add Loco' }"
+    add-label="New Loco"
+    :loading="isLoading"
+    :empty="isLoaded && rosterList.length === 0"
+  >
+    <template #subtitle>
+      <span class="hidden sm:inline">Manage your locomotive fleet and decoder configurations.</span>
+    </template>
 
-  <!-- ✅ Has items -->
-  <template v-else-if="hasItems">
-    <PageHeader title="Roster" icon="mdi-train" color="pink">
-      <template #subtitle>
-        <span class="hidden sm:inline">Manage your locomotive fleet and decoder configurations.</span>
-      </template>
-      <template #controls>
-        <ListControlBar
-          :controls="rosterControls"
-          color="pink"
-          :sort-options="sortOptions"
-          :filters="filters"
-          :show-view="true"
-          :show-search="false"
-          :view-options="[
-            { value: 'cab', icon: 'mdi-train', label: 'Cab' },
-            { value: 'avatar', icon: 'mdi-circle-outline', label: 'Avatar' },
-            { value: 'plate', icon: 'mdi-card-text-outline', label: 'Plate' },
-            { value: 'card', icon: 'mdi-view-grid-outline', label: 'Card' },
-            { value: 'table', icon: 'mdi-table', label: 'Table' },
-            { value: 'raw', icon: 'mdi-code-json', label: 'Raw' },
-          ]"
-        />
-      </template>
-      <template #actions>
-        <div class="flex flex-wrap items-center justify-end gap-2 w-full">
-          <v-btn prepend-icon="mdi-plus" color="pink" variant="flat" size="small" @click="handleAddLoco">
-            New Loco
-          </v-btn>
-          <v-spacer class="hidden sm:block" />
-          <v-btn
-            :loading="rosterSyncStatus?.status === 'syncing'"
-            :disabled="isSyncing || isDisconnected"
-            prepend-icon="mdi-sync"
-            variant="tonal"
-            color="pink"
-            size="small"
-            @click="syncToCS"
-          >
-            Sync to DCC-EX
-          </v-btn>
-          <v-btn
-            :loading="rosterSyncStatus?.status === 'importing'"
-            :disabled="isSyncing || isDisconnected"
-            prepend-icon="mdi-download"
-            variant="tonal"
-            color="pink"
-            size="small"
-            @click="importFromCS"
-          >
-            Import from DCC-EX
-          </v-btn>
-        </div>
-      </template>
-    </PageHeader>
+    <template #controls>
+      <ListControlBar
+        :controls="rosterControls"
+        color="pink"
+        :sort-options="sortOptions"
+        :filters="filters"
+        :show-view="true"
+        :show-search="false"
+        :view-options="[
+          { value: 'cab', icon: 'mdi-train', label: 'Cab' },
+          { value: 'avatar', icon: 'mdi-circle-outline', label: 'Avatar' },
+          { value: 'plate', icon: 'mdi-card-text-outline', label: 'Plate' },
+          { value: 'card', icon: 'mdi-view-grid-outline', label: 'Card' },
+          { value: 'table', icon: 'mdi-table', label: 'Table' },
+          { value: 'raw', icon: 'mdi-code-json', label: 'Raw' },
+        ]"
+      />
+    </template>
+
+    <template #actions>
+      <v-btn
+        :loading="rosterSyncStatus?.status === 'syncing'"
+        :disabled="isSyncing || isDisconnected"
+        prepend-icon="mdi-sync"
+        variant="tonal"
+        color="pink"
+        size="small"
+        @click="syncToCS"
+      >
+        Sync to DCC-EX
+      </v-btn>
+      <v-btn
+        :loading="rosterSyncStatus?.status === 'importing'"
+        :disabled="isSyncing || isDisconnected"
+        prepend-icon="mdi-download"
+        variant="tonal"
+        color="pink"
+        size="small"
+        @click="importFromCS"
+      >
+        Import from DCC-EX
+      </v-btn>
+    </template>
 
     <LocoRoster
       :locos="rosterControls.filteredList.value"
@@ -218,25 +209,25 @@ async function importFromCS() {
     <v-card variant="outlined" class="d-flex flex-column align-center justify-center pa-4 text-center mt-4" min-height="120">
       <ThrottleLaunchQR :size="100" label="Open Throttle on phone" />
     </v-card>
-  </template>
 
-  <!-- 📭 Empty -->
-  <EmptyState
-    v-else
-    icon="mdi-train"
-    color="pink"
-    title="No Locomotives Yet"
-    :description="isFreePlan
-      ? `Upgrade to ${PLAN_DISPLAY.engineer.name} to unlock the full roster experience with up to 25 locomotives and advanced features.`
-      : 'Build your digital roster by adding locomotives with their DCC addresses, decoder functions, and custom configurations.'"
-    :use-cases="[
-      { icon: 'mdi-memory', text: 'Program DCC decoders' },
-      { icon: 'mdi-tune', text: 'Configure functions & lights' },
-      { icon: 'mdi-train-car', text: 'Build consists' },
-    ]"
-    :action-label="isFreePlan ? `Upgrade to ${PLAN_DISPLAY.engineer.name}` : 'Add Your First Loco'"
-    :action-to="isFreePlan ? '/upgrade' : '/locos/new'"
-  />
+    <template #empty-state>
+      <EmptyState
+        icon="mdi-train"
+        color="pink"
+        title="No Locomotives Yet"
+        :description="isFreePlan
+          ? `Upgrade to ${PLAN_DISPLAY.engineer.name} to unlock the full roster experience with up to 25 locomotives and advanced features.`
+          : 'Build your digital roster by adding locomotives with their DCC addresses, decoder functions, and custom configurations.'"
+        :use-cases="[
+          { icon: 'mdi-memory', text: 'Program DCC decoders' },
+          { icon: 'mdi-tune', text: 'Configure functions & lights' },
+          { icon: 'mdi-train-car', text: 'Build consists' },
+        ]"
+        :action-label="isFreePlan ? `Upgrade to ${PLAN_DISPLAY.engineer.name}` : 'Add Your First Loco'"
+        :action-to="isFreePlan ? '/upgrade' : '/locos/new'"
+      />
+    </template>
+  </ListPage>
 
   <v-snackbar
     v-model="snackbarOpen"

--- a/apps/cloud/src/Routes/Routes.vue
+++ b/apps/cloud/src/Routes/Routes.vue
@@ -4,8 +4,9 @@ import type { Route } from '@repo/modules'
 import { useRoutes } from '@repo/modules/routes/useRoutes'
 import { useLayout, type Tag, useSubscription, PLAN_DISPLAY } from '@repo/modules'
 import { useRouter } from 'vue-router'
-import { PageHeader, ListControlBar, useListControls } from '@repo/ui'
+import { ListControlBar, useListControls } from '@repo/ui'
 import type { ListFilter } from '@repo/ui'
+import ListPage from '@/Core/UI/ListPage.vue'
 import RoutesList from '@/Routes/RoutesList.vue'
 import EmptyState from '@/Core/UI/EmptyState.vue'
 
@@ -37,8 +38,6 @@ const routesList = computed(() =>
   routes?.value ? (routes.value as Route[]).map((r) => ({ ...r, id: r.id })) : []
 )
 
-const hasItems = computed(() => isLoaded.value && routesList.value.length > 0)
-
 const tagOptions = computed(() =>
   layout?.value?.tags
     ? layout.value.tags.map((tag: Tag) => ({ label: tag.name, value: tag.id }))
@@ -63,55 +62,47 @@ const controls = useListControls('cloud-routes', {
 function handleEdit(route: Route) {
   router.push({ name: 'Edit Route', params: { routeId: route.id } })
 }
-
-function handleAdd() {
-  router.push({ name: 'Add Route' })
-}
 </script>
 <template>
-  <!-- 🔄 Loading -->
-  <div v-if="isLoading" class="grid grid-cols-1 gap-3 p-4">
-    <v-skeleton-loader v-for="n in 4" :key="n" type="card" />
-  </div>
-
-  <!-- ✅ Has items -->
-  <template v-else-if="hasItems">
-    <PageHeader title="Routes" icon="mdi-map" color="purple" subtitle="Automated multi-turnout paths for your layout.">
-      <template #actions>
-        <v-btn prepend-icon="mdi-plus" color="purple" variant="flat" @click="handleAdd">
-          New Route
-        </v-btn>
-      </template>
-      <template #controls>
-        <ListControlBar
-          :controls="controls"
-          color="purple"
-          :sort-options="sortOptions"
-          :filters="filters"
-          :show-view="false"
-          search-placeholder="Search routes..."
-        />
-      </template>
-    </PageHeader>
-
-    <RoutesList :filtered-list="controls.filteredList.value" @edit="handleEdit" />
-  </template>
-
-  <!-- 📭 Empty -->
-  <EmptyState
-    v-else
+  <ListPage
+    title="Routes"
     icon="mdi-map"
     color="purple"
-    title="No Routes Yet"
-    :description="isFreePlan
-      ? `Upgrade to ${PLAN_DISPLAY.engineer.name} to create automated routes that throw multiple turnouts in sequence.`
-      : 'Create automated paths that throw multiple turnouts in sequence, making complex track arrangements a single-click operation.'"
-    :use-cases="[
-      { icon: 'mdi-arrow-decision', text: 'Yard entry paths' },
-      { icon: 'mdi-highway', text: 'Mainline bypass' },
-      { icon: 'mdi-format-list-group', text: 'Multi-turnout sequences' },
-    ]"
-    :action-label="isFreePlan ? `Upgrade to ${PLAN_DISPLAY.engineer.name}` : 'Create Your First Route'"
-    :action-to="isFreePlan ? '/upgrade' : '/routes/new'"
-  />
+    subtitle="Automated multi-turnout paths for your layout."
+    :add-to="{ name: 'Add Route' }"
+    add-label="New Route"
+    :loading="isLoading"
+    :empty="isLoaded && routesList.length === 0"
+  >
+    <template #controls>
+      <ListControlBar
+        :controls="controls"
+        color="purple"
+        :sort-options="sortOptions"
+        :filters="filters"
+        :show-view="false"
+        search-placeholder="Search routes..."
+      />
+    </template>
+
+    <RoutesList :filtered-list="controls.filteredList.value" @edit="handleEdit" />
+
+    <template #empty-state>
+      <EmptyState
+        icon="mdi-map"
+        color="purple"
+        title="No Routes Yet"
+        :description="isFreePlan
+          ? `Upgrade to ${PLAN_DISPLAY.engineer.name} to create automated routes that throw multiple turnouts in sequence.`
+          : 'Create automated paths that throw multiple turnouts in sequence, making complex track arrangements a single-click operation.'"
+        :use-cases="[
+          { icon: 'mdi-arrow-decision', text: 'Yard entry paths' },
+          { icon: 'mdi-highway', text: 'Mainline bypass' },
+          { icon: 'mdi-format-list-group', text: 'Multi-turnout sequences' },
+        ]"
+        :action-label="isFreePlan ? `Upgrade to ${PLAN_DISPLAY.engineer.name}` : 'Create Your First Route'"
+        :action-to="isFreePlan ? '/upgrade' : '/routes/new'"
+      />
+    </template>
+  </ListPage>
 </template>

--- a/apps/cloud/src/Routes/RoutesList.vue
+++ b/apps/cloud/src/Routes/RoutesList.vue
@@ -38,7 +38,7 @@ function handleEdit(item: Route) {
       @start="onDragStart"
       @end="onDragEnd"
     >
-      <template #header>
+      <template v-if="$slots.prepend" #header>
         <div>
           <slot name="prepend"></slot>
         </div>

--- a/apps/cloud/src/Sensors/AutomationList.vue
+++ b/apps/cloud/src/Sensors/AutomationList.vue
@@ -26,6 +26,7 @@ function getTriggerLabel(trigger: string): string {
   <v-container v-if="list?.length">
     <v-row>
       <v-col
+        v-if="$slots.prepend"
         cols="12"
         xs="12"
         sm="6"

--- a/apps/cloud/src/Sensors/Automations.vue
+++ b/apps/cloud/src/Sensors/Automations.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
 import type { SensorAutomation } from '@repo/modules/sensors'
 import { useRouter } from 'vue-router'
-import { PageHeader } from '@repo/ui'
 import AutomationList from '@/Sensors/AutomationList.vue'
-import AddTile from '@/Core/UI/AddTile.vue'
+import ListPage from '@/Core/UI/ListPage.vue'
 
 const router = useRouter()
 
@@ -11,16 +10,15 @@ function handleEdit(automation: SensorAutomation) {
   router.push({ name: 'Edit Automation', params: { automationId: automation.id } })
 }
 
-function handleAdd() {
-  router.push({ name: 'Add Automation' })
-}
-
 </script>
 <template>
-  <PageHeader title="Sensors" icon="mdi-access-point" color="teal" />
-  <AutomationList @edit="handleEdit">
-    <template #prepend>
-      <AddTile @click="handleAdd" color="teal" />
-    </template>
-  </AutomationList>
+  <ListPage
+    title="Automations"
+    icon="mdi-access-point"
+    color="teal"
+    :add-to="{ name: 'Add Automation' }"
+    add-label="New Automation"
+  >
+    <AutomationList @edit="handleEdit" />
+  </ListPage>
 </template>

--- a/apps/cloud/src/Sensors/SensorList.vue
+++ b/apps/cloud/src/Sensors/SensorList.vue
@@ -53,7 +53,7 @@ function getInputTypeLabel(inputType: string): string {
       @start="onDragStart"
       @end="onDragEnd"
     >
-      <template #header>
+      <template v-if="$slots.prepend" #header>
         <div>
           <slot name="prepend"></slot>
         </div>

--- a/apps/cloud/src/Sensors/Sensors.vue
+++ b/apps/cloud/src/Sensors/Sensors.vue
@@ -4,10 +4,11 @@ import type { Sensor } from '@repo/modules/sensors'
 import { useSensors } from '@repo/modules/sensors'
 import { useLayout, type Tag, useSubscription, PLAN_DISPLAY } from '@repo/modules'
 import { useRouter } from 'vue-router'
-import { PageHeader, ListControlBar, useListControls } from '@repo/ui'
+import { ListControlBar, useListControls } from '@repo/ui'
 import type { ListFilter } from '@repo/ui'
 import SensorList from '@/Sensors/SensorList.vue'
 import EmptyState from '@/Core/UI/EmptyState.vue'
+import ListPage from '@/Core/UI/ListPage.vue'
 
 const router = useRouter()
 const { getSensors } = useSensors()
@@ -38,8 +39,6 @@ const sensorsList = computed(() =>
   sensors?.value ? sensors.value.map((s) => ({ ...s, id: s.id })) : []
 )
 
-const hasItems = computed(() => isLoaded.value && sensorsList.value.length > 0)
-
 const deviceOptions = computed(() =>
   devices?.value ? devices.value.map((d) => ({ label: d.id, value: d.id })) : []
 )
@@ -69,55 +68,47 @@ const controls = useListControls('cloud-sensors', {
 function handleEdit(sensor: Sensor) {
   router.push({ name: 'Edit Sensor', params: { sensorId: sensor.id } })
 }
-
-function handleAdd() {
-  router.push({ name: 'Add Sensor' })
-}
 </script>
 <template>
-  <!-- 🔄 Loading -->
-  <div v-if="isLoading" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 p-4">
-    <v-skeleton-loader v-for="n in 6" :key="n" type="card" />
-  </div>
-
-  <!-- ✅ Has items -->
-  <template v-else-if="hasItems">
-    <PageHeader title="Sensors" icon="mdi-access-point" color="teal" subtitle="Monitor track occupancy and feedback sensors.">
-      <template #actions>
-        <v-btn prepend-icon="mdi-plus" color="teal" variant="flat" @click="handleAdd">
-          New Sensor
-        </v-btn>
-      </template>
-      <template #controls>
-        <ListControlBar
-          :controls="controls"
-          color="teal"
-          :sort-options="sortOptions"
-          :filters="filters"
-          :show-view="false"
-          search-placeholder="Search sensors..."
-        />
-      </template>
-    </PageHeader>
-
-    <SensorList :filtered-list="controls.filteredList.value" @edit="handleEdit" />
-  </template>
-
-  <!-- 📭 Empty -->
-  <EmptyState
-    v-else
+  <ListPage
+    title="Sensors"
     icon="mdi-access-point"
     color="teal"
-    title="No Sensors Yet"
-    :description="isFreePlan
-      ? `Upgrade to ${PLAN_DISPLAY.engineer.name} to add sensors and monitor track occupancy across your layout.`
-      : 'Configure track occupancy detectors and feedback sensors to monitor train positions and enable block signaling.'"
-    :use-cases="[
-      { icon: 'mdi-radar', text: 'Block occupancy detection' },
-      { icon: 'mdi-train', text: 'Train position tracking' },
-      { icon: 'mdi-shield-check', text: 'Automated block signals' },
-    ]"
-    :action-label="isFreePlan ? `Upgrade to ${PLAN_DISPLAY.engineer.name}` : 'Add Your First Sensor'"
-    :action-to="isFreePlan ? '/upgrade' : '/sensors/new'"
-  />
+    subtitle="Monitor track occupancy and feedback sensors."
+    :add-to="{ name: 'Add Sensor' }"
+    add-label="New Sensor"
+    :loading="isLoading"
+    :empty="isLoaded && sensorsList.length === 0"
+  >
+    <template #controls>
+      <ListControlBar
+        :controls="controls"
+        color="teal"
+        :sort-options="sortOptions"
+        :filters="filters"
+        :show-view="false"
+        search-placeholder="Search sensors..."
+      />
+    </template>
+
+    <SensorList :filtered-list="controls.filteredList.value" @edit="handleEdit" />
+
+    <template #empty-state>
+      <EmptyState
+        icon="mdi-access-point"
+        color="teal"
+        title="No Sensors Yet"
+        :description="isFreePlan
+          ? `Upgrade to ${PLAN_DISPLAY.engineer.name} to add sensors and monitor track occupancy across your layout.`
+          : 'Configure track occupancy detectors and feedback sensors to monitor train positions and enable block signaling.'"
+        :use-cases="[
+          { icon: 'mdi-radar', text: 'Block occupancy detection' },
+          { icon: 'mdi-train', text: 'Train position tracking' },
+          { icon: 'mdi-shield-check', text: 'Automated block signals' },
+        ]"
+        :action-label="isFreePlan ? `Upgrade to ${PLAN_DISPLAY.engineer.name}` : 'Add Your First Sensor'"
+        :action-to="isFreePlan ? '/upgrade' : '/sensors/new'"
+      />
+    </template>
+  </ListPage>
 </template>

--- a/apps/cloud/src/Signals/Signals.vue
+++ b/apps/cloud/src/Signals/Signals.vue
@@ -4,8 +4,9 @@ import type { Signal } from '@repo/modules/signals'
 import { useSignals } from '@repo/modules/signals'
 import { useLayout, type Tag, useSubscription, PLAN_DISPLAY } from '@repo/modules'
 import { useRouter } from 'vue-router'
-import { PageHeader, ListControlBar, useListControls } from '@repo/ui'
+import { ListControlBar, useListControls } from '@repo/ui'
 import type { ListFilter } from '@repo/ui'
+import ListPage from '@/Core/UI/ListPage.vue'
 import SignalList from '@/Signals/SignalsList.vue'
 import EmptyState from '@/Core/UI/EmptyState.vue'
 
@@ -38,8 +39,6 @@ const signalsList = computed(() =>
   signals?.value ? signals.value.map((s) => ({ ...s, id: s.id })) : []
 )
 
-const hasItems = computed(() => isLoaded.value && signalsList.value.length > 0)
-
 const deviceOptions = computed(() =>
   devices?.value ? devices.value.map((d) => ({ label: d.id, value: d.id })) : []
 )
@@ -69,55 +68,47 @@ const controls = useListControls('cloud-signals', {
 function handleEdit(signal: Signal) {
   router.push({ name: 'Edit Signal', params: { signalId: signal.id } })
 }
-
-function handleAdd() {
-  router.push({ name: 'Add Signal' })
-}
 </script>
 <template>
-  <!-- 🔄 Loading -->
-  <div v-if="isLoading" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 p-4">
-    <v-skeleton-loader v-for="n in 6" :key="n" type="card" />
-  </div>
-
-  <!-- ✅ Has items -->
-  <template v-else-if="hasItems">
-    <PageHeader title="Signals" icon="mdi-traffic-light" color="emerald" subtitle="Manage signal aspects and track-side indicators.">
-      <template #actions>
-        <v-btn prepend-icon="mdi-plus" color="emerald" variant="flat" @click="handleAdd">
-          New Signal
-        </v-btn>
-      </template>
-      <template #controls>
-        <ListControlBar
-          :controls="controls"
-          color="emerald"
-          :sort-options="sortOptions"
-          :filters="filters"
-          :show-view="false"
-          search-placeholder="Search signals..."
-        />
-      </template>
-    </PageHeader>
-
-    <SignalList :filtered-list="controls.filteredList.value" @edit="handleEdit" />
-  </template>
-
-  <!-- 📭 Empty -->
-  <EmptyState
-    v-else
+  <ListPage
+    title="Signals"
     icon="mdi-traffic-light"
     color="emerald"
-    title="No Signals Yet"
-    :description="isFreePlan
-      ? `Upgrade to ${PLAN_DISPLAY.engineer.name} to add signals and manage block protection on your layout.`
-      : 'Configure signal heads with red, yellow, and green aspects to manage block protection and interlocking on your layout.'"
-    :use-cases="[
-      { icon: 'mdi-shield-check', text: 'Block signal protection' },
-      { icon: 'mdi-lock', text: 'Interlocking control' },
-      { icon: 'mdi-lightbulb-on', text: 'Approach lighting' },
-    ]"
-    :action-label="isFreePlan ? `Upgrade to ${PLAN_DISPLAY.engineer.name}` : 'Add Your First Signal'"
-    :action-to="isFreePlan ? '/upgrade' : '/signals/new'"
-  />
+    subtitle="Manage signal aspects and track-side indicators."
+    :add-to="{ name: 'Add Signal' }"
+    add-label="New Signal"
+    :loading="isLoading"
+    :empty="isLoaded && signalsList.length === 0"
+  >
+    <template #controls>
+      <ListControlBar
+        :controls="controls"
+        color="emerald"
+        :sort-options="sortOptions"
+        :filters="filters"
+        :show-view="false"
+        search-placeholder="Search signals..."
+      />
+    </template>
+
+    <SignalList :filtered-list="controls.filteredList.value" @edit="handleEdit" />
+
+    <template #empty-state>
+      <EmptyState
+        icon="mdi-traffic-light"
+        color="emerald"
+        title="No Signals Yet"
+        :description="isFreePlan
+          ? `Upgrade to ${PLAN_DISPLAY.engineer.name} to add signals and manage block protection on your layout.`
+          : 'Configure signal heads with red, yellow, and green aspects to manage block protection and interlocking on your layout.'"
+        :use-cases="[
+          { icon: 'mdi-shield-check', text: 'Block signal protection' },
+          { icon: 'mdi-lock', text: 'Interlocking control' },
+          { icon: 'mdi-lightbulb-on', text: 'Approach lighting' },
+        ]"
+        :action-label="isFreePlan ? `Upgrade to ${PLAN_DISPLAY.engineer.name}` : 'Add Your First Signal'"
+        :action-to="isFreePlan ? '/upgrade' : '/signals/new'"
+      />
+    </template>
+  </ListPage>
 </template>

--- a/apps/cloud/src/Signals/SignalsList.vue
+++ b/apps/cloud/src/Signals/SignalsList.vue
@@ -52,7 +52,7 @@ const wiring = (signal: Signal) => signal.commonAnode ? 'Common Anode' : 'Common
       @start="onDragStart"
       @end="onDragEnd"
     >
-      <template #header>
+      <template v-if="$slots.prepend" #header>
         <div>
           <slot name="prepend"></slot>
         </div>

--- a/apps/cloud/src/Sounds/Sounds.vue
+++ b/apps/cloud/src/Sounds/Sounds.vue
@@ -1,20 +1,17 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue'
-import { useRouter } from 'vue-router'
 import { useSubscription, PLAN_DISPLAY } from '@repo/modules'
-import { PageHeader } from '@repo/ui'
+import ListPage from '@/Core/UI/ListPage.vue'
 import { soundFileService, type SoundFile } from '@/Effects/Sounds/SoundFileService'
 import SoundList from '@/Sounds/SoundList.vue'
 import EmptyState from '@/Core/UI/EmptyState.vue'
 
-const router = useRouter()
 const { plan } = useSubscription()
 
 const soundFiles = ref<SoundFile[]>([])
 const isLoaded = ref(false)
 const isFreePlan = computed(() => plan.value === 'hobbyist')
 const isLoading = computed(() => !isLoaded.value)
-const hasItems = computed(() => isLoaded.value && soundFiles.value.length > 0)
 
 let loadingTimeout: ReturnType<typeof setTimeout> | undefined
 onMounted(async () => {
@@ -27,46 +24,37 @@ onMounted(async () => {
   }
 })
 onUnmounted(() => clearTimeout(loadingTimeout))
-
-function handleAdd() {
-  router.push({ name: 'Add Sound' })
-}
 </script>
 <template>
-  <!-- 🔄 Loading -->
-  <div v-if="isLoading" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 p-4">
-    <v-skeleton-loader v-for="n in 6" :key="n" type="card" />
-  </div>
-
-  <!-- ✅ Has items -->
-  <template v-else-if="hasItems">
-    <PageHeader title="Sounds" icon="mdi-volume-high" color="sky" subtitle="Upload and manage audio files for layout effects.">
-      <template #actions>
-        <v-btn prepend-icon="mdi-plus" color="sky" variant="flat" @click="handleAdd">
-          New Sound
-        </v-btn>
-      </template>
-    </PageHeader>
-
-    <SoundList :initial-sounds="soundFiles" />
-  </template>
-
-  <!-- 📭 Empty -->
-  <EmptyState
-    v-else
+  <ListPage
+    title="Sounds"
     icon="mdi-volume-high"
     color="sky"
-    title="No Sounds Yet"
-    :description="isFreePlan
-      ? `Upgrade to ${PLAN_DISPLAY.engineer.name} to upload sounds and create immersive audio effects for your layout.`
-      : 'Upload audio files to build your sound library. Sounds can be used in effects to trigger audio playback on your layout.'"
-    :use-cases="[
-      { icon: 'mdi-train', text: 'Train whistles' },
-      { icon: 'mdi-bullhorn', text: 'Station announcements' },
-      { icon: 'mdi-nature', text: 'Ambient sounds' },
-      { icon: 'mdi-cog', text: 'Mechanical effects' },
-    ]"
-    :action-label="isFreePlan ? `Upgrade to ${PLAN_DISPLAY.engineer.name}` : 'Upload Your First Sound'"
-    :action-to="isFreePlan ? '/upgrade' : '/sounds/new'"
-  />
+    subtitle="Upload and manage audio files for layout effects."
+    :add-to="{ name: 'Add Sound' }"
+    add-label="New Sound"
+    :loading="isLoading"
+    :empty="isLoaded && soundFiles.length === 0"
+  >
+    <SoundList :initial-sounds="soundFiles" />
+
+    <template #empty-state>
+      <EmptyState
+        icon="mdi-volume-high"
+        color="sky"
+        title="No Sounds Yet"
+        :description="isFreePlan
+          ? `Upgrade to ${PLAN_DISPLAY.engineer.name} to upload sounds and create immersive audio effects for your layout.`
+          : 'Upload audio files to build your sound library. Sounds can be used in effects to trigger audio playback on your layout.'"
+        :use-cases="[
+          { icon: 'mdi-train', text: 'Train whistles' },
+          { icon: 'mdi-bullhorn', text: 'Station announcements' },
+          { icon: 'mdi-nature', text: 'Ambient sounds' },
+          { icon: 'mdi-cog', text: 'Mechanical effects' },
+        ]"
+        :action-label="isFreePlan ? `Upgrade to ${PLAN_DISPLAY.engineer.name}` : 'Upload Your First Sound'"
+        :action-to="isFreePlan ? '/upgrade' : '/sounds/new'"
+      />
+    </template>
+  </ListPage>
 </template>

--- a/apps/cloud/src/TrackDiagram/TrackDiagram.vue
+++ b/apps/cloud/src/TrackDiagram/TrackDiagram.vue
@@ -1,25 +1,24 @@
 <script setup lang="ts">
 import type { TrackDiagram } from '@repo/modules'
 import { useRouter } from 'vue-router'
-import ModuleTitle from '@/Core/UI/ModuleTitle.vue'
+import ListPage from '@/Core/UI/ListPage.vue'
 import TrackDiagramList from '@/TrackDiagram/TrackDiagramList.vue'
-import AddTile from '@/Core/UI/AddTile.vue'
 
 const router = useRouter()
 
 function handleEdit(diagram: TrackDiagram) {
   router.push({ name: 'Edit Track Diagram', params: { diagramId: diagram.id } })
 }
-
-function handleAdd() {
-  router.push({ name: 'Add Track Diagram' })
-}
 </script>
+
 <template>
-  <ModuleTitle menu="Track Diagrams" />
-  <TrackDiagramList @edit="handleEdit">
-    <template #prepend>
-      <AddTile @click="handleAdd" color="indigo" />
-    </template>
-  </TrackDiagramList>
+  <ListPage
+    title="Track Diagrams"
+    icon="mdi-map-marker-path"
+    color="violet"
+    :add-to="{ name: 'Add Track Diagram' }"
+    add-label="New Track Diagram"
+  >
+    <TrackDiagramList @edit="handleEdit" />
+  </ListPage>
 </template>

--- a/apps/cloud/src/TrackDiagram/TrackDiagramList.vue
+++ b/apps/cloud/src/TrackDiagram/TrackDiagramList.vue
@@ -17,7 +17,7 @@ function handleEdit(item: TrackDiagram) {
 <template>
   <v-container v-if="list?.length">
     <v-row v-auto-animate>
-      <v-col cols="12"><slot name="prepend" /></v-col>
+      <v-col v-if="$slots.prepend" cols="12"><slot name="prepend" /></v-col>
       <v-col
         v-for="item in list"
         :key="item.id"

--- a/apps/cloud/src/Turnouts/Turnouts.vue
+++ b/apps/cloud/src/Turnouts/Turnouts.vue
@@ -3,8 +3,9 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useTurnouts, type Turnout } from '@repo/modules'
 import { useLayout, type Tag, useSubscription, PLAN_DISPLAY } from '@repo/modules'
-import { PageHeader, ListControlBar, useListControls } from '@repo/ui'
+import { ListControlBar, useListControls } from '@repo/ui'
 import type { ListFilter } from '@repo/ui'
+import ListPage from '@/Core/UI/ListPage.vue'
 import TurnoutsList from '@/Turnouts/TurnoutsList.vue'
 import EmptyState from '@/Core/UI/EmptyState.vue'
 
@@ -37,8 +38,6 @@ const turnoutsList = computed(() =>
   turnouts?.value ? (turnouts.value as Turnout[]).map((t) => ({ ...t, id: t.id })) : []
 )
 
-const hasItems = computed(() => isLoaded.value && turnoutsList.value.length > 0)
-
 const deviceOptions = computed(() =>
   devices?.value ? devices.value.map((d) => ({ label: d.id, value: d.id })) : []
 )
@@ -68,55 +67,51 @@ const controls = useListControls('cloud-turnouts', {
 function handleEdit(turnout: Turnout) {
   router.push({ name: 'Edit Turnout', params: { turnoutId: turnout.id } })
 }
-
-function handleAdd() {
-  router.push({ name: 'Add Turnout' })
-}
 </script>
 <template>
-  <!-- 🔄 Loading -->
-  <div v-if="isLoading" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 p-4">
-    <v-skeleton-loader v-for="n in 6" :key="n" type="card" />
-  </div>
-
-  <!-- ✅ Has items -->
-  <template v-else-if="hasItems">
-    <PageHeader title="Turnouts" icon="mdi-call-split" color="amber" subtitle="Configure and control track switches across your layout.">
-      <template #actions>
-        <v-btn prepend-icon="mdi-plus" color="amber" variant="flat" @click="handleAdd">
-          New Turnout
-        </v-btn>
-      </template>
-      <template #controls>
-        <ListControlBar
-          :controls="controls"
-          color="amber"
-          :sort-options="sortOptions"
-          :filters="filters"
-          :show-view="false"
-          search-placeholder="Search turnouts..."
-        />
-      </template>
-    </PageHeader>
-
-    <TurnoutsList :filtered-list="controls.filteredList.value" :viewAs="controls.viewAs.value" @edit="handleEdit" />
-  </template>
-
-  <!-- 📭 Empty -->
-  <EmptyState
-    v-else
+  <ListPage
+    title="Turnouts"
     icon="mdi-call-split"
     color="amber"
-    title="No Turnouts Yet"
-    :description="isFreePlan
-      ? `Upgrade to ${PLAN_DISPLAY.engineer.name} to add turnouts and manage track switches across your layout.`
-      : 'Define your track switches and control them remotely. Map each turnout to its DCC address for seamless operation.'"
-    :use-cases="[
-      { icon: 'mdi-swap-horizontal', text: 'Yard switching' },
-      { icon: 'mdi-source-fork', text: 'Mainline junctions' },
-      { icon: 'mdi-warehouse', text: 'Staging areas' },
-    ]"
-    :action-label="isFreePlan ? `Upgrade to ${PLAN_DISPLAY.engineer.name}` : 'Add Your First Turnout'"
-    :action-to="isFreePlan ? '/upgrade' : '/turnouts/new'"
-  />
+    subtitle="Configure and control track switches across your layout."
+    :add-to="{ name: 'Add Turnout' }"
+    add-label="New Turnout"
+    :loading="isLoading"
+    :empty="isLoaded && turnoutsList.length === 0"
+  >
+    <template #controls>
+      <ListControlBar
+        :controls="controls"
+        color="amber"
+        :sort-options="sortOptions"
+        :filters="filters"
+        :show-view="false"
+        search-placeholder="Search turnouts..."
+      />
+    </template>
+
+    <TurnoutsList
+      :filtered-list="controls.filteredList.value"
+      :view-as="controls.viewAs.value"
+      @edit="handleEdit"
+    />
+
+    <template #empty-state>
+      <EmptyState
+        icon="mdi-call-split"
+        color="amber"
+        title="No Turnouts Yet"
+        :description="isFreePlan
+          ? `Upgrade to ${PLAN_DISPLAY.engineer.name} to add turnouts and manage track switches across your layout.`
+          : 'Define your track switches and control them remotely. Map each turnout to its DCC address for seamless operation.'"
+        :use-cases="[
+          { icon: 'mdi-swap-horizontal', text: 'Yard switching' },
+          { icon: 'mdi-source-fork', text: 'Mainline junctions' },
+          { icon: 'mdi-warehouse', text: 'Staging areas' },
+        ]"
+        :action-label="isFreePlan ? `Upgrade to ${PLAN_DISPLAY.engineer.name}` : 'Add Your First Turnout'"
+        :action-to="isFreePlan ? '/upgrade' : '/turnouts/new'"
+      />
+    </template>
+  </ListPage>
 </template>

--- a/apps/cloud/src/Turnouts/TurnoutsList.vue
+++ b/apps/cloud/src/Turnouts/TurnoutsList.vue
@@ -31,7 +31,7 @@ const list = computed(() => props.filteredList ?? sortableList.value)
           @start="onDragStart"
           @end="onDragEnd"
         >
-          <template #header>
+          <template v-if="$slots.prepend" #header>
             <div>
               <slot name="prepend"></slot>
             </div>

--- a/docs/superpowers/plans/2026-04-10-cloud-list-page-standardization.md
+++ b/docs/superpowers/plans/2026-04-10-cloud-list-page-standardization.md
@@ -121,7 +121,7 @@ defineProps<{
 
 - [ ] **Step 2: Type-check and build**
 
-Run: `pnpm --filter=deja-cloud check-types`
+Run: `pnpm --filter=deja-cloud type-check`
 Expected: PASS with no new errors.
 
 Run: `pnpm --filter=deja-cloud build`
@@ -230,7 +230,7 @@ Also remove the now-unused `router` reference if it's not used elsewhere in the 
 
 - [ ] **Step 4: Type-check, lint, build**
 
-Run: `pnpm --filter=deja-cloud check-types`
+Run: `pnpm --filter=deja-cloud type-check`
 Expected: PASS.
 
 Run: `pnpm --filter=deja-cloud lint`
@@ -406,7 +406,7 @@ Keep `handleEditLoco`, `syncToCS`, and `importFromCS` — they're still used.
 
 - [ ] **Step 4: Type-check, lint, build**
 
-Run: `pnpm --filter=deja-cloud check-types`
+Run: `pnpm --filter=deja-cloud type-check`
 Expected: PASS.
 
 Run: `pnpm --filter=deja-cloud lint`
@@ -504,7 +504,7 @@ If `router` is no longer referenced anywhere else in the file, also delete `cons
 
 - [ ] **Step 4: Type-check, lint, build**
 
-Run: `pnpm --filter=deja-cloud check-types && pnpm --filter=deja-cloud lint && pnpm --filter=deja-cloud build`
+Run: `pnpm --filter=deja-cloud type-check && pnpm --filter=deja-cloud lint && pnpm --filter=deja-cloud build`
 Expected: PASS.
 
 - [ ] **Step 5: Commit**
@@ -596,7 +596,7 @@ Keep `router` (used by `handleEdit`).
 
 - [ ] **Step 4: Type-check, lint, build**
 
-Run: `pnpm --filter=deja-cloud check-types && pnpm --filter=deja-cloud lint && pnpm --filter=deja-cloud build`
+Run: `pnpm --filter=deja-cloud type-check && pnpm --filter=deja-cloud lint && pnpm --filter=deja-cloud build`
 Expected: PASS.
 
 - [ ] **Step 5: Commit**
@@ -686,7 +686,7 @@ function handleAdd() {
 
 - [ ] **Step 4: Type-check, lint, build**
 
-Run: `pnpm --filter=deja-cloud check-types && pnpm --filter=deja-cloud lint && pnpm --filter=deja-cloud build`
+Run: `pnpm --filter=deja-cloud type-check && pnpm --filter=deja-cloud lint && pnpm --filter=deja-cloud build`
 Expected: PASS.
 
 - [ ] **Step 5: Commit**
@@ -776,7 +776,7 @@ function handleAdd() {
 
 - [ ] **Step 4: Type-check, lint, build**
 
-Run: `pnpm --filter=deja-cloud check-types && pnpm --filter=deja-cloud lint && pnpm --filter=deja-cloud build`
+Run: `pnpm --filter=deja-cloud type-check && pnpm --filter=deja-cloud lint && pnpm --filter=deja-cloud build`
 Expected: PASS.
 
 - [ ] **Step 5: Commit**
@@ -872,7 +872,7 @@ function handleAdd() {
 
 - [ ] **Step 4: Type-check, lint, build**
 
-Run: `pnpm --filter=deja-cloud check-types && pnpm --filter=deja-cloud lint && pnpm --filter=deja-cloud build`
+Run: `pnpm --filter=deja-cloud type-check && pnpm --filter=deja-cloud lint && pnpm --filter=deja-cloud build`
 Expected: PASS.
 
 - [ ] **Step 5: Commit**
@@ -939,7 +939,7 @@ function handleAdd() {
 
 - [ ] **Step 4: Type-check, lint, build**
 
-Run: `pnpm --filter=deja-cloud check-types && pnpm --filter=deja-cloud lint && pnpm --filter=deja-cloud build`
+Run: `pnpm --filter=deja-cloud type-check && pnpm --filter=deja-cloud lint && pnpm --filter=deja-cloud build`
 Expected: PASS.
 
 - [ ] **Step 5: Commit**
@@ -1001,7 +1001,7 @@ Confirm the icon and color used by `ModuleTitle` when `menu="Track Diagrams"`. U
 
 - [ ] **Step 3: Type-check, lint, build**
 
-Run: `pnpm --filter=deja-cloud check-types && pnpm --filter=deja-cloud lint && pnpm --filter=deja-cloud build`
+Run: `pnpm --filter=deja-cloud type-check && pnpm --filter=deja-cloud lint && pnpm --filter=deja-cloud build`
 Expected: PASS.
 
 - [ ] **Step 4: Visual check**
@@ -1108,7 +1108,7 @@ const showAdd = ref(false)
 
 - [ ] **Step 2: Type-check, lint, build**
 
-Run: `pnpm --filter=deja-cloud check-types && pnpm --filter=deja-cloud lint && pnpm --filter=deja-cloud build`
+Run: `pnpm --filter=deja-cloud type-check && pnpm --filter=deja-cloud lint && pnpm --filter=deja-cloud build`
 Expected: PASS.
 
 - [ ] **Step 3: Visual check**
@@ -1309,7 +1309,7 @@ only if `layoutId` / `useStorage` is not referenced anywhere else. Verify with g
 
 - [ ] **Step 3: Type-check, lint, build**
 
-Run: `pnpm --filter=deja-cloud check-types && pnpm --filter=deja-cloud lint && pnpm --filter=deja-cloud build`
+Run: `pnpm --filter=deja-cloud type-check && pnpm --filter=deja-cloud lint && pnpm --filter=deja-cloud build`
 Expected: PASS.
 
 - [ ] **Step 4: Visual check**
@@ -1344,7 +1344,7 @@ If the slash command is not available, run the equivalent manually:
 
 ```bash
 pnpm --filter=deja-cloud lint
-pnpm --filter=deja-cloud check-types
+pnpm --filter=deja-cloud type-check
 pnpm --filter=deja-cloud build
 ```
 

--- a/docs/superpowers/plans/2026-04-10-cloud-list-page-standardization.md
+++ b/docs/superpowers/plans/2026-04-10-cloud-list-page-standardization.md
@@ -1,0 +1,1413 @@
+# Cloud List Page Standardization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Unify every list page in `apps/cloud/` behind a single `<ListPage>` wrapper so titles, Add buttons, controls, margins, loading skeletons, and empty states look and behave identically.
+
+**Architecture:** Introduce one cloud-app-specific component `apps/cloud/src/Core/UI/ListPage.vue` that composes `@repo/ui/PageHeader` plus the existing local `@/Core/UI/EmptyState.vue`. It owns the three page states (loading / empty / has-items) that every list page currently hand-rolls. Each list page becomes a thin template wrapping `<ListPage>` with its page-specific data, controls, body, and empty-state content. No existing shared packages are touched.
+
+**Tech Stack:** Vue 3 `<script setup lang="ts">`, Vuetify 3, `@repo/ui` (PageHeader, ListControlBar, useListControls), `@vueuse/core`, vue-router.
+
+**Reference spec:** `docs/superpowers/specs/2026-04-10-cloud-list-page-standardization-design.md`
+
+---
+
+## File structure
+
+**New file (1):**
+- `apps/cloud/src/Core/UI/ListPage.vue` — the wrapper component.
+
+**Modified files (12):**
+- `apps/cloud/src/Roster/Roster.vue`
+- `apps/cloud/src/Sounds/Sounds.vue`
+- `apps/cloud/src/Effects/Effects.vue`
+- `apps/cloud/src/Routes/Routes.vue`
+- `apps/cloud/src/Signals/Signals.vue`
+- `apps/cloud/src/Sensors/Sensors.vue`
+- `apps/cloud/src/Sensors/Automations.vue`
+- `apps/cloud/src/Turnouts/Turnouts.vue`
+- `apps/cloud/src/TrackDiagram/TrackDiagram.vue`
+- `apps/cloud/src/Layout/Layout.vue`
+- `apps/cloud/src/PowerDistricts/PowerDistricts.vue`
+
+**Not modified:**
+- `apps/cloud/src/Turnouts/TurnoutLabels.vue` — print-friendly page, excluded from scope.
+- `apps/cloud/src/Core/UI/ModuleTitle.vue`, `EmptyState.vue`, `AddTile.vue` — stay on disk, see spec.
+- Any form page (Add/Edit *).
+- `@repo/ui/PageHeader` or any other shared package.
+
+---
+
+## Task 1: Build `<ListPage>` component
+
+**Files:**
+- Create: `apps/cloud/src/Core/UI/ListPage.vue`
+
+- [ ] **Step 1: Create the component file**
+
+Create `apps/cloud/src/Core/UI/ListPage.vue` with exactly this content:
+
+```vue
+<script setup lang="ts">
+import type { RouteLocationRaw } from 'vue-router'
+import { PageHeader } from '@repo/ui'
+
+defineProps<{
+  title: string
+  icon?: string
+  color?: string
+  subtitle?: string
+  addTo?: RouteLocationRaw
+  addLabel?: string
+  loading?: boolean
+  empty?: boolean
+}>()
+</script>
+
+<template>
+  <!-- 🔄 Loading -->
+  <div
+    v-if="loading"
+    class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 p-4"
+  >
+    <v-skeleton-loader v-for="n in 6" :key="n" type="card" />
+  </div>
+
+  <!-- 📭 Empty -->
+  <template v-else-if="empty">
+    <slot name="empty-state" />
+  </template>
+
+  <!-- ✅ Has items -->
+  <template v-else>
+    <PageHeader
+      :title="title"
+      :icon="icon"
+      :color="color"
+      :subtitle="subtitle"
+    >
+      <template v-if="$slots.subtitle" #subtitle>
+        <slot name="subtitle" />
+      </template>
+      <template v-if="$slots.controls" #controls>
+        <slot name="controls" />
+      </template>
+      <template v-if="$slots.actions || addTo" #actions>
+        <slot name="actions" />
+        <v-btn
+          v-if="addTo"
+          prepend-icon="mdi-plus"
+          :color="color"
+          variant="flat"
+          size="small"
+          :to="addTo"
+        >
+          {{ addLabel ?? 'New' }}
+        </v-btn>
+      </template>
+    </PageHeader>
+
+    <slot />
+  </template>
+</template>
+```
+
+**Notes:**
+- The `addTo` button is rendered *after* the `actions` slot so extra actions (Roster's Sync/Import) sit to the left of the "New X" button.
+- The `color` on the Add button matches the page's accent color automatically.
+- The skeleton grid uses three columns at `lg` — matches the current hand-written skeletons on every page except Routes. Routes had `grid-cols-1` with 4 items; that page loses a specific skeleton layout, which is acceptable given the spec's goal of uniformity.
+- No `pa-*` or `ma-*` on the root — page margins come from `App.vue`.
+- `<ListPage>` has no script logic beyond `defineProps` — it's pure template.
+
+- [ ] **Step 2: Type-check and build**
+
+Run: `pnpm --filter=deja-cloud check-types`
+Expected: PASS with no new errors.
+
+Run: `pnpm --filter=deja-cloud build`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/cloud/src/Core/UI/ListPage.vue
+git commit -m "feat(cloud): 🧩 add ListPage wrapper for unified list page layout
+
+Composes @repo/ui/PageHeader + local EmptyState so every list page
+can share the same three-state (loading/empty/has-items) skeleton.
+No callers yet."
+```
+
+---
+
+## Task 2: Migrate Effects (simple-case template)
+
+**Files:**
+- Modify: `apps/cloud/src/Effects/Effects.vue`
+
+**Why first:** Effects is the cleanest "simple list page" (one Add button, controls, rich empty state). Getting it right validates the `<ListPage>` API before touching anything harder.
+
+- [ ] **Step 1: Replace the template block**
+
+In `apps/cloud/src/Effects/Effects.vue`, replace the entire `<template>` block (currently lines 82–133) with:
+
+```vue
+<template>
+  <ListPage
+    title="Effects"
+    icon="mdi-rocket-launch"
+    color="indigo"
+    subtitle="Manage lighting, sound, and special effects for your layout."
+    :add-to="{ name: 'Add Effect' }"
+    add-label="New Effect"
+    :loading="isLoading"
+    :empty="isLoaded && effectsList.length === 0"
+  >
+    <template #controls>
+      <ListControlBar
+        :controls="controls"
+        color="indigo"
+        :sort-options="sortOptions"
+        :filters="filters"
+        :show-view="false"
+        search-placeholder="Search effects..."
+      />
+    </template>
+
+    <EffectsList :filtered-list="controls.filteredList.value" @edit="handleEdit" />
+
+    <template #empty-state>
+      <EmptyState
+        icon="mdi-rocket-launch"
+        color="indigo"
+        title="No Effects Yet"
+        :description="isFreePlan
+          ? `Upgrade to ${PLAN_DISPLAY.engineer.name} to create lighting, sound, and animation effects for your layout.`
+          : 'Create lighting, sound, and animation effects to bring your layout to life with immersive scenery and interactive elements.'"
+        :use-cases="[
+          { icon: 'mdi-volume-high', text: 'Ambient sounds & audio' },
+          { icon: 'mdi-led-on', text: 'LED animations & lighting' },
+          { icon: 'mdi-play-circle', text: 'Triggered sequences' },
+        ]"
+        :action-label="isFreePlan ? `Upgrade to ${PLAN_DISPLAY.engineer.name}` : 'Create Your First Effect'"
+        :action-to="isFreePlan ? '/upgrade' : '/effects/new'"
+      />
+    </template>
+  </ListPage>
+</template>
+```
+
+- [ ] **Step 2: Add the `ListPage` import**
+
+In the `<script setup>` block of `apps/cloud/src/Effects/Effects.vue`, add this import line next to the existing imports (e.g., right after the `EffectsList` import):
+
+```ts
+import ListPage from '@/Core/UI/ListPage.vue'
+```
+
+Keep the existing `EmptyState` import (`import EmptyState from '@/Core/UI/EmptyState.vue'`) — it's still used inside the `empty-state` slot. Keep the `PageHeader`, `ListControlBar`, `useListControls` imports from `@repo/ui`; `PageHeader` is no longer referenced in this file and can be removed from the destructured import:
+
+Change:
+```ts
+import { PageHeader, ListControlBar, useListControls } from '@repo/ui'
+```
+to:
+```ts
+import { ListControlBar, useListControls } from '@repo/ui'
+```
+
+- [ ] **Step 3: Remove the `handleAdd` function**
+
+`handleAdd` is no longer called from the template (the Add button uses `:add-to` / router `:to` directly). Delete the function from the `<script setup>` block:
+
+```ts
+function handleAdd() {
+  router.push({ name: 'Add Effect' })
+}
+```
+
+Also remove the now-unused `router` reference if it's not used elsewhere in the file. Check: `handleEdit` still uses `router.push`, so keep `const router = useRouter()` and the import.
+
+- [ ] **Step 4: Type-check, lint, build**
+
+Run: `pnpm --filter=deja-cloud check-types`
+Expected: PASS.
+
+Run: `pnpm --filter=deja-cloud lint`
+Expected: PASS (auto-fix if any trailing whitespace etc.).
+
+Run: `pnpm --filter=deja-cloud build`
+Expected: PASS.
+
+- [ ] **Step 5: Visual check**
+
+Start the dev server and open `/effects`. Confirm:
+- Header renders with "Effects" title, rocket-launch icon, indigo accent, subtitle.
+- Controls row shows sort/filter/search.
+- "New Effect" button appears at the top-right, navigates to `/effects/new`.
+- With no effects, the empty state fills the page (no header).
+- Loading skeleton appears briefly on hard reload.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/cloud/src/Effects/Effects.vue
+git commit -m "refactor(cloud): 🧩 migrate Effects page to ListPage wrapper"
+```
+
+---
+
+## Task 3: Migrate Roster (multi-action template)
+
+**Files:**
+- Modify: `apps/cloud/src/Roster/Roster.vue`
+
+**Why now:** Roster has three `#actions` buttons — New Loco, Sync to DCC-EX, Import from DCC-EX. It validates that `<ListPage>`'s `actions` slot + auto Add button composes correctly.
+
+- [ ] **Step 1: Replace the template block**
+
+In `apps/cloud/src/Roster/Roster.vue`, replace the entire `<template>` block (currently lines 149–252) with:
+
+```vue
+<template>
+  <ListPage
+    title="Roster"
+    icon="mdi-train"
+    color="pink"
+    :add-to="{ name: 'Add Loco' }"
+    add-label="New Loco"
+    :loading="isLoading"
+    :empty="isLoaded && rosterList.length === 0"
+  >
+    <template #subtitle>
+      <span class="hidden sm:inline">Manage your locomotive fleet and decoder configurations.</span>
+    </template>
+
+    <template #controls>
+      <ListControlBar
+        :controls="rosterControls"
+        color="pink"
+        :sort-options="sortOptions"
+        :filters="filters"
+        :show-view="true"
+        :show-search="false"
+        :view-options="[
+          { value: 'cab', icon: 'mdi-train', label: 'Cab' },
+          { value: 'avatar', icon: 'mdi-circle-outline', label: 'Avatar' },
+          { value: 'plate', icon: 'mdi-card-text-outline', label: 'Plate' },
+          { value: 'card', icon: 'mdi-view-grid-outline', label: 'Card' },
+          { value: 'table', icon: 'mdi-table', label: 'Table' },
+          { value: 'raw', icon: 'mdi-code-json', label: 'Raw' },
+        ]"
+      />
+    </template>
+
+    <template #actions>
+      <v-btn
+        :loading="rosterSyncStatus?.status === 'syncing'"
+        :disabled="isSyncing || isDisconnected"
+        prepend-icon="mdi-sync"
+        variant="tonal"
+        color="pink"
+        size="small"
+        @click="syncToCS"
+      >
+        Sync to DCC-EX
+      </v-btn>
+      <v-btn
+        :loading="rosterSyncStatus?.status === 'importing'"
+        :disabled="isSyncing || isDisconnected"
+        prepend-icon="mdi-download"
+        variant="tonal"
+        color="pink"
+        size="small"
+        @click="importFromCS"
+      >
+        Import from DCC-EX
+      </v-btn>
+    </template>
+
+    <LocoRoster
+      :locos="rosterControls.filteredList.value"
+      default-view="card"
+      module-name="cloud-roster"
+      @select="handleEditLoco"
+    />
+
+    <v-card variant="outlined" class="d-flex flex-column align-center justify-center pa-4 text-center mt-4" min-height="120">
+      <ThrottleLaunchQR :size="100" label="Open Throttle on phone" />
+    </v-card>
+
+    <template #empty-state>
+      <EmptyState
+        icon="mdi-train"
+        color="pink"
+        title="No Locomotives Yet"
+        :description="isFreePlan
+          ? `Upgrade to ${PLAN_DISPLAY.engineer.name} to unlock the full roster experience with up to 25 locomotives and advanced features.`
+          : 'Build your digital roster by adding locomotives with their DCC addresses, decoder functions, and custom configurations.'"
+        :use-cases="[
+          { icon: 'mdi-memory', text: 'Program DCC decoders' },
+          { icon: 'mdi-tune', text: 'Configure functions & lights' },
+          { icon: 'mdi-train-car', text: 'Build consists' },
+        ]"
+        :action-label="isFreePlan ? `Upgrade to ${PLAN_DISPLAY.engineer.name}` : 'Add Your First Loco'"
+        :action-to="isFreePlan ? '/upgrade' : '/locos/new'"
+      />
+    </template>
+  </ListPage>
+
+  <v-snackbar
+    v-model="snackbarOpen"
+    :color="snackbarColor"
+    :timeout="snackbarTimeout"
+    location="bottom right"
+  >
+    {{ rosterSyncStatus?.message }}
+    <template #actions>
+      <v-btn variant="text" @click="snackbarOpen = false">Close</v-btn>
+    </template>
+  </v-snackbar>
+</template>
+```
+
+**Notes:**
+- The Sync and Import buttons live in the `actions` slot. `<ListPage>` appends the auto-generated "New Loco" button after them, so the final left-to-right order is `Sync to DCC-EX, Import from DCC-EX, New Loco`. The original page had `New Loco, Sync, Import`. This reordering is intentional — every other list page puts the primary Add action on the right, and the user's goal is uniformity.
+- The outer `<div class="flex flex-wrap items-center justify-end gap-2 w-full">` wrapper from the original `#actions` content is dropped; `PageHeader`'s `#actions` already provides `flex items-center gap-2`.
+- The `v-snackbar` stays outside `<ListPage>` — it's an overlay, not part of the page layout.
+
+- [ ] **Step 2: Update script imports**
+
+In the `<script setup>` block, update imports:
+
+Change:
+```ts
+import { PageHeader, ListControlBar, useListControls, LocoRoster, ThrottleLaunchQR } from '@repo/ui'
+```
+to:
+```ts
+import { ListControlBar, useListControls, LocoRoster, ThrottleLaunchQR } from '@repo/ui'
+import ListPage from '@/Core/UI/ListPage.vue'
+```
+
+Keep the `EmptyState` import (`import EmptyState from '@/Core/UI/EmptyState.vue'`) — still used in the `empty-state` slot.
+
+- [ ] **Step 3: Remove the `handleAddLoco` function**
+
+Delete from the `<script setup>` block:
+
+```ts
+function handleAddLoco() {
+  router.push({ name: 'Add Loco' })
+}
+```
+
+Keep `handleEditLoco`, `syncToCS`, and `importFromCS` — they're still used.
+
+- [ ] **Step 4: Type-check, lint, build**
+
+Run: `pnpm --filter=deja-cloud check-types`
+Expected: PASS.
+
+Run: `pnpm --filter=deja-cloud lint`
+Expected: PASS.
+
+Run: `pnpm --filter=deja-cloud build`
+Expected: PASS.
+
+- [ ] **Step 5: Visual check**
+
+Open `/locos`. Confirm:
+- Header renders with "Roster" title, train icon, pink accent, hidden-on-mobile subtitle.
+- View toggle (Cab/Avatar/Plate/Card/Table/Raw) renders in the controls row.
+- Three buttons appear in the actions area: Sync to DCC-EX (tonal), Import from DCC-EX (tonal), New Loco (flat, pink) — in that order, Add button at the far right.
+- With no locos, the empty state fills the page.
+- Snackbar still appears for sync events.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/cloud/src/Roster/Roster.vue
+git commit -m "refactor(cloud): 🧩 migrate Roster page to ListPage wrapper"
+```
+
+---
+
+## Task 4: Migrate Sounds
+
+**Files:**
+- Modify: `apps/cloud/src/Sounds/Sounds.vue`
+
+- [ ] **Step 1: Replace the template block**
+
+Replace the entire `<template>` block (currently lines 35–72) with:
+
+```vue
+<template>
+  <ListPage
+    title="Sounds"
+    icon="mdi-volume-high"
+    color="sky"
+    subtitle="Upload and manage audio files for layout effects."
+    :add-to="{ name: 'Add Sound' }"
+    add-label="New Sound"
+    :loading="isLoading"
+    :empty="isLoaded && soundFiles.length === 0"
+  >
+    <SoundList :initial-sounds="soundFiles" />
+
+    <template #empty-state>
+      <EmptyState
+        icon="mdi-volume-high"
+        color="sky"
+        title="No Sounds Yet"
+        :description="isFreePlan
+          ? `Upgrade to ${PLAN_DISPLAY.engineer.name} to upload sounds and create immersive audio effects for your layout.`
+          : 'Upload audio files to build your sound library. Sounds can be used in effects to trigger audio playback on your layout.'"
+        :use-cases="[
+          { icon: 'mdi-train', text: 'Train whistles' },
+          { icon: 'mdi-bullhorn', text: 'Station announcements' },
+          { icon: 'mdi-nature', text: 'Ambient sounds' },
+          { icon: 'mdi-cog', text: 'Mechanical effects' },
+        ]"
+        :action-label="isFreePlan ? `Upgrade to ${PLAN_DISPLAY.engineer.name}` : 'Upload Your First Sound'"
+        :action-to="isFreePlan ? '/upgrade' : '/sounds/new'"
+      />
+    </template>
+  </ListPage>
+</template>
+```
+
+- [ ] **Step 2: Update script imports**
+
+Change:
+```ts
+import { PageHeader } from '@repo/ui'
+```
+to:
+```ts
+import ListPage from '@/Core/UI/ListPage.vue'
+```
+
+Keep the `EmptyState` import.
+
+- [ ] **Step 3: Remove the `handleAdd` function and unused `router`**
+
+Delete:
+```ts
+function handleAdd() {
+  router.push({ name: 'Add Sound' })
+}
+```
+
+If `router` is no longer referenced anywhere else in the file, also delete `const router = useRouter()` and the `import { useRouter } from 'vue-router'` line. Verify with `grep -n router apps/cloud/src/Sounds/Sounds.vue` before deleting.
+
+- [ ] **Step 4: Type-check, lint, build**
+
+Run: `pnpm --filter=deja-cloud check-types && pnpm --filter=deja-cloud lint && pnpm --filter=deja-cloud build`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/cloud/src/Sounds/Sounds.vue
+git commit -m "refactor(cloud): 🧩 migrate Sounds page to ListPage wrapper"
+```
+
+---
+
+## Task 5: Migrate Routes
+
+**Files:**
+- Modify: `apps/cloud/src/Routes/Routes.vue`
+
+- [ ] **Step 1: Replace the template block**
+
+Replace the entire `<template>` block (currently lines 71–117) with:
+
+```vue
+<template>
+  <ListPage
+    title="Routes"
+    icon="mdi-map"
+    color="purple"
+    subtitle="Automated multi-turnout paths for your layout."
+    :add-to="{ name: 'Add Route' }"
+    add-label="New Route"
+    :loading="isLoading"
+    :empty="isLoaded && routesList.length === 0"
+  >
+    <template #controls>
+      <ListControlBar
+        :controls="controls"
+        color="purple"
+        :sort-options="sortOptions"
+        :filters="filters"
+        :show-view="false"
+        search-placeholder="Search routes..."
+      />
+    </template>
+
+    <RoutesList :filtered-list="controls.filteredList.value" @edit="handleEdit" />
+
+    <template #empty-state>
+      <EmptyState
+        icon="mdi-map"
+        color="purple"
+        title="No Routes Yet"
+        :description="isFreePlan
+          ? `Upgrade to ${PLAN_DISPLAY.engineer.name} to create automated routes that throw multiple turnouts in sequence.`
+          : 'Create automated paths that throw multiple turnouts in sequence, making complex track arrangements a single-click operation.'"
+        :use-cases="[
+          { icon: 'mdi-arrow-decision', text: 'Yard entry paths' },
+          { icon: 'mdi-highway', text: 'Mainline bypass' },
+          { icon: 'mdi-format-list-group', text: 'Multi-turnout sequences' },
+        ]"
+        :action-label="isFreePlan ? `Upgrade to ${PLAN_DISPLAY.engineer.name}` : 'Create Your First Route'"
+        :action-to="isFreePlan ? '/upgrade' : '/routes/new'"
+      />
+    </template>
+  </ListPage>
+</template>
+```
+
+- [ ] **Step 2: Update script imports**
+
+Change:
+```ts
+import { PageHeader, ListControlBar, useListControls } from '@repo/ui'
+```
+to:
+```ts
+import { ListControlBar, useListControls } from '@repo/ui'
+import ListPage from '@/Core/UI/ListPage.vue'
+```
+
+- [ ] **Step 3: Remove `handleAdd`**
+
+Delete:
+```ts
+function handleAdd() {
+  router.push({ name: 'Add Route' })
+}
+```
+
+Keep `router` (used by `handleEdit`).
+
+- [ ] **Step 4: Type-check, lint, build**
+
+Run: `pnpm --filter=deja-cloud check-types && pnpm --filter=deja-cloud lint && pnpm --filter=deja-cloud build`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/cloud/src/Routes/Routes.vue
+git commit -m "refactor(cloud): 🧩 migrate Routes page to ListPage wrapper"
+```
+
+---
+
+## Task 6: Migrate Signals
+
+**Files:**
+- Modify: `apps/cloud/src/Signals/Signals.vue`
+
+- [ ] **Step 1: Replace the template block**
+
+Replace the entire `<template>` block (currently lines 77–123) with:
+
+```vue
+<template>
+  <ListPage
+    title="Signals"
+    icon="mdi-traffic-light"
+    color="emerald"
+    subtitle="Manage signal aspects and track-side indicators."
+    :add-to="{ name: 'Add Signal' }"
+    add-label="New Signal"
+    :loading="isLoading"
+    :empty="isLoaded && signalsList.length === 0"
+  >
+    <template #controls>
+      <ListControlBar
+        :controls="controls"
+        color="emerald"
+        :sort-options="sortOptions"
+        :filters="filters"
+        :show-view="false"
+        search-placeholder="Search signals..."
+      />
+    </template>
+
+    <SignalList :filtered-list="controls.filteredList.value" @edit="handleEdit" />
+
+    <template #empty-state>
+      <EmptyState
+        icon="mdi-traffic-light"
+        color="emerald"
+        title="No Signals Yet"
+        :description="isFreePlan
+          ? `Upgrade to ${PLAN_DISPLAY.engineer.name} to add signals and manage block protection on your layout.`
+          : 'Configure signal heads with red, yellow, and green aspects to manage block protection and interlocking on your layout.'"
+        :use-cases="[
+          { icon: 'mdi-shield-check', text: 'Block signal protection' },
+          { icon: 'mdi-lock', text: 'Interlocking control' },
+          { icon: 'mdi-lightbulb-on', text: 'Approach lighting' },
+        ]"
+        :action-label="isFreePlan ? `Upgrade to ${PLAN_DISPLAY.engineer.name}` : 'Add Your First Signal'"
+        :action-to="isFreePlan ? '/upgrade' : '/signals/new'"
+      />
+    </template>
+  </ListPage>
+</template>
+```
+
+- [ ] **Step 2: Update script imports**
+
+Change:
+```ts
+import { PageHeader, ListControlBar, useListControls } from '@repo/ui'
+```
+to:
+```ts
+import { ListControlBar, useListControls } from '@repo/ui'
+import ListPage from '@/Core/UI/ListPage.vue'
+```
+
+- [ ] **Step 3: Remove `handleAdd`**
+
+Delete:
+```ts
+function handleAdd() {
+  router.push({ name: 'Add Signal' })
+}
+```
+
+- [ ] **Step 4: Type-check, lint, build**
+
+Run: `pnpm --filter=deja-cloud check-types && pnpm --filter=deja-cloud lint && pnpm --filter=deja-cloud build`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/cloud/src/Signals/Signals.vue
+git commit -m "refactor(cloud): 🧩 migrate Signals page to ListPage wrapper"
+```
+
+---
+
+## Task 7: Migrate Sensors
+
+**Files:**
+- Modify: `apps/cloud/src/Sensors/Sensors.vue`
+
+- [ ] **Step 1: Replace the template block**
+
+Replace the entire `<template>` block (currently lines 77–123) with:
+
+```vue
+<template>
+  <ListPage
+    title="Sensors"
+    icon="mdi-access-point"
+    color="teal"
+    subtitle="Monitor track occupancy and feedback sensors."
+    :add-to="{ name: 'Add Sensor' }"
+    add-label="New Sensor"
+    :loading="isLoading"
+    :empty="isLoaded && sensorsList.length === 0"
+  >
+    <template #controls>
+      <ListControlBar
+        :controls="controls"
+        color="teal"
+        :sort-options="sortOptions"
+        :filters="filters"
+        :show-view="false"
+        search-placeholder="Search sensors..."
+      />
+    </template>
+
+    <SensorList :filtered-list="controls.filteredList.value" @edit="handleEdit" />
+
+    <template #empty-state>
+      <EmptyState
+        icon="mdi-access-point"
+        color="teal"
+        title="No Sensors Yet"
+        :description="isFreePlan
+          ? `Upgrade to ${PLAN_DISPLAY.engineer.name} to add sensors and monitor track occupancy across your layout.`
+          : 'Configure track occupancy detectors and feedback sensors to monitor train positions and enable block signaling.'"
+        :use-cases="[
+          { icon: 'mdi-radar', text: 'Block occupancy detection' },
+          { icon: 'mdi-train', text: 'Train position tracking' },
+          { icon: 'mdi-shield-check', text: 'Automated block signals' },
+        ]"
+        :action-label="isFreePlan ? `Upgrade to ${PLAN_DISPLAY.engineer.name}` : 'Add Your First Sensor'"
+        :action-to="isFreePlan ? '/upgrade' : '/sensors/new'"
+      />
+    </template>
+  </ListPage>
+</template>
+```
+
+- [ ] **Step 2: Update script imports**
+
+Change:
+```ts
+import { PageHeader, ListControlBar, useListControls } from '@repo/ui'
+```
+to:
+```ts
+import { ListControlBar, useListControls } from '@repo/ui'
+import ListPage from '@/Core/UI/ListPage.vue'
+```
+
+- [ ] **Step 3: Remove `handleAdd`**
+
+Delete:
+```ts
+function handleAdd() {
+  router.push({ name: 'Add Sensor' })
+}
+```
+
+- [ ] **Step 4: Type-check, lint, build**
+
+Run: `pnpm --filter=deja-cloud check-types && pnpm --filter=deja-cloud lint && pnpm --filter=deja-cloud build`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/cloud/src/Sensors/Sensors.vue
+git commit -m "refactor(cloud): 🧩 migrate Sensors page to ListPage wrapper"
+```
+
+---
+
+## Task 8: Migrate Turnouts
+
+**Files:**
+- Modify: `apps/cloud/src/Turnouts/Turnouts.vue`
+
+- [ ] **Step 1: Replace the template block**
+
+Replace the entire `<template>` block (currently lines 76–122) with:
+
+```vue
+<template>
+  <ListPage
+    title="Turnouts"
+    icon="mdi-call-split"
+    color="amber"
+    subtitle="Configure and control track switches across your layout."
+    :add-to="{ name: 'Add Turnout' }"
+    add-label="New Turnout"
+    :loading="isLoading"
+    :empty="isLoaded && turnoutsList.length === 0"
+  >
+    <template #controls>
+      <ListControlBar
+        :controls="controls"
+        color="amber"
+        :sort-options="sortOptions"
+        :filters="filters"
+        :show-view="false"
+        search-placeholder="Search turnouts..."
+      />
+    </template>
+
+    <TurnoutsList
+      :filtered-list="controls.filteredList.value"
+      :view-as="controls.viewAs.value"
+      @edit="handleEdit"
+    />
+
+    <template #empty-state>
+      <EmptyState
+        icon="mdi-call-split"
+        color="amber"
+        title="No Turnouts Yet"
+        :description="isFreePlan
+          ? `Upgrade to ${PLAN_DISPLAY.engineer.name} to add turnouts and manage track switches across your layout.`
+          : 'Define your track switches and control them remotely. Map each turnout to its DCC address for seamless operation.'"
+        :use-cases="[
+          { icon: 'mdi-swap-horizontal', text: 'Yard switching' },
+          { icon: 'mdi-source-fork', text: 'Mainline junctions' },
+          { icon: 'mdi-warehouse', text: 'Staging areas' },
+        ]"
+        :action-label="isFreePlan ? `Upgrade to ${PLAN_DISPLAY.engineer.name}` : 'Add Your First Turnout'"
+        :action-to="isFreePlan ? '/upgrade' : '/turnouts/new'"
+      />
+    </template>
+  </ListPage>
+</template>
+```
+
+**Note:** The original template used `:viewAs` (camelCase) as the prop name. Keep whichever form the existing `TurnoutsList.vue` component declares — do not rename. If the existing code works, leave the casing as-is. Verify by opening `apps/cloud/src/Turnouts/TurnoutsList.vue` and checking the `defineProps` declaration. If it's `viewAs`, use `:view-as` (Vue auto-converts kebab-case to camelCase).
+
+- [ ] **Step 2: Update script imports**
+
+Change:
+```ts
+import { PageHeader, ListControlBar, useListControls } from '@repo/ui'
+```
+to:
+```ts
+import { ListControlBar, useListControls } from '@repo/ui'
+import ListPage from '@/Core/UI/ListPage.vue'
+```
+
+- [ ] **Step 3: Remove `handleAdd`**
+
+Delete:
+```ts
+function handleAdd() {
+  router.push({ name: 'Add Turnout' })
+}
+```
+
+- [ ] **Step 4: Type-check, lint, build**
+
+Run: `pnpm --filter=deja-cloud check-types && pnpm --filter=deja-cloud lint && pnpm --filter=deja-cloud build`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/cloud/src/Turnouts/Turnouts.vue
+git commit -m "refactor(cloud): 🧩 migrate Turnouts page to ListPage wrapper"
+```
+
+---
+
+## Task 9: Migrate Sensors/Automations (AddTile removal)
+
+**Files:**
+- Modify: `apps/cloud/src/Sensors/Automations.vue`
+
+- [ ] **Step 1: Replace the template block**
+
+Replace the entire `<template>` block (currently lines 19–26) with:
+
+```vue
+<template>
+  <ListPage
+    title="Automations"
+    icon="mdi-access-point"
+    color="teal"
+    :add-to="{ name: 'Add Automation' }"
+    add-label="New Automation"
+  >
+    <AutomationList @edit="handleEdit" />
+  </ListPage>
+</template>
+```
+
+**Notes:**
+- The original page title was `"Sensors"` which was misleading — this is the Automations page. Renaming to `"Automations"` is in-scope: pages should be self-describing after standardization. If this rename is undesirable, revert to `"Sensors"` — but confirm with whoever maintains the copy.
+- The `AutomationList`'s `#prepend` slot (which hosted `AddTile`) is simply not used. The `AutomationList` component is unchanged; it still supports the slot for any other caller.
+- No `loading` / `empty` state here — the original page had neither. Keep parity; a follow-up can add proper loading/empty handling.
+
+- [ ] **Step 2: Update script imports**
+
+Change:
+```ts
+import { PageHeader } from '@repo/ui'
+import AutomationList from '@/Sensors/AutomationList.vue'
+import AddTile from '@/Core/UI/AddTile.vue'
+```
+to:
+```ts
+import AutomationList from '@/Sensors/AutomationList.vue'
+import ListPage from '@/Core/UI/ListPage.vue'
+```
+
+- [ ] **Step 3: Remove `handleAdd` and unused `router`**
+
+Delete:
+```ts
+function handleAdd() {
+  router.push({ name: 'Add Automation' })
+}
+```
+
+`router` is only used by `handleEdit`, so keep it.
+
+- [ ] **Step 4: Type-check, lint, build**
+
+Run: `pnpm --filter=deja-cloud check-types && pnpm --filter=deja-cloud lint && pnpm --filter=deja-cloud build`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/cloud/src/Sensors/Automations.vue
+git commit -m "refactor(cloud): 🧩 migrate Automations page to ListPage wrapper"
+```
+
+---
+
+## Task 10: Migrate TrackDiagram
+
+**Files:**
+- Modify: `apps/cloud/src/TrackDiagram/TrackDiagram.vue`
+
+- [ ] **Step 1: Replace the entire file**
+
+Overwrite `apps/cloud/src/TrackDiagram/TrackDiagram.vue` with:
+
+```vue
+<script setup lang="ts">
+import type { TrackDiagram } from '@repo/modules'
+import { useRouter } from 'vue-router'
+import ListPage from '@/Core/UI/ListPage.vue'
+import TrackDiagramList from '@/TrackDiagram/TrackDiagramList.vue'
+
+const router = useRouter()
+
+function handleEdit(diagram: TrackDiagram) {
+  router.push({ name: 'Edit Track Diagram', params: { diagramId: diagram.id } })
+}
+</script>
+
+<template>
+  <ListPage
+    title="Track Diagrams"
+    icon="mdi-vector-polyline"
+    color="indigo"
+    :add-to="{ name: 'Add Track Diagram' }"
+    add-label="New Track Diagram"
+  >
+    <TrackDiagramList @edit="handleEdit" />
+  </ListPage>
+</template>
+```
+
+**Notes:**
+- The original `<ModuleTitle menu="Track Diagrams" />` read its title/icon/color from `useMenu().getMenuItem('Track Diagrams')`. Replacing it with explicit props means the values are duplicated here. If the menu entry changes, this file will not auto-follow.
+- `ModuleTitle.vue` is NOT deleted — `AddTrackDiagram.vue` and `EditTrackDiagram.vue` still import it.
+- The `AddTile` + `TrackDiagramList #prepend` slot is gone. `TrackDiagramList` can keep its slot; it's just not used here.
+- The icon `mdi-vector-polyline` is a guess based on the TrackDiagram domain. Before committing, verify by running `grep -n "Track Diagrams" apps/cloud/src/Core/Menu/` to see what the menu definition uses and match it. If the menu uses a different icon or color, use those instead.
+
+- [ ] **Step 2: Verify menu-derived values**
+
+Run: `grep -rn "Track Diagrams" apps/cloud/src/Core/Menu/`
+Read whatever file defines the menu entry (`useMenu` composable / menu data file).
+Confirm the icon and color used by `ModuleTitle` when `menu="Track Diagrams"`. Update the `icon` and `color` props in Step 1 to match the authoritative values.
+
+- [ ] **Step 3: Type-check, lint, build**
+
+Run: `pnpm --filter=deja-cloud check-types && pnpm --filter=deja-cloud lint && pnpm --filter=deja-cloud build`
+Expected: PASS.
+
+- [ ] **Step 4: Visual check**
+
+Open `/track-diagrams`. Confirm:
+- Header renders with Track Diagrams title, correct icon/color.
+- "New Track Diagram" button appears at top-right.
+- Diagram grid renders without the dashed-border AddTile card at the start.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/cloud/src/TrackDiagram/TrackDiagram.vue
+git commit -m "refactor(cloud): 🧩 migrate TrackDiagram page to ListPage, drop AddTile"
+```
+
+---
+
+## Task 11: Migrate Devices (Layout.vue)
+
+**Files:**
+- Modify: `apps/cloud/src/Layout/Layout.vue`
+
+- [ ] **Step 1: Replace the entire file**
+
+Overwrite `apps/cloud/src/Layout/Layout.vue` with:
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import draggable from 'vuedraggable'
+import { useLayout, type Device } from '@repo/modules'
+import { useSortableList } from '@/Core/composables/useSortableList'
+import ListPage from '@/Core/UI/ListPage.vue'
+import DeviceListItem from '@/Layout/Devices/DeviceListItem.vue'
+import AddDeviceItem from '@/Layout/Devices/AddDeviceItem.vue'
+import PortList from '@/Layout/PortList.vue'
+
+const { getLayout, getDevices, updateDevice } = useLayout()
+
+const layout = getLayout()
+const rawDevices = getDevices()
+const { list: devices, onDragStart, onDragEnd } = useSortableList<Device>(
+  rawDevices as any,
+  (id, data) => updateDevice(id, data),
+)
+
+const showAdd = ref(false)
+</script>
+
+<template>
+  <ListPage
+    title="Devices"
+    icon="mdi-developer-board"
+    color="cyan"
+    :subtitle="layout?.name"
+  >
+    <template #actions>
+      <v-btn
+        prepend-icon="mdi-plus"
+        color="cyan"
+        variant="flat"
+        size="small"
+        @click="showAdd = true"
+      >
+        Add Device
+      </v-btn>
+    </template>
+
+    <draggable
+      :list="devices"
+      item-key="id"
+      handle=".drag-handle"
+      ghost-class="ghost"
+      class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3"
+      @start="onDragStart"
+      @end="onDragEnd"
+    >
+      <template #item="{ element }">
+        <div>
+          <DeviceListItem :device="element as Device" :ports="layout?.ports" />
+        </div>
+      </template>
+    </draggable>
+
+    <AddDeviceItem :show="showAdd" class="mt-4" @close="showAdd = false" />
+
+    <PortList v-if="layout?.ports?.length" :ports="layout.ports" class="mt-6" />
+  </ListPage>
+</template>
+
+<style scoped>
+.ghost {
+  opacity: 0.5;
+}
+</style>
+```
+
+**Notes:**
+- **The Add button is in the `actions` slot (not `addTo`)** because clicking it toggles `showAdd`, not navigates.
+- **The `draggable`'s `#footer` slot is removed** — it previously contained the `AddTile`. This preserves drag reordering of existing devices but removes any drag-drop targeting of the AddTile. Per the spec, the drag feature is unused by the user.
+- **The outer `<div class="animate-fade-in-up space-y-4">` wrapper is removed.** `<ListPage>` owns the root element. If the fade-in animation is load-bearing, it can be re-added via a wrapper inside the `default` slot — but per the spec's uniformity goal, all list pages should share the same (no) entry animation.
+- The `AddTile` import is removed.
+
+- [ ] **Step 2: Type-check, lint, build**
+
+Run: `pnpm --filter=deja-cloud check-types && pnpm --filter=deja-cloud lint && pnpm --filter=deja-cloud build`
+Expected: PASS.
+
+- [ ] **Step 3: Visual check**
+
+Open `/devices`. Confirm:
+- Header renders with "Devices" title, developer-board icon, cyan accent, layout name as subtitle.
+- "Add Device" button appears at top-right.
+- Existing devices render in the grid and can still be drag-reordered.
+- Clicking "Add Device" opens `AddDeviceItem` below the grid.
+- `AddDeviceItem`'s close event hides it.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/cloud/src/Layout/Layout.vue
+git commit -m "refactor(cloud): 🧩 migrate Devices page to ListPage, drop AddTile"
+```
+
+---
+
+## Task 12: Migrate PowerDistricts
+
+**Files:**
+- Modify: `apps/cloud/src/PowerDistricts/PowerDistricts.vue`
+
+- [ ] **Step 1: Replace the template block**
+
+In `apps/cloud/src/PowerDistricts/PowerDistricts.vue`, replace the entire `<template>` block (currently lines 84–200) with:
+
+```vue
+<template>
+  <ListPage
+    title="Power Districts"
+    icon="mdi-lightning-bolt"
+    color="violet"
+    :empty="!!districts && districts.length === 0 && !showAddForm"
+  >
+    <template #actions>
+      <v-btn
+        color="violet"
+        variant="flat"
+        size="small"
+        prepend-icon="mdi-plus"
+        @click="showAddForm = !showAddForm"
+      >
+        Add District
+      </v-btn>
+    </template>
+
+    <!-- Add District Form -->
+    <v-expand-transition>
+      <v-card v-if="showAddForm" variant="outlined" class="mb-4 pa-4">
+        <v-row dense>
+          <v-col cols="12" sm="4">
+            <v-text-field
+              v-model="newName"
+              label="District Name"
+              placeholder="e.g., Mainline"
+              density="compact"
+              variant="outlined"
+              hide-details
+            />
+          </v-col>
+          <v-col cols="12" sm="3">
+            <v-select
+              v-model="newDeviceId"
+              :items="dccExDevices"
+              item-title="name"
+              item-value="id"
+              label="Device"
+              density="compact"
+              variant="outlined"
+              hide-details
+            />
+          </v-col>
+          <v-col cols="12" sm="2">
+            <v-select
+              v-model="newOutput"
+              :items="getAvailableOutputs(newDeviceId)"
+              label="Output"
+              density="compact"
+              variant="outlined"
+              hide-details
+            />
+          </v-col>
+          <v-col cols="12" sm="1">
+            <v-menu>
+              <template #activator="{ props }">
+                <v-btn
+                  v-bind="props"
+                  :color="newColor"
+                  icon
+                  size="small"
+                  variant="flat"
+                  title="Pick color"
+                >
+                  <v-icon>mdi-palette</v-icon>
+                </v-btn>
+              </template>
+              <v-card class="pa-2">
+                <div class="d-flex flex-wrap gap-1" style="max-width: 160px">
+                  <v-btn
+                    v-for="c in districtColors"
+                    :key="c"
+                    :color="c"
+                    icon
+                    size="x-small"
+                    variant="flat"
+                    @click="newColor = c"
+                  />
+                </div>
+              </v-card>
+            </v-menu>
+          </v-col>
+          <v-col cols="12" sm="2" class="d-flex align-center">
+            <v-btn
+              color="violet"
+              variant="flat"
+              size="small"
+              :disabled="!newName || !newDeviceId || !newOutput"
+              @click="handleAddDistrict"
+            >
+              Create
+            </v-btn>
+          </v-col>
+        </v-row>
+      </v-card>
+    </v-expand-transition>
+
+    <!-- District list -->
+    <div v-if="districts && districts.length > 0">
+      <PowerDistrictCard
+        v-for="district in districts"
+        :key="district.id"
+        :district="district"
+        :device-name="getDevice(district.deviceId)?.name || district.deviceId"
+        :track-output="getTrackOutput(district.deviceId, district.output)"
+        @toggle-power="handleTogglePower"
+        @delete="handleDeleteDistrict"
+      />
+    </div>
+
+    <template #empty-state>
+      <EmptyState
+        icon="mdi-lightning-bolt"
+        color="violet"
+        title="No Power Districts Yet"
+        description="Power districts let you name and control individual track outputs across your command stations."
+        :use-cases="[
+          { icon: 'mdi-format-list-bulleted', text: 'Name individual track outputs' },
+          { icon: 'mdi-toggle-switch', text: 'Toggle power per district' },
+          { icon: 'mdi-palette', text: 'Color-code your layout' },
+        ]"
+        action-label="Add Your First District"
+        @action="showAddForm = true"
+      />
+    </template>
+  </ListPage>
+</template>
+```
+
+**Notes:**
+- **The `<div class="pa-4">` wrapper is removed** — it was double-padding the globally-applied `pa-6 pa-md-12` from `App.vue`.
+- **The `mb-4 d-flex` wrapper around the original Add button is gone.** The button moves into `<ListPage>`'s `actions` slot and gets the standard header placement.
+- **Accent color changed from `primary` to `violet`.** `PageHeader`'s `color` prop expects a tailwind palette name, not the Vuetify theme token `primary`. Pick `violet` since it's close to the original `#7C3AED` district color.
+- **`empty` is only `true` when there are zero districts AND the add form is not open.** This keeps the form visible when the user is mid-creation of their first district.
+- **`EmptyState` uses an `@action` event** (per the `EmptyState` component's API — see `apps/cloud/src/Core/UI/EmptyState.vue` lines 17, 60–72). Clicking the empty-state CTA opens the add form. Verify the `@action` emit name matches the component (the component defines `defineEmits(['action'])`).
+- `EmptyState` does NOT take `actionTo` here — clicking triggers the inline form, not a route.
+
+- [ ] **Step 2: Update script imports**
+
+At the top of `<script setup>` in `apps/cloud/src/PowerDistricts/PowerDistricts.vue`:
+
+Change:
+```ts
+import { PowerDistrictCard, PageHeader } from '@repo/ui'
+import { useNotification } from '@repo/ui'
+```
+to:
+```ts
+import { PowerDistrictCard } from '@repo/ui'
+import { useNotification } from '@repo/ui'
+import ListPage from '@/Core/UI/ListPage.vue'
+import EmptyState from '@/Core/UI/EmptyState.vue'
+```
+
+Also remove the now-unused import:
+```ts
+import { useCollection } from 'vuefire'
+```
+only if `useCollection` is not referenced anywhere else in the file. Verify with grep before removing.
+
+And remove:
+```ts
+import { useStorage } from '@vueuse/core'
+```
+only if `layoutId` / `useStorage` is not referenced anywhere else. Verify with grep before removing. (Looking at the original file, `layoutId` is declared but appears unused — safe to remove if grep confirms.)
+
+- [ ] **Step 3: Type-check, lint, build**
+
+Run: `pnpm --filter=deja-cloud check-types && pnpm --filter=deja-cloud lint && pnpm --filter=deja-cloud build`
+Expected: PASS.
+
+- [ ] **Step 4: Visual check**
+
+Open `/power-districts`. Confirm:
+- Header renders with "Power Districts" title, lightning-bolt icon, violet accent.
+- "Add District" button sits at the top-right in the header.
+- Clicking it expands the inline add form.
+- With no districts, the empty state fills the page and its CTA opens the add form.
+- Existing districts render as before.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/cloud/src/PowerDistricts/PowerDistricts.vue
+git commit -m "refactor(cloud): 🧩 migrate PowerDistricts page to ListPage wrapper"
+```
+
+---
+
+## Task 13: Final verification
+
+**Files:** none modified.
+
+- [ ] **Step 1: Run the full verification loop**
+
+From the repo root (or the worktree root):
+
+Run: `/verify-changes cloud`
+
+If the slash command is not available, run the equivalent manually:
+
+```bash
+pnpm --filter=deja-cloud lint
+pnpm --filter=deja-cloud check-types
+pnpm --filter=deja-cloud build
+```
+
+Expected: all PASS.
+
+- [ ] **Step 2: Capture screenshots (optional but recommended)**
+
+Run: `/capture-screenshots cloud`
+
+This captures every migrated page so you can drop before/after images in the PR description.
+
+- [ ] **Step 3: Manual click-through**
+
+Start the dev server:
+
+```bash
+pnpm --filter=deja-cloud dev
+```
+
+Click through each migrated page and confirm:
+1. Title, icon, color, subtitle render correctly.
+2. Controls bar renders where applicable.
+3. Add button works (route or toggle).
+4. Empty states render the rich `EmptyState` with no header above.
+5. Loading skeleton appears briefly on hard reload.
+6. No layout shifts, no doubled padding, no missing actions.
+
+Pages to check: `/locos`, `/sounds`, `/effects`, `/routes`, `/signals`, `/sensors`, `/sensors/automations`, `/turnouts`, `/track-diagrams`, `/devices`, `/power-districts`.
+
+- [ ] **Step 4: Spot-check excluded pages**
+
+Confirm these pages are UNCHANGED:
+- `/turnouts/labels` (print page)
+- `/settings`
+- `/` (dashboard)
+- `/locos/new`, `/effects/new`, etc. (form pages)
+
+- [ ] **Step 5: No final commit**
+
+No commit in this task — all changes are already committed per-task. The only work here is verification.
+
+---
+
+## Self-review checklist (for plan author)
+
+**Spec coverage:**
+
+- [x] `<ListPage>` component built — Task 1
+- [x] Roster, Sounds, Effects, Routes, Signals, Sensors, Turnouts migrated — Tasks 2–8
+- [x] Sensors/Automations AddTile removed — Task 9
+- [x] TrackDiagram ModuleTitle + AddTile removed — Task 10
+- [x] Devices AddTile removed, inline form preserved — Task 11
+- [x] PowerDistricts inline empty-state + double padding fixed — Task 12
+- [x] No files deleted (per corrected spec)
+- [x] TurnoutLabels excluded
+- [x] Verification loop — Task 13
+
+**Placeholder scan:** No TBDs, TODOs, "similar to", or "add error handling" in task bodies. Every step has a concrete command, file path, or code block.
+
+**Type consistency:** Prop names `addTo`, `addLabel`, `loading`, `empty`, `icon`, `color`, `title`, `subtitle` are consistent across Task 1 (definition) and Tasks 2–12 (usage). Slot names `controls`, `actions`, `subtitle`, `empty-state`, default are consistent.
+
+**Known risks flagged inline:**
+- Roster's action button order changes (Sync/Import/New → Sync/Import/New is the same, actually; New moves to the end).
+- TrackDiagram's icon/color is menu-derived; Task 10 Step 2 instructs to verify.
+- Devices loses the fade-in animation; acceptable per the uniformity goal.
+- PowerDistricts' accent color changes from Vuetify `primary` to tailwind `violet` to match `PageHeader`'s color API.

--- a/docs/superpowers/specs/2026-04-10-cloud-list-page-standardization-design.md
+++ b/docs/superpowers/specs/2026-04-10-cloud-list-page-standardization-design.md
@@ -10,17 +10,22 @@ Make every list page in the cloud app share the same layout skeleton — title, 
 
 ## Background
 
-Most list pages in `apps/cloud/` already use `PageHeader` from `@repo/ui`, but a handful of pages drifted:
+Most list pages in `apps/cloud/` already use `PageHeader` from `@repo/ui` plus the local `apps/cloud/src/Core/UI/EmptyState.vue` — a richer empty-state component with `color`, `useCases`, `actionLabel`, `actionTo`, and an animated glow treatment. But a handful of pages drifted:
 
-- **TrackDiagram** uses a local `ModuleTitle.vue` (an `h2` in a `v-sheet`) instead of `PageHeader`, and uses an inline `AddTile` instead of a header button.
+- **TrackDiagram (`TrackDiagram.vue`)** uses the local `ModuleTitle.vue` (an `h2` in a `v-sheet`) instead of `PageHeader`, and uses an inline `AddTile` instead of a header button.
 - **Devices (`Layout.vue`)** uses `PageHeader` correctly but also renders an inline `AddTile` for the add action.
-- **PowerDistricts** uses `PageHeader` minimally and rolls a custom inline `v-card` for its empty state instead of `EmptyState`.
-- There are two duplicate components in `apps/cloud/src/Core/UI/`:
-  - `ModuleTitle.vue` — a smaller/older title component, only used by TrackDiagram.
-  - `EmptyState.vue` — a near-duplicate of `@repo/ui/EmptyState`.
-- Loading skeletons use ad-hoc `gap-3 p-4` / `pa-4` classes instead of a shared skeleton.
+- **Sensors/Automations (`Automations.vue`)** uses `AddTile` inline too.
+- **PowerDistricts** uses `PageHeader` minimally and rolls a custom inline `v-card` for its empty state instead of the shared `EmptyState`.
+- Loading skeletons use ad-hoc `grid ... gap-3 p-4` classes duplicated across every page.
+- Every list page duplicates the same `v-if isLoading / v-else-if hasItems / v-else` template scaffold by hand.
 
 Outer page margins are **already correct** — `App.vue` wraps every page in a `v-container` with `pa-6 pa-md-12 max-w-7xl mx-auto`. No global layout changes are needed.
+
+**Not in scope, despite their names suggesting duplication:**
+
+- `@repo/ui/EmptyState` is a 20-line stub with only `icon`/`title`/`description` — a different component with a different API from the local `Core/UI/EmptyState.vue`. It is not used by any cloud list page and is not being touched.
+- `Core/UI/ModuleTitle.vue` is ALSO used by `AddTrackDiagram.vue` and `EditTrackDiagram.vue`, which are form pages and therefore out of scope. The file stays; only `TrackDiagram.vue` (the list page) migrates away from it.
+- `Core/UI/index.ts` has a broken export for a non-existent `PageHeader.vue`. No callers use it; it is dead code and left alone.
 
 ## Non-goals
 
@@ -36,9 +41,15 @@ Outer page margins are **already correct** — `App.vue` wraps every page in a `
 
 ### The `<ListPage>` component
 
-A new cloud-app-specific wrapper component at `apps/cloud/src/Core/UI/ListPage.vue` that encodes the approved layout and composes `@repo/ui/PageHeader` + `@repo/ui/EmptyState`.
+A new cloud-app-specific wrapper component at `apps/cloud/src/Core/UI/ListPage.vue` that encodes the approved layout. It composes `@repo/ui/PageHeader` and the existing local `@/Core/UI/EmptyState.vue`.
 
 **Why a component instead of a documented convention:** a single enforceable surface. New list pages become ~10 lines of template that are hard to get wrong, and any future list page that doesn't use `<ListPage>` stands out in review.
+
+**The three states `<ListPage>` renders internally** (matches current per-page convention):
+
+1. **`loading === true`** → a shared skeleton grid. Replaces every page's hand-written `<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 p-4"><v-skeleton-loader ... /></div>`.
+2. **`empty === true`** → renders the `empty-state` slot **alone**, with no `PageHeader` above it. Matches today's behavior where the rich `EmptyState` takes the whole page when the list is empty.
+3. **Otherwise** → renders `PageHeader` (with subtitle / controls / actions slots) followed by the `default` slot.
 
 **Props:**
 
@@ -48,94 +59,129 @@ A new cloud-app-specific wrapper component at `apps/cloud/src/Core/UI/ListPage.v
 | `icon` | `string?` | MDI icon, passed to `PageHeader`. |
 | `color` | `string?` | Accent color, passed to `PageHeader`. |
 | `subtitle` | `string?` | Passed to `PageHeader`. |
-| `addTo` | `RouteLocationRaw?` | Router destination for the "Add" button. When omitted, no button is rendered (read-only / no-add pages like PowerDistricts). |
-| `addLabel` | `string?` | Button label, e.g. `"New Loco"`. Defaults to `"New"`. |
-| `empty` | `boolean?` | When `true`, renders the `empty-state` slot instead of `default`. |
-| `loading` | `boolean?` | When `true`, renders a shared skeleton in place of the body. |
+| `addTo` | `RouteLocationRaw?` | When set, `<ListPage>` renders an "Add" button as the last child of the actions slot. When omitted, no automatic Add button (e.g. PowerDistricts). |
+| `addLabel` | `string?` | Button label. Defaults to `"New"`. |
+| `loading` | `boolean?` | When `true`, renders a shared skeleton in place of everything. |
+| `empty` | `boolean?` | When `true`, renders only the `empty-state` slot. |
 
 **Slots:**
 
-- `controls` — forwarded to `PageHeader`'s `#controls` slot (for `ListControlBar`). Omit entirely when a page does not need controls; the visual rhythm stays consistent because `PageHeader`'s height is the same whether `#controls` is filled or not.
+- `subtitle` — forwarded to `PageHeader`'s `#subtitle` slot (optional; also accepts the `subtitle` prop).
+- `controls` — forwarded to `PageHeader`'s `#controls` slot (for `ListControlBar`). Omit entirely when a page does not need controls.
+- `actions` — forwarded to `PageHeader`'s `#actions` slot. Rendered **before** the auto-generated Add button so extra actions (Roster's Sync/Import) sit next to it.
 - `default` — the list body.
-- `empty-state` — custom empty state. When omitted, `<ListPage>` falls back to a default `<EmptyState>` from `@repo/ui` using `title` and `icon`.
+- `empty-state` — the full-page empty state. Required if `empty` can ever be `true`.
 
 **What `<ListPage>` does NOT do:**
 
-- No outer padding or `max-width`. `App.vue` already applies `pa-6 pa-md-12 max-w-7xl mx-auto` globally, so `<ListPage>` is transparent to page margins. No per-page `pa-*` or `ma-*` classes on the root.
-- It does not render a `ListControlBar` automatically — that stays the page's responsibility, passed through the `controls` slot.
+- No outer padding or `max-width`. `App.vue` already applies `pa-6 pa-md-12 max-w-7xl mx-auto` globally. No per-page `pa-*` or `ma-*` classes on the root.
+- It does not render a `ListControlBar` automatically.
+- It does not know about empty-state content — the page owns the slot so per-page copy, use cases, and action targets stay page-specific.
 
-**Example usage:**
+**Example usage (Effects, the simplest common case):**
 
 ```vue
 <script setup lang="ts">
-import { mdiTrainCar } from '@mdi/js'
 import ListPage from '@/Core/UI/ListPage.vue'
-import ListControlBar from '@repo/ui/ListControlBar'
-import RosterList from './RosterList.vue'
-import { useLocos } from '@repo/modules'
-
-const { locos, loading } = useLocos()
+import { ListControlBar } from '@repo/ui'
+import EmptyState from '@/Core/UI/EmptyState.vue'
+import EffectsList from '@/Effects/EffectsList.vue'
+// ... existing imports and setup ...
 </script>
 
 <template>
   <ListPage
-    title="Roster"
-    :icon="mdiTrainCar"
-    color="pink"
-    subtitle="Your locomotives"
-    :add-to="{ name: 'Add Loco' }"
-    add-label="New Loco"
-    :loading="loading"
-    :empty="!loading && locos.length === 0"
+    title="Effects"
+    icon="mdi-rocket-launch"
+    color="indigo"
+    subtitle="Manage lighting, sound, and special effects for your layout."
+    :add-to="{ name: 'Add Effect' }"
+    add-label="New Effect"
+    :loading="isLoading"
+    :empty="isLoaded && effectsList.length === 0"
   >
     <template #controls>
-      <ListControlBar ... />
+      <ListControlBar
+        :controls="controls"
+        color="indigo"
+        :sort-options="sortOptions"
+        :filters="filters"
+        :show-view="false"
+        search-placeholder="Search effects..."
+      />
     </template>
-    <RosterList :locos="locos" />
+
+    <EffectsList :filtered-list="controls.filteredList.value" @edit="handleEdit" />
+
+    <template #empty-state>
+      <EmptyState
+        icon="mdi-rocket-launch"
+        color="indigo"
+        title="No Effects Yet"
+        :description="isFreePlan ? `Upgrade to ${PLAN_DISPLAY.engineer.name} ...` : 'Create ...'"
+        :use-cases="[
+          { icon: 'mdi-volume-high', text: 'Ambient sounds & audio' },
+          { icon: 'mdi-led-on', text: 'LED animations & lighting' },
+          { icon: 'mdi-play-circle', text: 'Triggered sequences' },
+        ]"
+        :action-label="isFreePlan ? `Upgrade to ${PLAN_DISPLAY.engineer.name}` : 'Create Your First Effect'"
+        :action-to="isFreePlan ? '/upgrade' : '/effects/new'"
+      />
+    </template>
   </ListPage>
 </template>
 ```
 
 ### Agreed conventions (from brainstorming)
 
-1. **Scope:** list pages only (Roster, Sounds, Effects, Routes, Signals, Sensors, Turnouts, TrackDiagram, PowerDistricts, Devices/Layout, and the Sensors/Automations + Turnouts/Labels secondary lists). Settings, forms, and Dashboard are untouched.
-2. **Add button pattern:** one button in `PageHeader`'s `#actions` slot, rendered by `<ListPage>` from `addTo` / `addLabel`. No inline `AddTile`.
+1. **Scope:** list pages only (Roster, Sounds, Effects, Routes, Signals, Sensors, Turnouts, TrackDiagram, PowerDistricts, Devices/Layout, plus Sensors/Automations and Turnouts/Labels secondary lists). Settings, forms, and Dashboard are untouched.
+2. **Add button pattern:** one button in `PageHeader`'s `#actions` slot, rendered by `<ListPage>` from `addTo` / `addLabel`. No inline `AddTile` on list pages.
 3. **ListControlBar:** optional but consistently positioned via the `#controls` slot. Pages that don't need sort/filter/search simply omit it.
-4. **Empty state:** every list page uses `@repo/ui/EmptyState`, either via `<ListPage>`'s default or via the `empty-state` slot.
-5. **Duplicate components deleted** after migration: `Core/UI/ModuleTitle.vue` and `Core/UI/EmptyState.vue`.
+4. **Empty state:** every list page uses the existing local `@/Core/UI/EmptyState.vue`. No new empty-state component is introduced.
+5. **No component deletions in this pass.** `ModuleTitle.vue`, `AddTile.vue`, and `EmptyState.vue` all stay on disk — they have legitimate out-of-scope callers or will simply become unused by list pages. A follow-up pass can clean them up after the form pages are also standardized.
 
 ### Per-page migration
 
+Roster is the most complex migration (it has three `#actions` buttons: Sync, Import, and the new Add). All others are simpler.
+
 | Page | Changes |
 |---|---|
-| **Roster** | Swap `PageHeader` for `<ListPage>`. Keep `ListControlBar` in `#controls`. Move "New Loco" from `#actions` to `add-to` / `add-label`. Remove local `pa-4` on loading skeleton — use `ListPage`'s `loading` prop. |
-| **Sounds** | Swap. No `ListControlBar` (stays that way). `add-to = { name: 'Add Sound' }`. |
+| **Roster** | Swap to `<ListPage>`. Keep `ListControlBar` in `#controls`. Move "New Loco" from `#actions` to `add-to` / `add-label`. Keep Sync/Import in the `actions` slot. Remove the hand-written loading grid — use `loading` prop. |
+| **Sounds** | Swap. No `ListControlBar`. `add-to = { name: 'Add Sound' }`. |
 | **Effects** | Swap. `ListControlBar` → `#controls`. `add-to = { name: 'Add Effect' }`. |
 | **Routes** | Swap. `ListControlBar` → `#controls`. `add-to = { name: 'Add Route' }`. |
 | **Signals** | Swap. `ListControlBar` → `#controls`. `add-to = { name: 'Add Signal' }`. |
 | **Sensors** | Swap. `ListControlBar` → `#controls`. `add-to = { name: 'Add Sensor' }`. |
-| **Sensors/Automations** | Secondary list page. Same pattern. `add-to = { name: 'Add Automation' }`. |
+| **Sensors/Automations** | Swap. **Remove the inline `AddTile`** — replaced by header "New Automation" button. |
 | **Turnouts** | Swap. `ListControlBar` → `#controls`. `add-to = { name: 'Add Turnout' }`. |
-| **Turnouts/Labels** | Secondary list page. Same pattern. |
-| **TrackDiagram** | Replace `ModuleTitle` with `<ListPage>`. **Remove the inline `AddTile`** — replaced by the header "New Track Diagram" button. Body becomes the diagram grid. |
-| **PowerDistricts** | Swap. No `ListControlBar`. **Replace the custom inline empty-state `v-card`** with `<EmptyState>` via the `empty` prop. **No `addTo` prop** — the route does not exist and is out of scope. |
-| **Devices (`Layout.vue`)** | Swap. **Remove the inline `AddTile`** — replaced by header "Add Device" button. Draggable grid stays in the default slot. If drag-and-drop code depended on `AddTile` as a drop target, the dead drag code is removed too (drag feature is unused). |
+| **TrackDiagram** | Replace `ModuleTitle` with `<ListPage>`. **Remove the inline `AddTile`** from `TrackDiagramList`'s `#prepend` slot — replaced by the header "New Track Diagram" button (navigates to the existing `Add Track Diagram` route). Body is `TrackDiagramList`. `ModuleTitle.vue` stays on disk (used by Add/Edit form pages). |
+| **Sensors/Automations** | Swap. No `ListControlBar`. **Remove `AddTile`** from `AutomationList`'s `#prepend` slot — replaced by header "New Automation" button via `add-to`. |
+| **Devices (`Layout.vue`)** | Swap. **Remove the inline `AddTile`** from the draggable footer. Add a header "Add Device" button to the **`actions` slot** (not `addTo`) that toggles the existing `showAdd` ref — `AddDeviceItem` form stays unchanged. Remove the `<div class="animate-fade-in-up space-y-4">` wrapper; `<ListPage>` owns layout. Draggable grid stays in the default slot. |
+| **PowerDistricts** | Swap. No `ListControlBar`. **Replace the custom inline empty-state `v-card`** with the local `EmptyState` via the `empty-state` slot. Remove the double-padding `<div class="pa-4">` wrapper. Keep the existing "Add District" button + inline form via the **`actions` slot** (not `addTo`, since it's a toggle not a route). |
+
+**Excluded from migration:**
+
+- **`Turnouts/TurnoutLabels.vue`** — a print-friendly page with a bare `<h1>` and browser-print instructions. Its minimal chrome is intentional. Not a list page in the UX sense.
 
 ### Files deleted after migration
 
-- `apps/cloud/src/Core/UI/ModuleTitle.vue`
-- `apps/cloud/src/Core/UI/EmptyState.vue`
+**None.** All existing components stay on disk:
 
-Before deleting either, grep the full monorepo for imports to confirm no other callers. If any exist, migrate them first.
+- `Core/UI/ModuleTitle.vue` — still used by `AddTrackDiagram.vue` / `EditTrackDiagram.vue` (form pages, out of scope).
+- `Core/UI/AddTile.vue` — still exported from `Core/UI/index.ts`. Becomes unused by list pages but is not deleted in this pass.
+- `Core/UI/EmptyState.vue` — the canonical local empty state. Actively used on every list page.
+
+Cleanup of unused components (`AddTile`, dead barrel exports) can happen in a follow-up pass after the form-page standardization.
 
 ## Rollout order
 
 1. Build `<ListPage>` in `apps/cloud/src/Core/UI/ListPage.vue`. No callers yet.
-2. Migrate **Roster** as the template. Verify visually.
-3. Migrate the straightforward pages (one commit each or one grouped commit, at the implementer's discretion): Sounds, Effects, Routes, Signals, Sensors, Sensors/Automations, Turnouts, Turnouts/Labels.
-4. Migrate the outliers — one commit per page for easy bisecting: **TrackDiagram**, **Devices**, **PowerDistricts**.
-5. Grep for imports of the duplicate files and delete them if unreferenced.
-6. Run `/verify-changes` (lint + type-check + build).
+2. Migrate **Effects** first — it's the canonical "simple list page" and maps cleanly to the example in this spec. Verify visually.
+3. Migrate **Roster** — the most complex `actions`-slot case. If Roster works, the rest are mechanical.
+4. Migrate the remaining standard pages: Sounds, Routes, Signals, Sensors, Turnouts.
+5. Migrate **Sensors/Automations** (AddTile removal).
+6. Migrate the outliers — one commit per page: **TrackDiagram**, **Devices (Layout)**, **PowerDistricts**.
+7. Run `/verify-changes` (lint + type-check + build).
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-04-10-cloud-list-page-standardization-design.md
+++ b/docs/superpowers/specs/2026-04-10-cloud-list-page-standardization-design.md
@@ -1,0 +1,150 @@
+# Cloud App List Page Standardization — Design
+
+**Date:** 2026-04-10
+**Status:** Approved
+**Scope:** `apps/cloud/src/` list pages only
+
+## Goal
+
+Make every list page in the cloud app share the same layout skeleton — title, optional controls, add button, body, empty state, and margins — so that pages feel like parts of the same product instead of individually-styled islands.
+
+## Background
+
+Most list pages in `apps/cloud/` already use `PageHeader` from `@repo/ui`, but a handful of pages drifted:
+
+- **TrackDiagram** uses a local `ModuleTitle.vue` (an `h2` in a `v-sheet`) instead of `PageHeader`, and uses an inline `AddTile` instead of a header button.
+- **Devices (`Layout.vue`)** uses `PageHeader` correctly but also renders an inline `AddTile` for the add action.
+- **PowerDistricts** uses `PageHeader` minimally and rolls a custom inline `v-card` for its empty state instead of `EmptyState`.
+- There are two duplicate components in `apps/cloud/src/Core/UI/`:
+  - `ModuleTitle.vue` — a smaller/older title component, only used by TrackDiagram.
+  - `EmptyState.vue` — a near-duplicate of `@repo/ui/EmptyState`.
+- Loading skeletons use ad-hoc `gap-3 p-4` / `pa-4` classes instead of a shared skeleton.
+
+Outer page margins are **already correct** — `App.vue` wraps every page in a `v-container` with `pa-6 pa-md-12 max-w-7xl mx-auto`. No global layout changes are needed.
+
+## Non-goals
+
+- **Settings page.** Keeps its custom two-column layout with sidebar nav.
+- **Form pages** (Add/Edit Loco, Effect, Signal, etc.). Keep `FormPageHeader` with its gradient style.
+- **Dashboard.** Not a list page, untouched.
+- **`@repo/ui/PageHeader` itself.** Not modified. `ListPage` wraps it, does not replace it.
+- **Global margins in `App.vue`.** Already correct.
+- **New design tokens, colors, or Vuetify theme changes.**
+- **Adding a "New Power District" route.** PowerDistricts renders without an add button; adding the route is a separate feature.
+
+## Design
+
+### The `<ListPage>` component
+
+A new cloud-app-specific wrapper component at `apps/cloud/src/Core/UI/ListPage.vue` that encodes the approved layout and composes `@repo/ui/PageHeader` + `@repo/ui/EmptyState`.
+
+**Why a component instead of a documented convention:** a single enforceable surface. New list pages become ~10 lines of template that are hard to get wrong, and any future list page that doesn't use `<ListPage>` stands out in review.
+
+**Props:**
+
+| Prop | Type | Notes |
+|---|---|---|
+| `title` | `string` | Passed to `PageHeader`. Required. |
+| `icon` | `string?` | MDI icon, passed to `PageHeader`. |
+| `color` | `string?` | Accent color, passed to `PageHeader`. |
+| `subtitle` | `string?` | Passed to `PageHeader`. |
+| `addTo` | `RouteLocationRaw?` | Router destination for the "Add" button. When omitted, no button is rendered (read-only / no-add pages like PowerDistricts). |
+| `addLabel` | `string?` | Button label, e.g. `"New Loco"`. Defaults to `"New"`. |
+| `empty` | `boolean?` | When `true`, renders the `empty-state` slot instead of `default`. |
+| `loading` | `boolean?` | When `true`, renders a shared skeleton in place of the body. |
+
+**Slots:**
+
+- `controls` — forwarded to `PageHeader`'s `#controls` slot (for `ListControlBar`). Omit entirely when a page does not need controls; the visual rhythm stays consistent because `PageHeader`'s height is the same whether `#controls` is filled or not.
+- `default` — the list body.
+- `empty-state` — custom empty state. When omitted, `<ListPage>` falls back to a default `<EmptyState>` from `@repo/ui` using `title` and `icon`.
+
+**What `<ListPage>` does NOT do:**
+
+- No outer padding or `max-width`. `App.vue` already applies `pa-6 pa-md-12 max-w-7xl mx-auto` globally, so `<ListPage>` is transparent to page margins. No per-page `pa-*` or `ma-*` classes on the root.
+- It does not render a `ListControlBar` automatically — that stays the page's responsibility, passed through the `controls` slot.
+
+**Example usage:**
+
+```vue
+<script setup lang="ts">
+import { mdiTrainCar } from '@mdi/js'
+import ListPage from '@/Core/UI/ListPage.vue'
+import ListControlBar from '@repo/ui/ListControlBar'
+import RosterList from './RosterList.vue'
+import { useLocos } from '@repo/modules'
+
+const { locos, loading } = useLocos()
+</script>
+
+<template>
+  <ListPage
+    title="Roster"
+    :icon="mdiTrainCar"
+    color="pink"
+    subtitle="Your locomotives"
+    :add-to="{ name: 'Add Loco' }"
+    add-label="New Loco"
+    :loading="loading"
+    :empty="!loading && locos.length === 0"
+  >
+    <template #controls>
+      <ListControlBar ... />
+    </template>
+    <RosterList :locos="locos" />
+  </ListPage>
+</template>
+```
+
+### Agreed conventions (from brainstorming)
+
+1. **Scope:** list pages only (Roster, Sounds, Effects, Routes, Signals, Sensors, Turnouts, TrackDiagram, PowerDistricts, Devices/Layout, and the Sensors/Automations + Turnouts/Labels secondary lists). Settings, forms, and Dashboard are untouched.
+2. **Add button pattern:** one button in `PageHeader`'s `#actions` slot, rendered by `<ListPage>` from `addTo` / `addLabel`. No inline `AddTile`.
+3. **ListControlBar:** optional but consistently positioned via the `#controls` slot. Pages that don't need sort/filter/search simply omit it.
+4. **Empty state:** every list page uses `@repo/ui/EmptyState`, either via `<ListPage>`'s default or via the `empty-state` slot.
+5. **Duplicate components deleted** after migration: `Core/UI/ModuleTitle.vue` and `Core/UI/EmptyState.vue`.
+
+### Per-page migration
+
+| Page | Changes |
+|---|---|
+| **Roster** | Swap `PageHeader` for `<ListPage>`. Keep `ListControlBar` in `#controls`. Move "New Loco" from `#actions` to `add-to` / `add-label`. Remove local `pa-4` on loading skeleton — use `ListPage`'s `loading` prop. |
+| **Sounds** | Swap. No `ListControlBar` (stays that way). `add-to = { name: 'Add Sound' }`. |
+| **Effects** | Swap. `ListControlBar` → `#controls`. `add-to = { name: 'Add Effect' }`. |
+| **Routes** | Swap. `ListControlBar` → `#controls`. `add-to = { name: 'Add Route' }`. |
+| **Signals** | Swap. `ListControlBar` → `#controls`. `add-to = { name: 'Add Signal' }`. |
+| **Sensors** | Swap. `ListControlBar` → `#controls`. `add-to = { name: 'Add Sensor' }`. |
+| **Sensors/Automations** | Secondary list page. Same pattern. `add-to = { name: 'Add Automation' }`. |
+| **Turnouts** | Swap. `ListControlBar` → `#controls`. `add-to = { name: 'Add Turnout' }`. |
+| **Turnouts/Labels** | Secondary list page. Same pattern. |
+| **TrackDiagram** | Replace `ModuleTitle` with `<ListPage>`. **Remove the inline `AddTile`** — replaced by the header "New Track Diagram" button. Body becomes the diagram grid. |
+| **PowerDistricts** | Swap. No `ListControlBar`. **Replace the custom inline empty-state `v-card`** with `<EmptyState>` via the `empty` prop. **No `addTo` prop** — the route does not exist and is out of scope. |
+| **Devices (`Layout.vue`)** | Swap. **Remove the inline `AddTile`** — replaced by header "Add Device" button. Draggable grid stays in the default slot. If drag-and-drop code depended on `AddTile` as a drop target, the dead drag code is removed too (drag feature is unused). |
+
+### Files deleted after migration
+
+- `apps/cloud/src/Core/UI/ModuleTitle.vue`
+- `apps/cloud/src/Core/UI/EmptyState.vue`
+
+Before deleting either, grep the full monorepo for imports to confirm no other callers. If any exist, migrate them first.
+
+## Rollout order
+
+1. Build `<ListPage>` in `apps/cloud/src/Core/UI/ListPage.vue`. No callers yet.
+2. Migrate **Roster** as the template. Verify visually.
+3. Migrate the straightforward pages (one commit each or one grouped commit, at the implementer's discretion): Sounds, Effects, Routes, Signals, Sensors, Sensors/Automations, Turnouts, Turnouts/Labels.
+4. Migrate the outliers — one commit per page for easy bisecting: **TrackDiagram**, **Devices**, **PowerDistricts**.
+5. Grep for imports of the duplicate files and delete them if unreferenced.
+6. Run `/verify-changes` (lint + type-check + build).
+
+## Testing
+
+- **No unit tests** — `<ListPage>` is presentational and composes well-tested primitives.
+- **Visual verification** via `/capture-screenshots cloud` before merging. Side-by-side before/after for the 10+ affected pages in the PR description.
+- **Manual click-through** in dev mode to confirm every Add button navigates correctly.
+
+## Risks & mitigations
+
+- **TrackDiagram and Devices lose visual prominence for the "add" action** when `AddTile` goes away. Mitigated by the header button being clearly labeled. If the new UX feels wrong after we see it, a dedicated "empty grid" CTA can be added inside `EmptyState` without reverting the rest.
+- **Deleting duplicate components could break an unknown caller.** Mitigated by grepping before deletion and by the per-commit rollout.
+- **Devices drag-and-drop may depend on `AddTile`** as a drop target. Verified during TrackDiagram/Devices migration; if removing `AddTile` unravels the drag code, that code gets removed alongside since the drag feature is unused.


### PR DESCRIPTION
## Summary
- Introduces a single `<ListPage>` wrapper component (`apps/cloud/src/Core/UI/ListPage.vue`) that owns the loading / empty / has-items states every list page used to hand-roll, plus an auto-generated header Add button driven by `addTo` / `addLabel` props.
- Migrates all 11 cloud list pages — Roster, Sounds, Effects, Routes, Signals, Sensors, Sensors/Automations, Turnouts, TrackDiagram, Devices, PowerDistricts — to use the wrapper. Each page now has the same title bar, controls slot, actions slot, body, and empty-state slot. Inline `AddTile` removed from TrackDiagram, Devices, and Sensors/Automations in favor of the standard header button.
- Side cleanups: PowerDistricts loses its double `pa-4` padding; the local list components stop rendering an empty `prepend` slot tile when no content is passed; orphaned `hasItems` computeds removed; the unused Emulator menu entry is dropped from `useMenu.ts`.

## Out of scope (intentional)
- `TurnoutLabels.vue` (print-friendly page), Settings, Dashboard, and all Add/Edit form pages.
- `@repo/ui/PageHeader` and other shared packages — `<ListPage>` lives in the cloud app and wraps `PageHeader`, doesn't replace it.
- Cleanup of `Core/UI/ModuleTitle.vue` and `Core/UI/AddTile.vue` (still used by out-of-scope form pages; deferred to a follow-up).

## Test plan
- [x] `pnpm --filter=deja-cloud type-check` passes
- [x] `pnpm --filter=deja-cloud build` passes
- [x] No new lint errors in any migrated file
- [ ] Click-through on staging: every list page renders header + controls + body, Add button navigates correctly, empty states fill the page, loading skeletons appear briefly on hard reload
- [ ] Roster Sync to DCC-EX / Import from DCC-EX buttons still work and sit in the header actions area
- [ ] PowerDistricts inline add form still toggles via the header button and from the empty-state CTA
- [ ] Devices: drag-reorder of existing devices still works; "Add Device" button toggles the inline form

## Plan & spec
- Spec: `docs/superpowers/specs/2026-04-10-cloud-list-page-standardization-design.md`
- Plan: `docs/superpowers/plans/2026-04-10-cloud-list-page-standardization.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)