### PR TITLE
feat(dejajs-www): 🎬 architecture hero animation + guide nav polish

### DIFF
--- a/apps/dejajs-www/app/guides/layout.tsx
+++ b/apps/dejajs-www/app/guides/layout.tsx
@@ -1,4 +1,5 @@
 import GuidesSidebar from '../../components/GuidesSidebar';
+import GuideFooterNav from '../../components/GuideFooterNav';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -18,6 +19,7 @@ export default function GuidesLayout({ children }: { children: React.ReactNode }
       </aside>
       <article className="flex-1 min-w-0 max-w-4xl">
         {children}
+        <GuideFooterNav />
       </article>
     </div>
   );

--- a/apps/dejajs-www/components/GuideFooterNav.tsx
+++ b/apps/dejajs-www/components/GuideFooterNav.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import Link from 'next/link';
+import { guides } from './guides-list';
+
+/**
+ * Footer for each guide page. Renders a "Next: [title]" button if there's a
+ * next guide in the list, or "Back to top" on the final guide. 🎯
+ */
+export default function GuideFooterNav() {
+  const pathname = usePathname();
+  // Only consider publishable guides (skip comingSoon for "next")
+  const available = guides.filter((g) => !g.comingSoon);
+  const currentIdx = available.findIndex((g) => g.href === pathname);
+
+  // Not on a guide page at all — render nothing
+  if (currentIdx === -1) return null;
+
+  const next = available[currentIdx + 1];
+
+  return (
+    <div className="mt-16 pt-8 border-t border-gray-200 dark:border-gray-800">
+      {next ? (
+        <Link
+          href={next.href}
+          className="group flex items-center justify-between gap-4 p-5 rounded-xl border border-gray-200 dark:border-gray-700 bg-white/60 dark:bg-slate-900/60 hover:border-cyan-400/60 dark:hover:border-cyan-400/60 hover:bg-cyan-50/40 dark:hover:bg-cyan-950/20 transition-colors"
+        >
+          <span className="flex flex-col min-w-0">
+            <span className="text-[10px] uppercase tracking-wider font-semibold text-gray-500 dark:text-gray-400">
+              Next guide
+            </span>
+            <span className="text-lg font-semibold text-gray-900 dark:text-white truncate">
+              {next.title}
+            </span>
+            <span className="text-sm text-gray-500 dark:text-gray-400 truncate">
+              {next.desc}
+            </span>
+          </span>
+          <span className="shrink-0 flex items-center gap-2 text-cyan-600 dark:text-cyan-400 font-medium">
+            <span className="hidden sm:inline">Read</span>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="w-5 h-5 transition-transform group-hover:translate-x-1"
+              aria-hidden="true"
+            >
+              <path d="M5 12h14" />
+              <path d="m12 5 7 7-7 7" />
+            </svg>
+          </span>
+        </Link>
+      ) : (
+        <button
+          type="button"
+          onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+          className="group flex items-center justify-center gap-2 w-full p-5 rounded-xl border border-gray-200 dark:border-gray-700 bg-white/60 dark:bg-slate-900/60 hover:border-cyan-400/60 dark:hover:border-cyan-400/60 hover:bg-cyan-50/40 dark:hover:bg-cyan-950/20 text-gray-900 dark:text-white font-semibold transition-colors"
+          aria-label="Back to top"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="w-5 h-5 transition-transform group-hover:-translate-y-1"
+            aria-hidden="true"
+          >
+            <path d="m5 12 7-7 7 7" />
+            <path d="M12 19V5" />
+          </svg>
+          Back to top
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/dejajs-www/components/GuidesSidebar.tsx
+++ b/apps/dejajs-www/components/GuidesSidebar.tsx
@@ -4,42 +4,38 @@ import { useState } from 'react';
 import { usePathname } from 'next/navigation';
 import Link from 'next/link';
 import Image from 'next/image';
-
-interface GuideItem {
-  title: string;
-  href: string;
-  desc: string;
-  comingSoon?: boolean;
-}
-
-const guides: GuideItem[] = [
-  { title: 'Getting Started', href: '/guides/getting-started', desc: 'From zero to driving trains' },
-  { title: 'Architecture', href: '/guides/architecture', desc: 'How the platform works' },
-  { title: 'Throttle', href: '/guides/throttle', desc: 'Train control & functions' },
-
-  { title: 'Server', href: '/guides/server', desc: 'Installation & CLI reference' },
-  { title: 'Cloud', href: '/guides/cloud', desc: 'Roster, turnouts & effects' },
-  { title: 'IO', href: '/guides/io', desc: 'Hardware expansion & MQTT' },
-  { title: 'Monitor', href: '/guides/monitor', desc: 'Diagnostics & logging', comingSoon: true },
-];
+import { guides } from './guides-list';
 
 export default function GuidesSidebar() {
   const pathname = usePathname();
   const [mobileOpen, setMobileOpen] = useState(false);
 
+  const currentGuide = guides.find((g) => g.href === pathname);
+  const currentTitle = currentGuide?.title ?? 'Guides';
+
   return (
     <>
       <button
         onClick={() => setMobileOpen(!mobileOpen)}
-        className="lg:hidden flex items-center gap-2 px-3 py-2 mb-4 rounded-md text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700"
+        className="lg:hidden flex items-center justify-between w-full gap-3 px-4 py-3 mb-4 rounded-lg text-left bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700"
         aria-expanded={mobileOpen}
         aria-controls="guides-sidebar-nav"
-        aria-label="Toggle guides navigation"
+        aria-label={`Current guide: ${currentTitle}. Toggle guides navigation`}
       >
-        <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-          <path strokeLinecap="round" strokeLinejoin="round" d={mobileOpen ? 'M6 18L18 6M6 6l12 12' : 'M4 6h16M4 12h16M4 18h16'} />
-        </svg>
-        Menu
+        <span className="flex flex-col min-w-0">
+          <span className="text-[10px] uppercase tracking-wider font-semibold text-gray-500 dark:text-gray-400">
+            Guide
+          </span>
+          <span className="text-base font-semibold text-gray-900 dark:text-white truncate">
+            {currentTitle}
+          </span>
+        </span>
+        <span className="shrink-0 flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-medium text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700">
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" d={mobileOpen ? 'M6 18L18 6M6 6l12 12' : 'M4 6h16M4 12h16M4 18h16'} />
+          </svg>
+          {mobileOpen ? 'Close' : 'Menu'}
+        </span>
       </button>
 
       <nav

--- a/apps/dejajs-www/components/architecture/AppsSection.tsx
+++ b/apps/dejajs-www/components/architecture/AppsSection.tsx
@@ -5,7 +5,6 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { motion, useScroll, useTransform } from 'framer-motion';
 import DocLink from '../DocLink';
-import PhoneMockup from './PhoneMockup';
 
 const apps = [
   { label: 'Throttle', desc: 'Drive trains, throw turnouts, trigger effects', href: '/throttle', docsHref: '/docs/apps/throttle' },
@@ -62,18 +61,25 @@ export default function AppsSection() {
           </p>
         </motion.div>
 
-        {/* Device mockups with parallax depth */}
+        {/* Device screenshots with parallax depth — no frames */}
         <div className="flex items-end justify-center gap-4">
           <motion.div style={{ y: phoneY, opacity: phoneOpacity }}>
-            <PhoneMockup src="/screenshots/throttle_mobile_throttle.png" alt="Throttle app on mobile" className="w-[140px]" />
+            <Image
+              src="/screenshots/throttle_mobile_throttle.png"
+              alt="Throttle app on mobile"
+              width={260}
+              height={560}
+              className="w-[140px] h-auto rounded-xl shadow-2xl"
+            />
           </motion.div>
           <motion.div style={{ y: tabletY, opacity: tabletOpacity }}>
-            <div className="rounded-2xl border-2 border-gray-700 bg-gray-900 p-2 shadow-2xl w-[280px]">
-              <div className="mx-auto w-8 h-1 bg-gray-800 rounded-full mb-1" />
-              <div className="rounded-xl overflow-hidden">
-                <Image src="/screenshots/cloud_desktop_roster.png" alt="Cloud dashboard" width={560} height={350} className="w-full h-auto" />
-              </div>
-            </div>
+            <Image
+              src="/screenshots/cloud_desktop_roster.png"
+              alt="Cloud dashboard"
+              width={560}
+              height={350}
+              className="w-[280px] h-auto rounded-xl shadow-2xl"
+            />
           </motion.div>
         </div>
       </div>

--- a/apps/dejajs-www/components/architecture/ArchitectureHero.tsx
+++ b/apps/dejajs-www/components/architecture/ArchitectureHero.tsx
@@ -1,77 +1,108 @@
 'use client';
 
-import { motion } from 'framer-motion';
+import { AnimatePresence, motion } from 'framer-motion';
 import Image from 'next/image';
+import { useEffect, useRef, useState } from 'react';
 import TerminalMockup from './TerminalMockup';
 
 /*
- * ── TIMELINE ──
+ * ── ARCHITECTURE HERO — TWO-PHASE ANIMATION ──
  *
- * Phase 1 — Stage: elements fade in grayscale + dim
- * Phase 2 — Story: tap → dots travel → elements activate (grayscale → color)
+ * PHASE 1 — INTRO (on scroll/click):
+ *   Phone zooms out → lines draw in → terminal fades in → "deja start" types
+ *   → ✓ Ready → connector 2 → DCC-EX → connector 3 → track (train parked)
  *
- * 0.0–1.2s  Elements fade in (grayscale, 40% opacity)
- * 2.0s      TAP ripple → phone activates (color)
- * 2.6s      Dot travels conn 1 → arrives 3.4s → terminal activates
- * 3.6s      Terminal: "← throttle" appears
- * 4.2s      Terminal: "→ serial" appears
- * 4.5s      Dot travels conn 2 → arrives 5.3s → DCC-EX activates + glow
- * 5.7s      Dot travels conn 3 → arrives 6.5s → track activates, train orbits
+ * PHASE 2 — STORY (automatic, after phase 1):
+ *   Tap ripple → "You tap" label → dot flies conn 1 → "Server routes" label
+ *   → throttle command lines roll in → dot flies conn 2 → "Translates" label
+ *   → dot flies conn 3 → "Train moves" label → train orbits! 🚂
  */
 
-const T = {
-  // Phase 1: Stage setup (everything fades in grayscale)
-  headline: 0,
-  phone: 0.2,
-  conn1Draw: 0.8,
-  terminal: 0.4,
-  conn2Draw: 1.0,
-  dccex: 0.6,
-  conn3Draw: 1.2,
-  track: 0.8,
-  subhead: 1.2,
+const SEQ = {
+  // ── PHASE 1: intro ────────────────────────────────
+  phoneShrinkDur: 0.35,
+  conn1Draw: 0.35,
+  conn1Dur: 0.35,
+  terminalFade: 0.6,
+  terminalDur: 0.2,
+  typingStart: 0.75,    // "deja start" @ 40ms/char ≈ 0.4s
+  readyLine: 1.2,
+  conn2Draw: 1.3,
+  conn2Dur: 0.35,
+  dccFade: 1.55,
+  dccDur: 0.2,
+  conn3Draw: 1.7,
+  conn3Dur: 0.35,
+  trackFade: 1.95,
+  trackDur: 0.2,
 
-  // Phase 2: The story
-  tap: 2.0,           // phone activates
-  dot1: 2.6,          // dot travels conn 1 (0.8s)
-  termActivate: 3.4,  // terminal activates (dot1 + 0.8)
-  termCmd: 3.6,       // terminal receives command
-  termSerial: 4.2,    // terminal dispatches serial
-  dot2: 4.5,          // dot travels conn 2 (0.8s)
-  dccActivate: 5.3,   // DCC-EX activates (dot2 + 0.8)
-  dccGlow: 5.3,
-  dot3: 5.7,          // dot travels conn 3 (0.8s)
-  trackActivate: 6.5, // track activates (dot3 + 0.8)
-  trainStart: 6.6,
+  // ── PHASE 2: story (slower — gives viewer time to read each label) ────────
+  tap: 2.25,            // 👆 tap ripple on phone
+  label1: 2.35,         // "You tap" / "Throttle App"
+  dot1: 2.95,           // pause 0.6s after label1 so the viewer can read it
+  dotDur: 0.8,
+  label2: 3.85,         // "Server routes" / "DEJA Server" — as dot arrives
+  throttleCmd: 4.35,    // ← throttle line
+  serialCmd: 4.7,       // → <t 3 50 1> line
+  dot2: 5.25,
+  label3: 6.15,         // "Translates & transmits" / "DCC-EX CommandStation"
+  dot3: 6.65,
+  label4: 7.55,         // "Train moves" / "DCC Track"
+  trainStart: 7.65,     // 🚂 train begins orbit
 } as const;
 
 const EASE_ENTER = [0.22, 1, 0.36, 1] as [number, number, number, number];
 
-/** S-curve connector with faint track, animated draw, and a traveling command dot. */
+interface ArchitectureHeroProps {
+  /** Start the sequence immediately on mount (used by the replay button). */
+  autoStart?: boolean;
+}
+
+/** Smooth cable-drape S-curve connector, optional traveling command dot. */
 function Connector({
   direction,
   drawDelay,
-  dotDelay,
+  drawDuration = 0.35,
   color1,
   color2,
   id,
+  showDot = false,
+  dotDelay = 0,
+  dotDuration = 0.6,
 }: {
   direction: 'left-to-right' | 'right-to-left';
   drawDelay: number;
-  dotDelay: number;
+  drawDuration?: number;
   color1: string;
   color2: string;
   id: string;
+  showDot?: boolean;
+  dotDelay?: number;
+  dotDuration?: number;
 }) {
+  // Original vertical-tangent S — renders as a letterboxed square in the row
+  // center thanks to the default preserveAspectRatio="xMidYMid meet". Graphics
+  // are positioned near the row center to sit close to the curve endpoints.
   const d =
     direction === 'left-to-right'
       ? 'M 10,2 C 10,40 90,60 90,98'
       : 'M 90,2 C 90,40 10,60 10,98';
 
   return (
-    <div className="w-full h-8 sm:h-10">
-      <svg viewBox="0 0 100 100" className="w-full h-full" fill="none">
-        <path d={d} stroke={color1} strokeOpacity={0.06} strokeWidth={2} strokeLinecap="round" vectorEffect="non-scaling-stroke" />
+    <div className="w-full h-10 sm:h-12">
+      <svg
+        viewBox="0 0 100 100"
+        className="w-full h-full"
+        fill="none"
+      >
+        <path
+          d={d}
+          stroke={color1}
+          strokeOpacity={0.06}
+          strokeWidth={2}
+          strokeLinecap="round"
+          vectorEffect="non-scaling-stroke"
+        />
         <motion.path
           d={d}
           stroke={`url(#${id})`}
@@ -80,33 +111,39 @@ function Connector({
           vectorEffect="non-scaling-stroke"
           initial={{ pathLength: 0 }}
           animate={{ pathLength: 1 }}
-          transition={{ duration: 1.0, delay: drawDelay, ease: EASE_ENTER }}
+          transition={{ duration: drawDuration, delay: drawDelay, ease: EASE_ENTER }}
         />
-        <motion.circle
-          r={4} fill={color1}
-          initial={{ opacity: 0 }}
-          animate={{ opacity: [0, 1, 1, 0] }}
-          transition={{ delay: dotDelay, duration: 0.8, times: [0, 0.05, 0.9, 1] }}
-        >
-          <animateMotion dur="0.8s" fill="freeze" begin={`${dotDelay}s`}>
-            <mpath href={`#${id}-path`} />
-          </animateMotion>
-        </motion.circle>
-        <motion.circle
-          r={8} fill={color1}
-          initial={{ opacity: 0 }}
-          animate={{ opacity: [0, 0.2, 0.2, 0] }}
-          transition={{ delay: dotDelay, duration: 0.8, times: [0, 0.05, 0.9, 1] }}
-        >
-          <animateMotion dur="0.8s" fill="freeze" begin={`${dotDelay}s`}>
-            <mpath href={`#${id}-path`} />
-          </animateMotion>
-        </motion.circle>
+        {showDot && (
+          <>
+            <motion.circle
+              r={4}
+              fill={color1}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: [0, 1, 1, 0] }}
+              transition={{ delay: dotDelay, duration: dotDuration, times: [0, 0.05, 0.9, 1] }}
+            >
+              <animateMotion dur={`${dotDuration}s`} fill="freeze" begin={`${dotDelay}s`}>
+                <mpath href={`#${id}-path`} />
+              </animateMotion>
+            </motion.circle>
+            <motion.circle
+              r={8}
+              fill={color1}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: [0, 0.25, 0.25, 0] }}
+              transition={{ delay: dotDelay, duration: dotDuration, times: [0, 0.05, 0.9, 1] }}
+            >
+              <animateMotion dur={`${dotDuration}s`} fill="freeze" begin={`${dotDelay}s`}>
+                <mpath href={`#${id}-path`} />
+              </animateMotion>
+            </motion.circle>
+          </>
+        )}
         <path id={`${id}-path`} d={d} fill="none" stroke="none" />
         <defs>
           <linearGradient id={id} x1="0%" y1="0%" x2="0%" y2="100%">
-            <stop offset="0%" stopColor={color1} stopOpacity={0.7} />
-            <stop offset="100%" stopColor={color2} stopOpacity={0.5} />
+            <stop offset="0%" stopColor={color1} stopOpacity={0.8} />
+            <stop offset="100%" stopColor={color2} stopOpacity={0.6} />
           </linearGradient>
         </defs>
       </svg>
@@ -114,301 +151,583 @@ function Connector({
   );
 }
 
-/** Tap ripple effect on the phone. */
+/** 👆 Tap ripple on the phone. */
 function TapRipple({ delay }: { delay: number }) {
   return (
     <motion.div
       className="absolute inset-0 flex items-center justify-center pointer-events-none z-20"
       initial={{ opacity: 0 }}
       animate={{ opacity: [0, 1, 0] }}
-      transition={{ delay, duration: 0.8 }}
+      transition={{ delay, duration: 0.7 }}
     >
       <motion.div
-        className="w-6 h-6 rounded-full bg-white/30 backdrop-blur-sm"
+        className="w-8 h-8 rounded-full bg-white/30 backdrop-blur-sm"
         initial={{ scale: 0.5 }}
         animate={{ scale: [0.5, 1, 0.8] }}
         transition={{ delay, duration: 0.3 }}
       />
       <motion.div
-        className="absolute w-12 h-12 rounded-full border-2 border-deja-cyan/40"
+        className="absolute w-16 h-16 rounded-full border-2 border-deja-cyan/50"
         initial={{ scale: 0.5, opacity: 0 }}
-        animate={{ scale: [0.5, 1.8], opacity: [0, 0.6, 0] }}
-        transition={{ delay: delay + 0.1, duration: 0.5 }}
+        animate={{ scale: [0.5, 2.0], opacity: [0, 0.7, 0] }}
+        transition={{ delay: delay + 0.05, duration: 0.5 }}
       />
     </motion.div>
   );
 }
 
-/** Terminal with startup + command lines. */
-function AnimatedTerminal({ activateAt }: { activateAt: number }) {
-  const lines = [
-    { text: '$ deja start', color: 'text-deja-cyan', delay: T.terminal },
-    { text: '✓ Ready', color: 'text-green-400', delay: T.terminal + 0.3 },
-    { text: '', color: '', delay: T.terminal + 0.5 },
-    { text: '← throttle {addr:3, speed:50}', color: 'text-yellow-400', delay: T.termCmd },
-    { text: '→ <t 3 50 1>', color: 'text-deja-magenta', delay: T.termSerial },
-  ];
+/** Types text one character at a time after an absolute delay. */
+function TypeWriter({
+  text,
+  startAt,
+  speed = 40,
+}: {
+  text: string;
+  startAt: number;
+  speed?: number;
+}) {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    let interval: ReturnType<typeof setInterval> | null = null;
+    const startTimer = setTimeout(() => {
+      interval = setInterval(() => {
+        setCount((c) => {
+          if (c >= text.length) {
+            if (interval) clearInterval(interval);
+            return c;
+          }
+          return c + 1;
+        });
+      }, speed);
+    }, startAt * 1000);
+
+    return () => {
+      clearTimeout(startTimer);
+      if (interval) clearInterval(interval);
+    };
+  }, [text, startAt, speed]);
+
+  return <span>{text.slice(0, count)}</span>;
+}
+
+/** Terminal with typewriter prompt + rolling output lines. */
+function SequenceTerminal() {
+  // Delays are relative to terminal mount, so subtract terminalFade offset.
+  const typingStart = SEQ.typingStart - SEQ.terminalFade;
+  const readyStart = SEQ.readyLine - SEQ.terminalFade;
+  const throttleStart = SEQ.throttleCmd - SEQ.terminalFade;
+  const serialStart = SEQ.serialCmd - SEQ.terminalFade;
 
   return (
-    <div>
-      <TerminalMockup title="deja — tamarack" className="text-[9px] w-[190px] sm:w-[230px]">
-        {lines.map((line, i) => (
-          <motion.p
-            key={i}
-            className={line.color}
-            initial={{ opacity: 0, x: 4 }}
-            animate={{ opacity: 1, x: 0 }}
-            transition={{ duration: 0.25, delay: line.delay, ease: 'easeOut' }}
-          >
-            {line.text || '\u00A0'}
-          </motion.p>
-        ))}
-      </TerminalMockup>
-    </div>
+    <TerminalMockup title="deja — tamarack" className="text-[10px] w-[210px] sm:w-[240px]">
+      <p className="text-deja-cyan">
+        $ <TypeWriter text="deja start" startAt={typingStart} />
+      </p>
+      <motion.p
+        className="text-green-400"
+        initial={{ opacity: 0, y: 4 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: readyStart, duration: 0.18, ease: 'easeOut' }}
+      >
+        ✓ Ready
+      </motion.p>
+      {/* 🏗️ reserved space — actual content rolls in during phase 2 */}
+      <p aria-hidden className="invisible">{'\u00A0'}</p>
+      <motion.p
+        className="text-yellow-400"
+        initial={{ opacity: 0, y: 4 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: throttleStart, duration: 0.25, ease: 'easeOut' }}
+      >
+        ← throttle {'{addr:3, speed:50}'}
+      </motion.p>
+      <motion.p
+        className="text-deja-magenta"
+        initial={{ opacity: 0, y: 4 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: serialStart, duration: 0.25, ease: 'easeOut' }}
+      >
+        → {'<t 3 50 1>'}
+      </motion.p>
+    </TerminalMockup>
   );
 }
 
-/** Stadium-shaped track. Activates + train starts orbiting when command arrives. */
-function OvalTrack({ activateAt }: { activateAt: number }) {
+/** Stadium track — train parked initially, starts orbiting at `trainStartDelay`. */
+function SequenceOvalTrack({ trainStartDelay }: { trainStartDelay: number }) {
   const outerTrack = 'M 60,10 L 140,10 A 30,30 0 0 1 140,70 L 60,70 A 30,30 0 0 1 60,10 Z';
   const innerTrack = 'M 62,14 L 138,14 A 26,26 0 0 1 138,66 L 62,66 A 26,26 0 0 1 62,14 Z';
   const orbitPath = 'M 61,12 L 139,12 A 28,28 0 0 1 139,68 L 61,68 A 28,28 0 0 1 61,12 Z';
+
+  const [moving, setMoving] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setMoving(true), trainStartDelay * 1000);
+    return () => clearTimeout(timer);
+  }, [trainStartDelay]);
 
   const ties: { x1: number; y1: number; x2: number; y2: number }[] = [];
   for (let i = 0; i < 8; i++) { const x = 65 + i * 10; ties.push({ x1: x, y1: 7, x2: x, y2: 17 }); }
   for (let i = 0; i < 8; i++) { const x = 65 + i * 10; ties.push({ x1: x, y1: 63, x2: x, y2: 73 }); }
   for (let i = 0; i < 5; i++) {
     const a = -Math.PI / 2 + (i + 1) * (Math.PI / 6);
-    ties.push({ x1: Math.round(140 + 25 * Math.cos(a)), y1: Math.round(40 + 25 * Math.sin(a)), x2: Math.round(140 + 35 * Math.cos(a)), y2: Math.round(40 + 35 * Math.sin(a)) });
+    ties.push({
+      x1: Math.round(140 + 25 * Math.cos(a)),
+      y1: Math.round(40 + 25 * Math.sin(a)),
+      x2: Math.round(140 + 35 * Math.cos(a)),
+      y2: Math.round(40 + 35 * Math.sin(a)),
+    });
   }
   for (let i = 0; i < 5; i++) {
     const a = Math.PI / 2 + (i + 1) * (Math.PI / 6);
-    ties.push({ x1: Math.round(60 + 25 * Math.cos(a)), y1: Math.round(40 + 25 * Math.sin(a)), x2: Math.round(60 + 35 * Math.cos(a)), y2: Math.round(40 + 35 * Math.sin(a)) });
+    ties.push({
+      x1: Math.round(60 + 25 * Math.cos(a)),
+      y1: Math.round(40 + 25 * Math.sin(a)),
+      x2: Math.round(60 + 35 * Math.cos(a)),
+      y2: Math.round(40 + 35 * Math.sin(a)),
+    });
   }
 
   return (
     <div className="w-[140px] sm:w-[170px] h-[56px] sm:h-[68px] relative">
       <svg viewBox="0 0 200 80" className="w-full h-full" fill="none">
         {ties.map((t, i) => (
-          <motion.line
+          <line
             key={i}
-            x1={t.x1} y1={t.y1} x2={t.x2} y2={t.y2}
-            stroke="#F97316" strokeOpacity={0.2} strokeWidth={1.5}
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ delay: T.track + 0.1 + i * 0.015 }}
+            x1={t.x1}
+            y1={t.y1}
+            x2={t.x2}
+            y2={t.y2}
+            stroke="#F97316"
+            strokeOpacity={0.2}
+            strokeWidth={1.5}
           />
         ))}
-        <motion.path d={outerTrack} stroke="#F97316" strokeOpacity={0.35} strokeWidth={1.2} initial={{ pathLength: 0 }} animate={{ pathLength: 1 }} transition={{ duration: 0.6, delay: T.track, ease: EASE_ENTER }} />
-        <motion.path d={innerTrack} stroke="#F97316" strokeOpacity={0.25} strokeWidth={1} initial={{ pathLength: 0 }} animate={{ pathLength: 1 }} transition={{ duration: 0.6, delay: T.track + 0.08, ease: EASE_ENTER }} />
-        {/* 5-dot train — each dot starts slightly later to create a following chain */}
-        {[0, 1, 2, 3, 4].map((i) => (
-          <motion.circle key={i} r={i === 0 ? 4.5 : 3} fill="#F97316" fillOpacity={i === 0 ? 1 : 0.7 - i * 0.1}
-            initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: T.trainStart + i * 0.1, duration: 0.3 }}>
-            <animateMotion dur="3s" repeatCount="indefinite" begin={`${T.trainStart + i * 0.1}s`}>
-              <mpath href="#stadium-orbit" />
-            </animateMotion>
-          </motion.circle>
-        ))}
+        <path d={outerTrack} stroke="#F97316" strokeOpacity={0.35} strokeWidth={1.2} />
+        <path d={innerTrack} stroke="#F97316" strokeOpacity={0.25} strokeWidth={1} />
+
+        {moving ? (
+          // 🚂 train chain orbiting the path
+          [0, 1, 2, 3, 4].map((i) => (
+            <circle key={i} r={i === 0 ? 4.5 : 3} fill="#F97316" fillOpacity={i === 0 ? 1 : 0.75 - i * 0.1}>
+              <animateMotion dur="3s" repeatCount="indefinite" begin={`${i * 0.1}s`}>
+                <mpath href="#stadium-orbit" />
+              </animateMotion>
+            </circle>
+          ))
+        ) : (
+          // 🛑 train parked at the top-left
+          <>
+            <circle cx={61} cy={12} r={4.5} fill="#F97316" />
+            <circle cx={71} cy={12} r={3} fill="#F97316" fillOpacity={0.75} />
+            <circle cx={81} cy={12} r={3} fill="#F97316" fillOpacity={0.65} />
+            <circle cx={91} cy={12} r={3} fill="#F97316" fillOpacity={0.55} />
+            <circle cx={101} cy={12} r={3} fill="#F97316" fillOpacity={0.45} />
+          </>
+        )}
+
         <path id="stadium-orbit" d={orbitPath} fill="none" stroke="none" />
       </svg>
     </div>
   );
 }
 
-export default function ArchitectureHero() {
+/**
+ * Two-line label that fades in with a subtle slide.
+ * - Mobile (< sm): stacks above the graphic, centered.
+ * - Desktop (≥ sm): sits beside the graphic (left or right).
+ */
+function StepLabel({
+  title,
+  subtitle,
+  color,
+  delay,
+  align = 'left',
+  className = '',
+}: {
+  title: string;
+  subtitle: string;
+  color: string;
+  delay: number;
+  align?: 'left' | 'right';
+  className?: string;
+}) {
+  // Mobile: absolutely position above the graphic, centered horizontally
+  const mobilePos = 'bottom-full left-1/2 -translate-x-1/2 mb-2 text-center';
+  // Desktop: to the side of the graphic, vertically centered
+  const desktopPos =
+    align === 'right'
+      ? 'sm:bottom-auto sm:top-1/2 sm:left-auto sm:right-full sm:mb-0 sm:mr-3 sm:translate-x-0 sm:-translate-y-1/2 sm:text-right'
+      : 'sm:bottom-auto sm:top-1/2 sm:left-full sm:mb-0 sm:ml-3 sm:translate-x-0 sm:-translate-y-1/2 sm:text-left';
+
   return (
-    <section className="relative -mx-6 px-6 py-6 sm:py-10">
+    <motion.div
+      className={`absolute whitespace-nowrap ${mobilePos} ${desktopPos} ${className}`}
+      initial={{ opacity: 0, y: 4 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay, duration: 0.35, ease: 'easeOut' }}
+    >
+      <motion.p
+        className="font-mono text-xs sm:text-sm font-semibold"
+        style={{ color }}
+        initial={{ filter: `drop-shadow(0 0 0px ${color}00)` }}
+        animate={{
+          filter: [
+            `drop-shadow(0 0 0px ${color}00)`,
+            `drop-shadow(0 0 14px ${color})`,
+            `drop-shadow(0 0 5px ${color}99)`,
+          ],
+        }}
+        transition={{
+          delay: delay + 0.1,
+          duration: 1.2,
+          times: [0, 0.3, 1],
+          ease: 'easeOut',
+        }}
+      >
+        {title}
+      </motion.p>
+      <p className="text-gray-500 text-[10px] sm:text-xs mt-0.5">{subtitle}</p>
+    </motion.div>
+  );
+}
+
+export default function ArchitectureHero({ autoStart = false }: ArchitectureHeroProps) {
+  const [started, setStarted] = useState(autoStart);
+  const [progressVisible, setProgressVisible] = useState(false);
+  const [headerHeight, setHeaderHeight] = useState(96);
+  const sectionRef = useRef<HTMLElement>(null);
+
+  const handleStart = () => {
+    if (!started) setStarted(true);
+  };
+
+  // 📏 Measure the global <header> so the progress bar sits exactly below it
+  // regardless of promo banners, responsive padding, or future header changes.
+  useEffect(() => {
+    const measure = () => {
+      const header = document.querySelector('header');
+      if (header) setHeaderHeight(header.getBoundingClientRect().height);
+    };
+    measure();
+    window.addEventListener('resize', measure);
+    return () => window.removeEventListener('resize', measure);
+  }, []);
+
+  // 📊 Show the progress bar while the sequence plays, then fade it away.
+  useEffect(() => {
+    if (!started) return;
+    setProgressVisible(true);
+    const hide = setTimeout(
+      () => setProgressVisible(false),
+      (SEQ.trainStart + 1.5) * 1000,
+    );
+    return () => clearTimeout(hide);
+  }, [started]);
+
+  useEffect(() => {
+    if (started) return;
+
+    const handleScroll = () => {
+      if (window.scrollY > 8) setStarted(true);
+    };
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [started]);
+
+  // 🔒 Clamp page scroll to stay within the hero's bounds while the sequence
+  // plays. The user can still scroll freely within the hero (so they can
+  // reach the bottom where the tracks live on mobile), but cannot scroll
+  // past the top or bottom of the hero until the animation finishes.
+  useEffect(() => {
+    if (!started) return;
+
+    const clampScroll = () => {
+      const section = sectionRef.current;
+      if (!section) return;
+
+      const rect = section.getBoundingClientRect();
+      const scrollY = window.scrollY;
+      const sectionTop = scrollY + rect.top;
+      const sectionBottom = sectionTop + rect.height;
+
+      const minAllowed = Math.max(0, sectionTop);
+      // If the hero is taller than the viewport, allow scrolling down until
+      // the hero's bottom reaches the viewport bottom. Otherwise, pin to top.
+      const maxAllowed = Math.max(minAllowed, sectionBottom - window.innerHeight);
+
+      if (scrollY < minAllowed) {
+        window.scrollTo({ top: minAllowed });
+      } else if (scrollY > maxAllowed) {
+        window.scrollTo({ top: maxAllowed });
+      }
+    };
+
+    // Initial clamp, then clamp on every subsequent scroll event.
+    clampScroll();
+    window.addEventListener('scroll', clampScroll, { passive: true });
+
+    // Release once the sequence has finished (train is orbiting).
+    const totalMs = (SEQ.trainStart + 1.2) * 1000;
+    const unlockTimer = setTimeout(() => {
+      window.removeEventListener('scroll', clampScroll);
+    }, totalMs);
+
+    return () => {
+      clearTimeout(unlockTimer);
+      window.removeEventListener('scroll', clampScroll);
+    };
+  }, [started]);
+
+  return (
+    <section
+      ref={sectionRef}
+      className="relative -mx-6 px-6 pt-28 pb-12 sm:pt-16 sm:pb-16 lg:py-20 scroll-mt-24"
+      onClick={handleStart}
+    >
+      {/* 📊 Deterministic progress bar — fixed below nav header, full window width.
+          Fades in on start, fades out ~0.3s after the sequence completes. */}
+      <AnimatePresence>
+        {progressVisible && (
+          <motion.div
+            key="progress-bar"
+            className="fixed left-0 right-0 z-40 h-0.5 bg-gray-900/40 overflow-hidden pointer-events-none"
+            style={{ top: `${headerHeight}px` }}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.5, ease: 'easeOut' }}
+            aria-label="Animation progress"
+            role="progressbar"
+            aria-valuemin={0}
+            aria-valuemax={100}
+          >
+            <motion.div
+              className="h-full bg-cyan-900/70"
+              initial={{ width: '0%' }}
+              animate={{ width: '100%' }}
+              transition={{ duration: SEQ.trainStart + 1.2, ease: 'linear' }}
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
+
       <div className="flex items-center justify-center">
         <div className="absolute inset-0 bg-grid-dark opacity-40" />
 
-        <div className="relative w-full max-w-4xl mx-auto flex flex-col lg:flex-row lg:items-center lg:gap-12">
+        <div className="relative w-full max-w-4xl mx-auto flex flex-col lg:flex-row lg:items-start lg:gap-12 min-h-[520px] lg:min-h-[600px]">
 
           {/* ── Left: Headline ── */}
-          <div className="lg:w-[280px] shrink-0 text-center lg:text-left mb-6 lg:mb-0">
+          <div className="lg:w-[280px] shrink-0 text-center lg:text-left mb-6 lg:mb-0 lg:pt-8 overflow-hidden">
             <h1 className="font-display text-4xl sm:text-5xl lg:text-6xl tracking-wide text-white">
-              <motion.span className="block" initial={{ opacity: 0, y: 12 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.5, delay: T.headline, ease: EASE_ENTER }}>
+              <motion.span
+                className="block"
+                initial={{ opacity: 0, x: -40 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ duration: 0.6, delay: 0.1, ease: EASE_ENTER }}
+              >
                 Tap.
               </motion.span>
-              <motion.span className="block" initial={{ opacity: 0, y: 12 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.5, delay: T.headline + 0.15, ease: EASE_ENTER }}>
+              <motion.span
+                className="block"
+                initial={{ opacity: 0, x: -40 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ duration: 0.6, delay: 0.25, ease: EASE_ENTER }}
+              >
                 Command.
               </motion.span>
-              <motion.span className="block text-deja-cyan" initial={{ opacity: 0, y: 12 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.5, delay: T.headline + 0.3, ease: EASE_ENTER }}>
+              <motion.span
+                className="block text-deja-cyan"
+                initial={{ opacity: 0, x: -40 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ duration: 0.6, delay: 0.4, ease: EASE_ENTER }}
+              >
                 Move.
               </motion.span>
             </h1>
             <motion.p
               className="text-gray-400 text-sm sm:text-base mt-4 max-w-sm mx-auto lg:mx-0"
-              initial={{ opacity: 0, y: 8 }}
+              initial={{ opacity: 0, y: 16 }}
               animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.5, delay: T.subhead, ease: EASE_ENTER }}
+              transition={{ duration: 0.6, delay: 0.9, ease: EASE_ENTER }}
             >
               From the app in your hand to the track under your trains — every layer connected.
             </motion.p>
+            {!started && (
+              <motion.p
+                className="hidden lg:block text-gray-500 text-xs mt-6 font-mono"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                transition={{ delay: 1.6, duration: 0.6 }}
+              >
+                ↓ scroll or click to begin
+              </motion.p>
+            )}
           </div>
 
-          {/* ── Right: Vertical cascade ── */}
-          <div className="flex-1">
-
-            {/* Row 1: Phone — LEFT-CENTER (visible immediately in grayscale, activates on tap) */}
+          {/* ── Right: Phone (zooms out) + sequence ── */}
+          <div className="flex-1 flex flex-col cursor-pointer">
+            {/* Phone — layout animates from centered/big to zig-zag slot/small */}
             <motion.div
-              className="flex justify-center sm:justify-start sm:pl-[25%]"
-              initial={{ opacity: 0, y: 12 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.5, delay: T.phone, ease: EASE_ENTER }}
+              layout
+              transition={{ duration: SEQ.phoneShrinkDur, ease: EASE_ENTER }}
+              className={
+                started
+                  ? 'flex justify-center mt-12 sm:mt-0 sm:justify-start sm:pl-[32%]'
+                  : 'flex items-center justify-center lg:justify-end min-h-[460px] lg:min-h-[540px]'
+              }
             >
-              <div className="flex items-center gap-3">
-                <div className="relative">
-                  <Image
-                    src="/screenshots/throttle_mobile_throttle.png"
-                    alt="Throttle app — slide to control speed"
-                    width={260} height={560}
-                    className="w-[90px] sm:w-[120px] h-auto max-h-[160px] sm:max-h-[200px] object-cover object-top rounded-lg"
-                  />
-                  <TapRipple delay={T.tap} />
-                  {/* Pulse glow */}
-                  <motion.div
-                    className="absolute -inset-2 rounded-2xl -z-10"
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: [0, 0.5, 0], scale: [0.95, 1.05, 1] }}
-                    transition={{ delay: T.tap, duration: 0.8 }}
-                    style={{ background: 'radial-gradient(circle, rgba(0,229,255,0.3) 0%, transparent 70%)' }}
-                  />
-                </div>
-                <div>
-                  <motion.p
-                    className="font-mono text-xs sm:text-sm font-semibold"
-                    initial={{ color: '#9CA3AF' }}
-                    animate={{ color: '#00E5FF' }}
-                    transition={{ delay: T.tap, duration: 0.5 }}
-                  >You tap</motion.p>
-                  <p className="text-gray-500 text-[10px] sm:text-xs mt-0.5">Throttle App</p>
-                </div>
-              </div>
+              <motion.div
+                layout
+                transition={{ duration: SEQ.phoneShrinkDur, ease: EASE_ENTER }}
+                className={
+                  started
+                    ? 'relative w-[180px] sm:w-[220px]'
+                    : 'relative w-[60%] lg:w-[420px]'
+                }
+              >
+                <Image
+                  src="/screenshots/throttle_mobile_throttle.png"
+                  alt="Throttle app — slide to control speed"
+                  width={520}
+                  height={1120}
+                  className="w-full h-auto rounded-xl shadow-2xl"
+                  priority
+                />
+                {started && (
+                  <>
+                    <TapRipple delay={SEQ.tap} />
+                    <StepLabel
+                      title="You tap"
+                      subtitle="Throttle App"
+                      color="#00E5FF"
+                      delay={SEQ.label1}
+                      align="left"
+                    />
+                  </>
+                )}
+              </motion.div>
             </motion.div>
 
-            <Connector direction="left-to-right" drawDelay={T.conn1Draw} dotDelay={T.dot1} color1="#00E5FF" color2="#00E5FF" id="conn-1" />
-
-            {/* Row 2: Terminal — RIGHT (visible in grayscale, activates when dot arrives) */}
-            <motion.div
-              className="flex justify-end pr-4 sm:pr-8"
-              initial={{ opacity: 0, y: 10 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.5, delay: T.terminal, ease: EASE_ENTER }}
-            >
-              <div className="flex items-center gap-3">
-                <div className="text-right">
-                  <motion.p
-                    className="font-mono text-xs sm:text-sm font-semibold"
-                    initial={{ color: '#9CA3AF' }}
-                    animate={{ color: '#00E5FF' }}
-                    transition={{ delay: T.termActivate, duration: 0.5 }}
-                  >Server routes</motion.p>
-                  <p className="text-gray-500 text-[10px] sm:text-xs mt-0.5">DEJA Server</p>
+            {started && (
+              <>
+                {/* Connector 1 — phone → terminal, with dot */}
+                <div className="-mt-6 sm:-mt-8">
+                  <Connector
+                    direction="left-to-right"
+                    drawDelay={SEQ.conn1Draw}
+                    drawDuration={SEQ.conn1Dur}
+                    color1="#00E5FF"
+                    color2="#00E5FF"
+                    id="conn-1"
+                    showDot
+                    dotDelay={SEQ.dot1}
+                    dotDuration={SEQ.dotDur}
+                  />
                 </div>
+
+                {/* Terminal row — extra top margin on mobile to fit the label above */}
                 <motion.div
-                  className="relative"
+                  className="flex justify-center mt-10 sm:mt-0 sm:justify-end sm:pr-[28%]"
+                  initial={{ opacity: 0, scale: 0.95 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  transition={{ delay: SEQ.terminalFade, duration: SEQ.terminalDur, ease: 'easeOut' }}
+                >
+                  <div className="relative">
+                    <SequenceTerminal />
+                    <StepLabel
+                      title="Server routes"
+                      subtitle="DEJA Server"
+                      color="#00E5FF"
+                      delay={SEQ.label2}
+                      align="right"
+                    />
+                  </div>
+                </motion.div>
+
+                {/* Connector 2 — terminal → DCC-EX, with dot */}
+                <Connector
+                  direction="right-to-left"
+                  drawDelay={SEQ.conn2Draw}
+                  drawDuration={SEQ.conn2Dur}
+                  color1="#00E5FF"
+                  color2="#8B5CF6"
+                  id="conn-2"
+                  showDot
+                  dotDelay={SEQ.dot2}
+                  dotDuration={SEQ.dotDur}
+                />
+
+                {/* DCC-EX row */}
+                <motion.div
+                  className="flex justify-center mt-10 sm:mt-0 sm:justify-start sm:pl-[36%]"
                   initial={{ opacity: 0, scale: 0.9 }}
                   animate={{ opacity: 1, scale: 1 }}
-                  transition={{ delay: T.termActivate, duration: 0.5, ease: 'easeOut' }}
+                  transition={{ delay: SEQ.dccFade, duration: SEQ.dccDur, ease: 'easeOut' }}
                 >
-                  <AnimatedTerminal activateAt={T.termActivate} />
-                  <motion.div
-                    className="absolute -inset-2 rounded-2xl -z-10"
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: [0, 0.4, 0], scale: [0.95, 1.05, 1] }}
-                    transition={{ delay: T.termActivate, duration: 0.8 }}
-                    style={{ background: 'radial-gradient(circle, rgba(0,229,255,0.25) 0%, transparent 70%)' }}
-                  />
+                  <div className="relative w-[100px] sm:w-[130px]">
+                    <Image
+                      src="/images/dcc-ex-commandstation.png"
+                      alt="DCC-EX CommandStation — Arduino Mega with Motor Shield"
+                      width={440}
+                      height={300}
+                      className="w-full h-auto drop-shadow-[0_0_12px_rgba(139,92,246,0.25)]"
+                    />
+                    <Image
+                      src="/dcc-ex/android-chrome-192x192.png"
+                      alt="DCC-EX"
+                      width={32}
+                      height={32}
+                      className="absolute -top-2 -right-2 w-6 h-6 sm:w-8 sm:h-8 rounded-full border border-purple-500/30 shadow-lg"
+                    />
+                    <StepLabel
+                      title="Translates & transmits"
+                      subtitle="DCC-EX CommandStation"
+                      color="#A78BFA"
+                      delay={SEQ.label3}
+                      align="left"
+                    />
+                  </div>
                 </motion.div>
-              </div>
-            </motion.div>
 
-            <Connector direction="right-to-left" drawDelay={T.conn2Draw} dotDelay={T.dot2} color1="#00E5FF" color2="#8B5CF6" id="conn-2" />
+                {/* Connector 3 — DCC-EX → track, with dot */}
+                <Connector
+                  direction="left-to-right"
+                  drawDelay={SEQ.conn3Draw}
+                  drawDuration={SEQ.conn3Dur}
+                  color1="#8B5CF6"
+                  color2="#F97316"
+                  id="conn-3"
+                  showDot
+                  dotDelay={SEQ.dot3}
+                  dotDuration={SEQ.dotDur}
+                />
 
-            {/* Row 3: DCC-EX — LEFT (visible in grayscale, activates when dot arrives) */}
-            <motion.div
-              className="flex justify-start pl-4 sm:pl-8"
-              initial={{ opacity: 0, y: 10 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.5, delay: T.dccex, ease: EASE_ENTER }}
-            >
-              <div className="flex items-center gap-3">
+                {/* Track row — train parked → orbits after label4 */}
                 <motion.div
-                  className="relative w-[100px] sm:w-[130px]"
+                  className="flex justify-center mt-10 sm:mt-0 sm:justify-end sm:pr-[34%]"
                   initial={{ opacity: 0, scale: 0.9 }}
                   animate={{ opacity: 1, scale: 1 }}
-                  transition={{ delay: T.dccActivate, duration: 0.5, ease: 'easeOut' }}
+                  transition={{ delay: SEQ.trackFade, duration: SEQ.trackDur, ease: 'easeOut' }}
                 >
-                  <Image
-                    src="/images/dcc-ex-commandstation.png"
-                    alt="DCC-EX CommandStation — Arduino Mega with Motor Shield"
-                    width={440} height={300}
-                    className="w-full h-auto drop-shadow-[0_0_12px_rgba(0,229,255,0.2)]"
-                  />
-                  <Image
-                    src="/dcc-ex/android-chrome-192x192.png"
-                    alt="DCC-EX"
-                    width={32} height={32}
-                    className="absolute -top-2 -right-2 w-6 h-6 sm:w-8 sm:h-8 rounded-full border border-purple-500/30 shadow-lg"
-                  />
-                  <motion.div
-                    className="absolute -inset-2 rounded-2xl -z-10"
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: [0, 0.4, 0], scale: [0.95, 1.05, 1] }}
-                    transition={{ delay: T.dccActivate, duration: 0.8 }}
-                    style={{ background: 'radial-gradient(circle, rgba(139,92,246,0.3) 0%, transparent 70%)' }}
-                  />
+                  <div className="relative">
+                    <SequenceOvalTrack trainStartDelay={SEQ.trainStart} />
+                    <StepLabel
+                      title="Train moves"
+                      subtitle="DCC Track"
+                      color="#F97316"
+                      delay={SEQ.label4}
+                      align="right"
+                    />
+                  </div>
                 </motion.div>
-                <div>
-                  <motion.p
-                    className="font-mono text-xs sm:text-sm font-semibold"
-                    initial={{ color: '#9CA3AF' }}
-                    animate={{ color: '#A78BFA' }}
-                    transition={{ delay: T.dccActivate, duration: 0.5 }}
-                  >Translates &amp; transmits</motion.p>
-                  <p className="text-gray-500 text-[10px] sm:text-xs mt-0.5">DCC-EX CommandStation</p>
-                </div>
-              </div>
-            </motion.div>
-
-            <Connector direction="left-to-right" drawDelay={T.conn3Draw} dotDelay={T.dot3} color1="#8B5CF6" color2="#F97316" id="conn-3" />
-
-            {/* Row 4: Track — RIGHT (visible in grayscale, activates when dot arrives) */}
-            <motion.div
-              className="flex justify-end pr-4 sm:pr-8"
-              initial={{ opacity: 0, y: 10 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.5, delay: T.track, ease: EASE_ENTER }}
-            >
-              <div className="flex items-center gap-3">
-                <div className="text-right">
-                  <motion.p
-                    className="font-mono text-xs sm:text-sm font-semibold"
-                    initial={{ color: '#9CA3AF' }}
-                    animate={{ color: '#F97316' }}
-                    transition={{ delay: T.trackActivate, duration: 0.5 }}
-                  >Train moves</motion.p>
-                  <p className="text-gray-500 text-[10px] sm:text-xs mt-0.5">DCC Track</p>
-                </div>
-                <motion.div
-                  initial={{ opacity: 0, scale: 0.9 }}
-                  animate={{ opacity: 1, scale: 1 }}
-                  transition={{ delay: T.trackActivate, duration: 0.5, ease: 'easeOut' }}
-                >
-                  <OvalTrack activateAt={T.trackActivate} />
-                  <motion.div
-                    className="absolute -inset-2 rounded-2xl -z-10"
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: [0, 0.4, 0], scale: [0.95, 1.05, 1] }}
-                    transition={{ delay: T.trackActivate, duration: 0.8 }}
-                    style={{ background: 'radial-gradient(circle, rgba(249,115,22,0.3) 0%, transparent 70%)' }}
-                  />
-                </motion.div>
-              </div>
-            </motion.div>
+              </>
+            )}
           </div>
         </div>
+
       </div>
     </section>
   );

--- a/apps/dejajs-www/components/architecture/ArchitecturePage.tsx
+++ b/apps/dejajs-www/components/architecture/ArchitecturePage.tsx
@@ -1,8 +1,7 @@
 'use client';
 
+import { useState, type ReactNode } from 'react';
 import ArchitectureHero from './ArchitectureHero';
-import ArchitectureHeroV2 from './ArchitectureHeroV2';
-import ArchitectureHeroV3 from './ArchitectureHeroV3';
 import WhySection from './WhySection';
 import AppsSection from './AppsSection';
 import ServerSection from './ServerSection';
@@ -11,20 +10,47 @@ import DiagramSection from './DiagramSection';
 import VideoSection from './VideoSection';
 import UnderTheHoodSection from './UnderTheHoodSection';
 
+/** Wraps an animation in a remountable container with a replay button. 🔁 */
+function ReplayableAnimation({ children }: { children: (key: number) => ReactNode }) {
+  const [replayKey, setReplayKey] = useState(0);
+
+  return (
+    <div className="relative">
+      {children(replayKey)}
+      <div className="flex justify-center mt-4 mb-16 sm:mb-24">
+        <button
+          type="button"
+          onClick={() => setReplayKey((k) => k + 1)}
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-gray-700/60 bg-gray-900/60 hover:bg-gray-800/80 hover:border-deja-cyan/50 text-gray-300 hover:text-deja-cyan text-xs font-mono transition-colors backdrop-blur-sm"
+          aria-label="Replay animation"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="w-3.5 h-3.5"
+            aria-hidden="true"
+          >
+            <path d="M3 12a9 9 0 1 0 3-6.7" />
+            <path d="M3 4v5h5" />
+          </svg>
+          Replay
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export default function ArchitecturePage() {
   return (
     <div>
-      <ArchitectureHero />
-
-      <div className="border-t border-gray-700/50 my-8 -mx-6 px-6 pt-8">
-        <p className="text-xs text-gray-500 font-mono text-center mb-4">V2 — Vertical Centered</p>
-        <ArchitectureHeroV2 />
-      </div>
-
-      <div className="border-t border-gray-700/50 my-8 -mx-6 px-6 pt-8">
-        <p className="text-xs text-gray-500 font-mono text-center mb-4">V3 — Horizontal Genie</p>
-        <ArchitectureHeroV3 />
-      </div>
+      <ReplayableAnimation>
+        {(key) => <ArchitectureHero key={key} autoStart={key > 0} />}
+      </ReplayableAnimation>
 
       {/* Video — dark bg */}
       <div className="bg-gray-900/50 border-y border-gray-800/50 py-20 -mx-6 px-6">

--- a/apps/dejajs-www/components/architecture/DiagramSwitcher.tsx
+++ b/apps/dejajs-www/components/architecture/DiagramSwitcher.tsx
@@ -91,39 +91,44 @@ export default function DiagramSwitcher() {
     </div>
   );
 
-  const diagram = (
-    <AnimatePresence mode="wait">
-      <motion.div
-        key={activeId}
-        initial={{ opacity: 0, scale: 0.98 }}
-        animate={{ opacity: 1, scale: 1 }}
-        exit={{ opacity: 0, scale: 0.98 }}
-        transition={{ duration: 0.35, ease: [0.22, 1, 0.36, 1] }}
-      >
-        <ArchitectureDiagram config={activeId} />
-      </motion.div>
-    </AnimatePresence>
-  );
-
+  // Everything lives inside containerRef so the element that goes
+  // native-fullscreen actually contains the diagram. When expanded, the
+  // SVG is forced to fill its flex cell with `!w-full !h-full`, and its
+  // intrinsic preserveAspectRatio="xMidYMid meet" letterboxes it inside
+  // the viewport — so it fits 100% of the screen without overflowing.
   return (
-    <>
-      {/* Normal inline view */}
-      <div ref={containerRef}>
-        {toggleBar}
-        {!expanded && diagram}
+    <div
+      ref={containerRef}
+      className={
+        expanded
+          ? 'fixed inset-0 z-50 bg-gray-950 flex flex-col p-4 sm:p-6'
+          : ''
+      }
+    >
+      {toggleBar}
+      <div
+        className={
+          expanded
+            ? 'flex-1 min-h-0 min-w-0 flex items-center justify-center'
+            : ''
+        }
+      >
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={activeId}
+            className={expanded ? 'w-full h-full flex items-center justify-center' : 'w-full'}
+            initial={{ opacity: 0, scale: 0.98 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.98 }}
+            transition={{ duration: 0.35, ease: [0.22, 1, 0.36, 1] }}
+          >
+            <ArchitectureDiagram
+              config={activeId}
+              className={expanded ? '!w-full !h-full' : undefined}
+            />
+          </motion.div>
+        </AnimatePresence>
       </div>
-
-      {/* Expanded overlay */}
-      {expanded && (
-        <div className="fixed inset-0 z-50 bg-gray-950 flex flex-col">
-          <div className="p-4">
-            {toggleBar}
-          </div>
-          <div className="flex-1 overflow-auto p-4 flex items-center justify-center">
-            {diagram}
-          </div>
-        </div>
-      )}
-    </>
+    </div>
   );
 }

--- a/apps/dejajs-www/components/architecture/IoDevicesSection.tsx
+++ b/apps/dejajs-www/components/architecture/IoDevicesSection.tsx
@@ -16,10 +16,69 @@ const peripherals = [
   { label: 'Buttons', icon: '🔘', desc: 'Physical control panels, dispatcher boards' },
 ];
 
-const devices = [
-  { name: 'Arduino', desc: 'USB serial — direct pin control. Great for turnout machines, signals, and panel buttons near the command station.' },
-  { name: 'Pico W', desc: 'WiFi MQTT — wireless placement anywhere on the layout. Perfect for lighting, sound, and sensors in hard-to-reach spots.' },
+type DeviceConnection = 'usb' | 'wifi';
+
+const devices: { name: string; desc: string; connection: DeviceConnection; connectionLabel: string }[] = [
+  {
+    name: 'Arduino',
+    desc: 'USB serial — direct pin control. Great for turnout machines, signals, and panel buttons near the command station.',
+    connection: 'usb',
+    connectionLabel: 'USB serial',
+  },
+  {
+    name: 'Pico W',
+    desc: 'WiFi MQTT — wireless placement anywhere on the layout. Perfect for lighting, sound, and sensors in hard-to-reach spots.',
+    connection: 'wifi',
+    connectionLabel: 'Wi-Fi / MQTT',
+  },
 ];
+
+/** Icon-only indicator showing how a device talks to the DEJA Server. */
+function ConnectionIcon({ type, label }: { type: DeviceConnection; label: string }) {
+  return type === 'usb' ? (
+    // 🔌 USB icon
+    <svg
+      className="w-5 h-5 text-[rgb(234,179,8)]"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      role="img"
+      aria-label={label}
+    >
+      <title>{label}</title>
+      <circle cx="12" cy="20" r="1.5" fill="currentColor" />
+      <path d="M12 18.5V7" />
+      <path d="M12 7L8 11" />
+      <path d="M8 11V13" />
+      <path d="M6 13h4" />
+      <path d="M12 7L16 10" />
+      <rect x="14.5" y="9" width="3" height="3" rx="0.5" />
+      <circle cx="12" cy="4" r="2" />
+    </svg>
+  ) : (
+    // 📶 Wi-Fi icon
+    <svg
+      className="w-5 h-5 text-[rgb(234,179,8)]"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      role="img"
+      aria-label={label}
+    >
+      <title>{label}</title>
+      <path d="M5 12.55a11 11 0 0 1 14 0" />
+      <path d="M1.42 9a16 16 0 0 1 21.16 0" />
+      <path d="M8.53 16.11a6 6 0 0 1 6.95 0" />
+      <circle cx="12" cy="20" r="1" fill="currentColor" />
+    </svg>
+  );
+}
 
 export default function IoDevicesSection() {
   const sectionRef = useRef<HTMLDivElement>(null);
@@ -56,7 +115,10 @@ export default function IoDevicesSection() {
           >
             {devices.map((d) => (
               <div key={d.name} className="rounded-lg border border-[rgb(234,179,8)]/20 bg-[rgb(234,179,8)]/5 p-4">
-                <p className="text-[rgb(234,179,8)] font-semibold mb-1">{d.name}</p>
+                <div className="flex items-center justify-between gap-2 mb-1">
+                  <p className="text-[rgb(234,179,8)] font-semibold">{d.name}</p>
+                  <ConnectionIcon type={d.connection} label={d.connectionLabel} />
+                </div>
                 <p className="text-gray-400 text-sm">{d.desc}</p>
               </div>
             ))}

--- a/apps/dejajs-www/components/architecture/ServerSection.tsx
+++ b/apps/dejajs-www/components/architecture/ServerSection.tsx
@@ -7,8 +7,10 @@ import DocLink from '../DocLink';
 import TerminalMockup from './TerminalMockup';
 
 const terminalLines = [
-  { text: '$ deja start', color: 'text-deja-cyan' },
+  { text: '$ curl -fsSL install.dejajs.com | bash', color: 'text-gray-400' },
+  { text: '✓ Installed deja to ~/.deja', color: 'text-green-400' },
   { text: '', color: '' },
+  { text: '$ deja start', color: 'text-deja-cyan' },
   { text: '✓ WebSocket server on :8082', color: 'text-green-400' },
   { text: '✓ Firebase connected (layout: tamarack)', color: 'text-green-400' },
   { text: '✓ Serial: /dev/ttyUSB0 @ 115200', color: 'text-green-400' },
@@ -60,7 +62,7 @@ export default function ServerSection() {
           <p className="text-xs text-deja-cyan font-mono tracking-[0.2em] uppercase mb-3">DEJA Server</p>
           <h2 className="text-3xl sm:text-4xl font-bold text-white mb-4">One command. Everything connects.</h2>
           <p className="text-gray-400 leading-relaxed mb-6">The DEJA Server bridges your apps to your layout. It speaks WebSocket to your browser, Firebase to the cloud, serial to your DCC-EX command station, and MQTT to your IO devices.</p>
-          <p className="text-gray-400 leading-relaxed mb-6">Install it anywhere Node.js runs — your laptop, a Raspberry Pi, or a dedicated server. One command and your entire layout is online.</p>
+          <p className="text-gray-400 leading-relaxed mb-6">Install it anywhere Node.js runs — your laptop, a Raspberry Pi, or a dedicated server. One <code className="text-deja-cyan font-mono text-sm">curl</code> to install, one <code className="text-deja-cyan font-mono text-sm">deja start</code> to launch, and your entire layout is online.</p>
           <div className="flex flex-wrap gap-3">
             <Link href="/server" className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-deja-cyan/10 border border-deja-cyan/30 text-deja-cyan font-semibold text-sm hover:bg-deja-cyan/20 transition-colors">
               Explore Server

--- a/apps/dejajs-www/components/architecture/UnderTheHoodSection.tsx
+++ b/apps/dejajs-www/components/architecture/UnderTheHoodSection.tsx
@@ -10,13 +10,28 @@ const explainers = [
     color: 'border-deja-cyan/20',
   },
   {
+    question: 'How does authentication work?',
+    answer: 'Every app — Throttle, Cloud, Monitor — signs in with Firebase Authentication. Sessions are backed by signed JWT tokens and verified on every request, and the DEJA Server checks your subscription against Firestore before it will even open a port. You can share a layout with guest operators without handing out your password, and revoking access is instant.',
+    color: 'border-deja-cyan/20',
+  },
+  {
+    question: 'Is my layout data secure?',
+    answer: 'Your roster, routes, turnouts, and effects live in Firestore and Realtime Database, protected by per-layout security rules — only accounts you\'ve granted access can read or write them. All traffic between the apps, the server, and Firebase is TLS-encrypted in transit and encrypted at rest on Google\'s infrastructure. No layout data ever touches a public internet path in plaintext.',
+    color: 'border-blue-400/20',
+  },
+  {
     question: 'How does Firebase work?',
     answer: 'Firebase provides real-time sync between your apps and the server. When you change a throttle setting on your phone, Firebase pushes that change to the server instantly — no polling, no refresh. Your roster, routes, turnout states, and effects are all stored in Firebase so they persist across sessions and devices.',
     color: 'border-blue-400/20',
   },
   {
     question: 'What are Cloudflare Tunnels?',
-    answer: 'Cloudflare Tunnels let you access your layout from anywhere — not just your home WiFi. The DEJA Server creates a secure tunnel to Cloudflare\'s network, giving you a public URL that reaches your command station without opening router ports or configuring firewalls. Control your layout from work, from a friend\'s house, or from a train show.',
+    answer: 'Cloudflare Tunnels let you reach your layout from anywhere without exposing your home network. The DEJA Server opens an outbound-only encrypted tunnel to Cloudflare — there are no inbound router ports to forward, no firewall rules to punch holes in, and no DDNS to maintain. Cloudflare then routes authenticated requests through its global edge, giving you a public HTTPS URL that terminates inside your running server.',
+    color: 'border-purple-400/20',
+  },
+  {
+    question: 'Why Cloudflare on top of auth?',
+    answer: 'Cloudflare sits in front of every request as a second layer of defense. It handles TLS termination, shields the server from DDoS and bot traffic, and can enforce Cloudflare Access policies so only your accounts ever reach the tunnel. Combined with Firebase Auth inside the app, that\'s WAF + identity + subscription validation before any DCC command touches the track.',
     color: 'border-purple-400/20',
   },
   {

--- a/apps/dejajs-www/components/architecture/WhySection.tsx
+++ b/apps/dejajs-www/components/architecture/WhySection.tsx
@@ -96,7 +96,7 @@ export default function WhySection() {
       {/* Comparison cards */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {comparisons.map((comp, i) => (
-          <ComparisonCard key={comp.label} comparison={comp} index={i} scrollProgress={scrollYProgress} />
+          <ComparisonCard key={comp.label} comparison={comp} index={i} />
         ))}
       </div>
     </section>
@@ -130,19 +130,20 @@ function TechCard({
 function ComparisonCard({
   comparison,
   index,
-  scrollProgress,
 }: {
   comparison: (typeof comparisons)[number];
   index: number;
-  scrollProgress: ReturnType<typeof useScroll>['scrollYProgress'];
 }) {
-  const start = 0.55 + index * 0.06;
-  const end = start + 0.1;
-  const opacity = useTransform(scrollProgress, [start, end], [0, 1]);
-  const x = useTransform(scrollProgress, [start, end], [index === 0 ? -32 : 32, 0]);
-
+  // whileInView — the card fires as soon as it enters the viewport so the
+  // animation no longer depends on scroll progress, which can't reach 1 for
+  // the last section on the page.
   return (
-    <motion.div style={{ opacity, x }}>
+    <motion.div
+      initial={{ opacity: 0, x: index === 0 ? -32 : 32 }}
+      whileInView={{ opacity: 1, x: 0 }}
+      viewport={{ once: true, amount: 0.3 }}
+      transition={{ duration: 0.6, delay: index * 0.1, ease: [0.22, 1, 0.36, 1] }}
+    >
       <div className="rounded-xl border border-gray-700/50 bg-gray-800/30 p-6 h-full">
         <p className="text-white font-semibold mb-4">{comparison.label}</p>
         <ul className="space-y-3">

--- a/apps/dejajs-www/components/guides-list.ts
+++ b/apps/dejajs-www/components/guides-list.ts
@@ -1,0 +1,16 @@
+export interface GuideItem {
+  title: string;
+  href: string;
+  desc: string;
+  comingSoon?: boolean;
+}
+
+export const guides: GuideItem[] = [
+  { title: 'Getting Started', href: '/guides/getting-started', desc: 'From zero to driving trains' },
+  { title: 'Architecture', href: '/guides/architecture', desc: 'How the platform works' },
+  { title: 'Throttle', href: '/guides/throttle', desc: 'Train control & functions' },
+  { title: 'Server', href: '/guides/server', desc: 'Installation & CLI reference' },
+  { title: 'Cloud', href: '/guides/cloud', desc: 'Roster, turnouts & effects' },
+  { title: 'IO', href: '/guides/io', desc: 'Hardware expansion & MQTT' },
+  { title: 'Monitor', href: '/guides/monitor', desc: 'Diagnostics & logging', comingSoon: true },
+];


### PR DESCRIPTION
## Summary

Rebuilds the `/guides/architecture` page around a two-phase scroll/click-triggered hero animation and tightens up a pile of supporting polish across the guides experience.

### 🎬 Architecture hero animation
- Two-phase sequence on `ArchitectureHero`:
  - **Phase 1 (intro):** phone zooms out via `framer-motion layout` → connector 1 draws → blank terminal fades in → `$ deja start` types letter-by-letter → `✓ Ready` → connector 2 → DCC-EX fades in → connector 3 → track fades in with train parked
  - **Phase 2 (story):** tap ripple on phone → `You tap` label with pulsing drop-shadow glow → dot flies conn 1 → `Server routes` label → throttle & serial command lines roll into the terminal → dot conn 2 → `Translates & transmits` label → dot conn 3 → `Train moves` label → 🚂 train orbits the track
- Triggered by scrolling past 8px OR clicking the hero section; `autoStart` prop flips true on replay remount
- **Scroll clamp:** while the sequence plays, page scroll is clamped to the hero's bounds so users can navigate up/down within the hero but can't jump past it until the train is orbiting (mobile-friendly — allows scrolling to see the track on tall viewports)
- **Deterministic progress bar:** fixed below the nav header, full window width, `bg-cyan-900/70` fill that animates linearly over `SEQ.trainStart + 1.2s`, fades in on start + fades out after the sequence completes, header height measured dynamically via `getBoundingClientRect`
- **Label glow pulse:** step labels pulse to a bright `drop-shadow` then settle to a subtle sustained glow in their accent color
- Connector lines reverted to the original vertical-tangent S-curve + letterboxed `meet` aspect; graphics repositioned (`pl-[32%]` / `pr-[28%]` / `pl-[36%]` / `pr-[34%]`) so they sit near the curve endpoints
- Mobile labels stack above the graphic via responsive positioning + `mt-10` on each sequence row to reserve space; phone row gets `mt-12` so \"You tap\" doesn't collide with the headline paragraph
- Mobile hero section top padding bumped to `pt-28` + `scroll-mt-24` so `TAP.` no longer clips behind the sticky header
- Headline slides in from the left (`Tap.` → `Command.` → `Move.` staggered 0.15s); subhead fades up from below
- Replay button outside the component (`ArchitecturePage.tsx`) remounts via key, passes `autoStart={key > 0}` so replays auto-run

### 🧭 Guides nav polish
- Mobile sidebar menu button now shows the current guide title with a compact menu pill (`Guide` label + current title + \"Menu\"/\"Close\" toggle)
- Shared `guides-list.ts` so the sidebar and new `GuideFooterNav` consume the same source of truth
- New `GuideFooterNav` mounted in `app/guides/layout.tsx` — shows a \"Next guide\" card or a \"Back to top\" button on the final guide; skips `comingSoon` entries

### 🔒 Architecture content updates
- **ServerSection:** terminal now shows the install command `curl -fsSL install.dejajs.com | bash` before `deja start`; paragraph text updated
- **UnderTheHoodSection:** added three new explainer cards for authentication (Firebase Auth + JWT + subscription gating), layout data security (Firestore rules + TLS + encryption at rest), and \"Why Cloudflare on top of auth?\" (defense in depth — WAF + identity + subscription). Rewrote the Cloudflare Tunnels card to emphasize outbound-only encryption and no inbound port forwarding.
- **IoDevicesSection:** device cards get icon-only connection indicators (USB icon for Arduino, Wi-Fi icon for Pico W) — no label pill, accessible title tooltip
- **AppsSection:** removed `PhoneMockup` + tablet frame wrapper; screenshots now render as raw `next/image` with `rounded-xl shadow-2xl`
- **WhySection:** `ComparisonCard` migrated from `useScroll` progress-tied animation to `whileInView` — fixes the bug where the last section's cards never fully faded in because `scrollYProgress` can't reach 1 for the final section on a page
- `DiagramSwitcher` fullscreen fix: restructured so `containerRef` actually contains the diagram (previously it was conditionally rendered into a sibling overlay, causing the black-screen fullscreen bug); SVG is forced to `!w-full !h-full` in expanded mode so it fills 100% of the screen via `preserveAspectRatio=\"meet\"` letterboxing
- Removed V2 / V3 hero variants from `ArchitecturePage`

## Test plan

- [ ] `/guides/architecture` on desktop: scroll or click hero → intro animation plays → story sequence runs → train orbits → scroll unlocks → progress bar fades out
- [ ] `/guides/architecture` on mobile: `TAP.` visible below header, labels stack above each graphic, scrolling down during animation clamps at hero bottom
- [ ] Replay button (below hero) restarts the full sequence from the beginning
- [ ] Every other guide's mobile menu shows the current guide title
- [ ] Next Guide card appears at the bottom of each guide page; Monitor (comingSoon) is skipped; last guide shows \"Back to top\"
- [ ] Diagram fullscreen button on DiagramSection fills the screen with the diagram (not a black box)
- [ ] `WhySection` comparison cards fully fade in when scrolled into view
- [ ] Headline \"Tap. Command. Move.\" slides in from the left on initial page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)