### PR TITLE
feat(throttle): 🎛️ conductor settings + container-query list components

### DIFF
--- a/apps/throttle/src/conductor/ConductorLayout.vue
+++ b/apps/throttle/src/conductor/ConductorLayout.vue
@@ -5,13 +5,19 @@ import ButtonsThrottle from '@/throttle/ButtonsThrottle.vue'
 import SliderThrottle from '@/throttle/SliderThrottle.vue'
 import Dashboard from '@/throttle/Dashboard.vue'
 import ThrottleList from '@/throttle/ThrottleList.vue'
-import { TurnoutList } from '@repo/ui'
-import { useThrottleSettings } from '@/throttle/useThrottleSettings'
+import Routes from '@/routes/Routes.vue'
+import {
+  TurnoutList,
+  EffectList,
+  SignalList,
+  DeviceConnectionList,
+} from '@repo/ui'
+import { useConductorSettings } from '@/conductor/useConductorSettings'
 
 const { getThrottles } = useLocos()
 const throttles = getThrottles()
 
-const { variant } = useThrottleSettings()
+const { variant, rightPanel } = useConductorSettings()
 
 const variantMap = {
   buttons: ButtonsThrottle,
@@ -21,32 +27,41 @@ const variantMap = {
 
 const variantComponent = computed(() => variantMap[variant.value] ?? ButtonsThrottle)
 
+const rightPanelMap = {
+  turnouts: TurnoutList,
+  effects: EffectList,
+  signals: SignalList,
+  devices: DeviceConnectionList,
+  routes: Routes,
+} as const
+
+const rightPanelComponent = computed(() => rightPanelMap[rightPanel.value] ?? TurnoutList)
+
 </script>
   <template>
     <main class="@container relative">
       <div class="conductor-layout grid grid-cols-1 @[960px]:grid-cols-3 gap-2 w-full">
-      <div class="rounded border-1 border-green-500 border-opacity-50 order-2 @[960px]:!order-1 overflow-hidden" style="background: rgba(var(--v-theme-surface), 0.2)">
-        <div class="@container h-full overflow-y-auto p-4">
+      <div class="rounded border-1 border-green-500 border-opacity-50 order-2 @[960px]:!order-1 overflow-hidden min-h-[70vh] @[960px]:min-h-0" style="background: rgba(var(--v-theme-surface), 0.2)">
+        <div class="@container h-full overflow-hidden p-4">
           <!-- Column 1 content goes here -->
-          <div v-if="throttles?.length" class="flex-grow flex flex-row flex-wrap gap-1 relative overflow-auto items-end content-end">
-            <div class="flex-grow"></div>
+          <div v-if="throttles?.length" class="relative h-full w-full">
             <ThrottleList />
           </div>
         </div>
       </div>
-      <div class="order-1 @[960px]:!order-2 overflow-hidden" style="background: rgba(var(--v-theme-surface), 0.2)">
-        <div class="@containermin-h-[500px] h-full overflow-y-auto p-4">
+      <div class="order-1 @[960px]:!order-2 overflow-hidden min-h-[90vh] @[960px]:min-h-0" style="background: rgba(var(--v-theme-surface), 0.2)">
+        <div class="@container h-full overflow-y-auto p-4">
           <!-- Column 2 content goes here -->
            <v-carousel v-if="throttles && throttles.length > 0" height="100%" class="min-h-90vh" hideDelimiters>
             <v-carousel-item v-for="(item) in throttles" :key="item.address" draggable>
-              <component :is="variantComponent" :address="item.address" :show-speedometer="false" />
+              <component :is="variantComponent" :address="item.address" :show-speedometer="false" :show-consist="false" />
             </v-carousel-item>
           </v-carousel>
         </div>
       </div>
-      <div class="order-3 overflow-hidden" style="background: rgba(var(--v-theme-surface), 0.2)">
+      <div class="order-3 overflow-hidden min-h-[70vh] @[960px]:min-h-0" style="background: rgba(var(--v-theme-surface), 0.2)">
         <div class="@container h-full overflow-y-auto p-4">
-          <TurnoutList />
+          <component :is="rightPanelComponent" />
         </div>
       </div>
     </div>

--- a/apps/throttle/src/conductor/useConductorSettings.ts
+++ b/apps/throttle/src/conductor/useConductorSettings.ts
@@ -1,0 +1,39 @@
+import { computed } from 'vue'
+import type { ComputedRef } from 'vue'
+import {
+  useUserPreferences,
+  type ConductorSettings,
+  type ConductorRightPanel,
+  type ThrottleVariant,
+} from '@repo/modules'
+
+const DEFAULTS: ConductorSettings = {
+  variant: 'buttons',
+  rightPanel: 'turnouts',
+}
+
+export function useConductorSettings() {
+  const { getPreference, setPreference } = useUserPreferences()
+
+  const settings: ComputedRef<ConductorSettings> = getPreference('conductorSettings', DEFAULTS)
+
+  const variant = computed(() => settings.value.variant)
+  const rightPanel = computed(() => settings.value.rightPanel)
+
+  async function setVariant(value: ThrottleVariant) {
+    await setPreference('conductorSettings', { ...settings.value, variant: value })
+  }
+
+  async function setRightPanel(value: ConductorRightPanel) {
+    await setPreference('conductorSettings', { ...settings.value, rightPanel: value })
+  }
+
+  return {
+    variant,
+    rightPanel,
+    setVariant,
+    setRightPanel,
+  }
+}
+
+export default useConductorSettings

--- a/apps/throttle/src/throttle/Dashboard.vue
+++ b/apps/throttle/src/throttle/Dashboard.vue
@@ -244,7 +244,7 @@ onBeforeUnmount(() => {
             :color="loco.meta?.roadname ? ROADNAMES.find(r => r.value === loco.meta?.roadname)?.color : undefined"
             size="sm"
           />
-          <ConsistIndicator v-if="loco" :loco="loco" />
+          <ConsistIndicator v-if="loco && showConsist" :loco="loco" />
           <v-spacer class="w-2 md:w-6" />
           <h1 class="text-xl md:text-4xl font-bold tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-cyan-400 drop-shadow-lg">
             {{ loco?.name }}

--- a/apps/throttle/src/throttle/SliderThrottle.vue
+++ b/apps/throttle/src/throttle/SliderThrottle.vue
@@ -74,7 +74,7 @@ async function clearLoco() {
             :color="loco.meta?.roadname ? ROADNAMES.find(r => r.value === loco.meta?.roadname)?.color : undefined"
             size="sm"
           />
-          <ConsistIndicator v-if="loco" :loco="loco" />
+          <ConsistIndicator v-if="loco && showConsist" :loco="loco" />
           <v-spacer class="w-2 md:w-6" />
           <h1 class="text-xl md:text-4xl font-bold tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-cyan-400 drop-shadow-lg">
             {{ loco?.name }}
@@ -144,6 +144,15 @@ async function clearLoco() {
           />
           <span class="text-xs font-bold" :class="isForward ? 'text-green-400' : 'opacity-40'">FWD</span>
         </div>
+        <v-btn
+          icon="mdi-stop-circle-outline"
+          color="red"
+          size="large"
+          variant="tonal"
+          class="mt-3"
+          aria-label="Stop"
+          @click="handleStop"
+        />
       </section>
 
       <!-- Mobile: Functions + Logo -->

--- a/apps/throttle/src/throttle/ThrottleList.vue
+++ b/apps/throttle/src/throttle/ThrottleList.vue
@@ -71,7 +71,7 @@ watch(
     <div class="absolute w-[500px] h-[500px] rounded-full bg-blue-500/10 blur-[80px] -bottom-[100px] -right-[200px]"></div>
     <div class="absolute w-[400px] h-[400px] rounded-full bg-violet-500/10 blur-[90px] top-[30%] left-[40%]"></div>
   </div>
-  <div v-if="throttles" class="throttle-list-container">
+  <div v-if="throttles" class="throttle-list-container @container">
     <draggable
       v-model="orderedThrottles"
       item-key="address"
@@ -80,7 +80,7 @@ watch(
       :animation="150"
     >
       <template #item="{ element }">
-        <div class="basis-full md:basis-1/2 p-1">
+        <div class="basis-full @[600px]:basis-1/2 p-1">
           <ThrottleTile v-if="element.address" :address="element.address" />
         </div>
       </template>
@@ -115,8 +115,7 @@ watch(
   inset: 0;
   display: flex;
   flex-direction: column;
-  justify-content: flex-end;
-  overflow: auto;
+  overflow-y: auto;
   padding-bottom: 4rem;
 }
 

--- a/apps/throttle/src/throttle/ThrottleTile.vue
+++ b/apps/throttle/src/throttle/ThrottleTile.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import { computed, ref, toRef } from 'vue'
+import { computed, toRef } from 'vue'
 import { useRouter } from 'vue-router'
 import ThrottleButtonControls from './ThrottleButtonControls.vue'
 import CurrentSpeed from './CurrentSpeed.vue'
 import RoadnameLogo from '@/throttle/RoadnameLogo.vue'
+import { LocoNumberPlate } from '@repo/ui'
 import { useThrottle } from './useThrottle'
 
 const props = defineProps({
@@ -15,17 +16,20 @@ const props = defineProps({
 
 const $router = useRouter()
 const addressRef = toRef(props, 'address')
-const isMenuOpen = ref(false)
 const {
   adjustSpeed: handleAdjustSpeed,
   currentSpeed,
   loco,
-  releaseThrottle,
   stop: handleStop,
   throttle,
 } = useThrottle(addressRef)
 
-const locoColor = computed(() => loco?.meta?.color || 'primary')
+const plateColor = computed(() => loco?.meta?.color || undefined)
+
+function openThrottle() {
+  if (!loco?.address) return
+  $router.push({ name: 'throttle', params: { address: loco.address } })
+}
 </script>
 <template>
   <main v-if="throttle" class="rounded-2xl shadow-xl relative bg-gradient-to-br from-violet-800 to-cyan-500 bg-gradient-border ">
@@ -48,34 +52,20 @@ const locoColor = computed(() => loco?.meta?.color || 'primary')
         <span class="bg-clip-text text-transparent bg-gradient-to-r from-violet-500 to-cyan-400 font-bold">{{loco?.name || throttle.address}}</span>
       </div>
       <div class="order-2 basis-1/3 pr-2 flex justify-end">
-        <v-speed-dial
+        <component
           v-if="loco"
-          v-model="isMenuOpen"
-          location="left center"
-          transition="fade-transition"
-          contained
+          :is="loco.consist?.length ? 'v-badge' : 'div'"
+          :color="loco.consist?.length ? 'primary' : undefined"
+          :content="loco.consist?.length"
+          class="cursor-pointer"
+          @click="openThrottle"
         >
-          <template v-slot:activator="{ props: activatorProps }">
-            <component
-              :is="loco.consist?.length ? 'v-badge' : 'div'"
-              :color="loco.consist?.length ? 'primary' : undefined"
-              :content="loco.consist?.length"
-            >
-              <v-btn
-                v-bind="activatorProps"
-                :color="locoColor"
-                rounded="circle"
-                :size="48"
-                :text="loco.address?.toString() || '?'"
-                variant="tonal"
-              />
-            </component>
-          </template>
-          <v-btn @click="$router.push({ name: 'throttle', params: { address: loco.address } })" :color="locoColor" icon="mdi-gamepad-square" />
-          <v-btn @click="$router.push({ name: 'throttle-list' })" :color="locoColor" icon="mdi-view-sequential-outline" />
-          <v-btn @click="releaseThrottle" :color="locoColor" icon="mdi-parking" />
-          <v-btn @click="handleStop" :color="locoColor" icon="mdi-stop-circle-outline" />
-        </v-speed-dial>
+          <LocoNumberPlate
+            :address="loco.address"
+            :color="plateColor"
+            size="sm"
+          />
+        </component>
       </div>
     </section>
   </main>

--- a/apps/throttle/src/views/SettingsView.vue
+++ b/apps/throttle/src/views/SettingsView.vue
@@ -14,6 +14,7 @@ import { useDisplay } from 'vuetify'
 import { wiThrottleService } from '@/services/WiThrottleService'
 import { useServerDiscovery } from '@/composables/useServerDiscovery'
 import { useThrottleSettings } from '@/throttle/useThrottleSettings'
+import { useConductorSettings } from '@/conductor/useConductorSettings'
 import { useQuickMenu } from '@/quick-menu/useQuickMenu'
 
 const user = useCurrentUser()
@@ -25,6 +26,13 @@ const {
   variant, showFunctions, showSpeedometer, showConsist,
   setVariant, setShowFunctions, setShowSpeedometer, setShowConsist,
 } = useThrottleSettings()
+
+const {
+  variant: conductorVariant,
+  rightPanel: conductorRightPanel,
+  setVariant: setConductorVariant,
+  setRightPanel: setConductorRightPanel,
+} = useConductorSettings()
 
 const { quickMenuVisible } = useQuickMenu()
 
@@ -138,6 +146,7 @@ const sections = [
   { id: 'billing', label: 'Billing', icon: 'mdi-credit-card-outline' },
   { id: 'appearance', label: 'Appearance', icon: 'mdi-palette-outline' },
   { id: 'throttle', label: 'Throttle & Quick Menu', icon: 'mdi-speedometer' },
+  { id: 'conductor', label: 'Conductor', icon: 'mdi-account-hard-hat' },
   { id: 'connection', label: 'Connection', icon: 'mdi-server-network' },
   { id: 'server-setup', label: 'Server Setup', icon: 'mdi-download-outline' },
   { id: 'favorites', label: 'Favorites', icon: 'mdi-star-outline' },
@@ -302,6 +311,66 @@ const backgroundPages = [
             </div>
             <div class="settings-row__value">
               <v-switch v-model="quickMenuVisible" color="primary" density="compact" hide-details />
+            </div>
+          </div>
+        </div>
+
+        <!-- Conductor -->
+        <div id="conductor" class="settings-section">
+          <div class="settings-section__header">
+            <v-icon size="20" class="settings-section__icon">mdi-account-hard-hat</v-icon>
+            <h2 class="settings-section__title">Conductor</h2>
+          </div>
+          <div class="settings-row">
+            <div class="settings-row__label">
+              <span class="settings-row__name">Throttle Style</span>
+              <span class="settings-row__desc">Throttle control style used inside the Conductor view</span>
+            </div>
+            <div class="settings-row__value">
+              <v-btn-toggle :model-value="conductorVariant" @update:model-value="(v) => setConductorVariant(v)" mandatory divided density="compact" variant="outlined" color="primary">
+                <v-btn value="buttons" size="small" class="text-none">
+                  <v-icon start size="16">mdi-gesture-tap-button</v-icon>
+                  <span class="hidden sm:inline">Buttons</span>
+                </v-btn>
+                <v-btn value="slider" size="small" class="text-none">
+                  <v-icon start size="16">mdi-tune-vertical</v-icon>
+                  <span class="hidden sm:inline">Slider</span>
+                </v-btn>
+                <v-btn value="dashboard" size="small" class="text-none">
+                  <v-icon start size="16">mdi-train</v-icon>
+                  <span class="hidden sm:inline">Dashboard</span>
+                </v-btn>
+              </v-btn-toggle>
+            </div>
+          </div>
+          <div class="settings-row">
+            <div class="settings-row__label">
+              <span class="settings-row__name">Right Panel</span>
+              <span class="settings-row__desc">Which component to load in the Conductor's right column</span>
+            </div>
+            <div class="settings-row__value">
+              <v-btn-toggle :model-value="conductorRightPanel" @update:model-value="(v) => setConductorRightPanel(v)" mandatory divided density="compact" variant="outlined" color="primary">
+                <v-btn value="turnouts" size="small" class="text-none">
+                  <v-icon start size="16">mdi-directions-fork</v-icon>
+                  <span class="hidden sm:inline">Turnouts</span>
+                </v-btn>
+                <v-btn value="effects" size="small" class="text-none">
+                  <v-icon start size="16">mdi-auto-fix</v-icon>
+                  <span class="hidden sm:inline">Effects</span>
+                </v-btn>
+                <v-btn value="signals" size="small" class="text-none">
+                  <v-icon start size="16">mdi-traffic-light</v-icon>
+                  <span class="hidden sm:inline">Signals</span>
+                </v-btn>
+                <v-btn value="devices" size="small" class="text-none">
+                  <v-icon start size="16">mdi-chip</v-icon>
+                  <span class="hidden sm:inline">Devices</span>
+                </v-btn>
+                <v-btn value="routes" size="small" class="text-none">
+                  <v-icon start size="16">mdi-map-marker-path</v-icon>
+                  <span class="hidden sm:inline">Routes</span>
+                </v-btn>
+              </v-btn-toggle>
             </div>
           </div>
         </div>

--- a/packages/modules/preferences/types.ts
+++ b/packages/modules/preferences/types.ts
@@ -12,9 +12,17 @@ export interface ThrottleSettings {
   showConsist: boolean
 }
 
+export type ConductorRightPanel = 'turnouts' | 'effects' | 'signals' | 'devices' | 'routes'
+
+export interface ConductorSettings {
+  variant: ThrottleVariant
+  rightPanel: ConductorRightPanel
+}
+
 export interface UserPreferences {
   backgrounds: {
     [appName: string]: AppBackgroundPrefs
   }
   throttleSettings?: ThrottleSettings
+  conductorSettings?: ConductorSettings
 }

--- a/packages/ui/src/ListControls/ListControlBar.vue
+++ b/packages/ui/src/ListControls/ListControlBar.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { ref } from 'vue'
-import { useDisplay } from 'vuetify'
 import type { ListControlsReturn, ViewOption, SortOption, ListFilter } from './types'
 import ListSearch from './ListSearch.vue'
 import ListViewToggle from './ListViewToggle.vue'
@@ -33,16 +32,15 @@ const props = withDefaults(defineProps<{
   filters: () => [],
 })
 
-const { mdAndUp } = useDisplay()
-
 const showViewSheet = ref(false)
 const showSortSheet = ref(false)
 const showFilterSheet = ref(false)
 </script>
 
 <template>
-  <!-- Desktop: inline controls bar -->
-  <div v-if="mdAndUp">
+  <div class="@container">
+  <!-- Desktop: inline controls bar (shown when container ≥ 640px) -->
+  <div class="hidden @[640px]:block">
     <div class="lcb-bar">
       <ListFilters
         v-if="showFilters && filters.length"
@@ -110,8 +108,8 @@ const showFilterSheet = ref(false)
     </div>
   </div>
 
-  <!-- Mobile: search bar + icon buttons -->
-  <div v-else class="px-2 py-2">
+  <!-- Mobile: search bar + icon buttons (shown when container < 640px) -->
+  <div class="block @[640px]:hidden px-2 py-2">
     <div class="flex items-center gap-2">
       <ListSearch
         v-if="showSearch"
@@ -200,6 +198,7 @@ const showFilterSheet = ref(false)
       @update:active-filters="controls.activeFilters.value = $event"
       :color="color"
     />
+  </div>
   </div>
 </template>
 

--- a/packages/ui/src/ModuleList/List.vue
+++ b/packages/ui/src/ModuleList/List.vue
@@ -32,7 +32,7 @@ function handleUpdateState(item: DocumentData, newState: boolean) {
 </script>
 
 <template>
-  <div class="w-full p-4">
+  <div class="@container w-full p-4">
     <v-row v-if="loading">
       <v-col v-for="n in 6" :key="n" :cols="cols.xs" :sm="cols.sm" :md="cols.md" :lg="cols.lg" :xl="cols.xl" :xxl="cols.xxl">
         <v-skeleton-loader type="card" />

--- a/packages/ui/src/Turnouts/TurnoutList.vue
+++ b/packages/ui/src/Turnouts/TurnoutList.vue
@@ -94,7 +94,7 @@ async function handleTurnout(turnout: Turnout) {
         :turnout="item as Turnout"
         :turnout-id="item?.id"
         :state="item.state"
-        class="w-42 sm:w-64 md:w-84"
+        class="w-32 @sm:w-40 @md:w-48 @lg:w-56 @xl:w-64"
       />
     </template>
   </List>


### PR DESCRIPTION
## Summary

Adds a new **Conductor** settings section in the throttle app and reworks the Conductor layout + embedded list components so they render in their compact/mobile mode based on **column width** (via Tailwind container queries) instead of viewport size.

## What changed

### ⚙️ Conductor settings
- New \`ConductorSettings\` preference (\`variant\` + \`rightPanel\`) stored via \`useUserPreferences\`
- New \`useConductorSettings\` composable — independent from the global throttle settings so the Conductor view can be tuned separately
- \`SettingsView\` gains a **Conductor** section with two \`v-btn-toggle\`s:
  - **Throttle Style** — Buttons / Slider / Dashboard
  - **Right Panel** — Turnouts / Effects / Signals / Devices / Routes

### 🎚️ ConductorLayout
- Right column now renders a dynamic \`<component :is=\"rightPanelComponent\">\`
- Variant component receives \`:show-consist=\"false\"\` and \`:show-speedometer=\"false\"\` so the tile throttles are clean of extras
- Mobile grid cells now get real \`min-h-[70vh]\` / \`min-h-[90vh]\` with \`@[960px]:min-h-0\` so \`ThrottleList\` is fully visible when the layout collapses to a single column
- Fixed a pre-existing typo: \`@containermin-h-[500px]\` → \`@container\`
- Fixed the left-column wrapper which previously relied on \`flex-grow\` inside a non-flex parent (collapsed \`ThrottleList\`'s \`absolute inset-0\` to zero height)

### 🚂 ThrottleList + ThrottleTile
- Tile basis switched from viewport \`md:basis-1/2\` to container-query \`@[600px]:basis-1/2\` → full-width in narrow columns, 2-up in wide lists
- Removed \`justify-content: flex-end\` scroll bug so the list scrolls properly when overflowing
- \`ThrottleTile\` replaced the \`v-speed-dial\` address button with a \`LocoNumberPlate\` coloured by \`loco.meta.color\`; clicking the plate now navigates directly to \`/throttle/:address\`

### 🛑 SliderThrottle
- Added a tonal red \`mdi-stop-circle-outline\` stop button below the FWD/REV toggle
- Header \`ConsistIndicator\` now respects \`showConsist\`

### 🎛️ TurnoutList / List / ListControlBar
- \`CTCSwitch\` sized via container queries (\`w-32 @sm:w-40 @md:w-48 @lg:w-56 @xl:w-64\`) — two fit comfortably in a narrow mobile row
- \`List.vue\` root now has \`@container\` so container queries propagate on full-page views too
- \`ListControlBar\` dropped \`useDisplay()\` / \`mdAndUp\`; template wrapped in \`@container\` and uses \`@[640px]\` to swap between the inline desktop toolbar and the compact mobile sheet UI. Same component now renders full bar on the \`/turnouts\` page and compact bar inside the narrow Conductor column.

## Test plan

- [ ] Settings → Conductor: toggle throttle style (Buttons / Slider / Dashboard) and confirm Conductor updates
- [ ] Settings → Conductor: toggle right panel through all five options (Turnouts / Effects / Signals / Devices / Routes) and confirm they render
- [ ] Conductor view on desktop (≥960px): three-column layout with throttle list on the left, carousel in middle, selected panel on the right
- [ ] Conductor view below 960px: columns stack vertically, each section has real height, throttle list fully visible and scrollable
- [ ] Right column: ListControlBar renders in mobile mode (search + icon buttons + bottom sheets)
- [ ] Right column: two CTC switches fit side-by-side
- [ ] Full-page \`/turnouts\` route: ListControlBar still renders in the desktop inline toolbar mode
- [ ] ThrottleTile: LocoNumberPlate shows loco color, click navigates to throttle route
- [ ] SliderThrottle: stop button appears and zeroes the slider; header has no consist badge inside Conductor

🤖 Generated with [Claude Code](https://claude.com/claude-code)