### PR TITLE
fix(io): 🔧 unblock Arduino deploy on Nano clones and disabled sensors

### DIFF
--- a/io/scripts/lib/deploy-arduino.ts
+++ b/io/scripts/lib/deploy-arduino.ts
@@ -1,9 +1,11 @@
 // 🔧 Arduino compile & upload via arduino-cli
 
 import { execSync } from 'child_process'
-import { ensureArduinoCli } from './detect.js'
+import { ensureArduinoCli, ensureArduinoLibs } from './detect.js'
 
 const DEFAULT_BOARD = 'arduino:avr:mega:cpu=atmega2560'
+
+const REQUIRED_LIBS = ['Adafruit PWM Servo Driver Library', 'ArduinoJson', 'TurnoutPulser']
 
 export interface ArduinoDeployOptions {
   sketchPath: string
@@ -21,6 +23,8 @@ export async function compileAndUpload(options: ArduinoDeployOptions): Promise<v
   if (!available) {
     process.exit(1)
   }
+
+  ensureArduinoLibs(REQUIRED_LIBS)
 
   console.log(`🔨 Compiling sketch at ${sketchPath}...`)
   console.log(`   Board: ${board}`)

--- a/io/scripts/lib/detect.ts
+++ b/io/scripts/lib/detect.ts
@@ -98,6 +98,52 @@ export async function ensureArduinoCli(): Promise<boolean> {
   return false
 }
 
+/**
+ * Ensure required Arduino libraries are installed. Installs any missing ones.
+ */
+export function ensureArduinoLibs(requiredLibs: string[]): void {
+  if (requiredLibs.length === 0) return
+  if (!isArduinoCliInstalled()) return
+
+  let installed = new Set<string>()
+  try {
+    const output = execSync('arduino-cli lib list --format json', {
+      stdio: 'pipe',
+      encoding: 'utf-8',
+    })
+    const data = JSON.parse(output)
+    const libs = data.installed_libraries || data || []
+    installed = new Set(
+      (Array.isArray(libs) ? libs : [])
+        .map((l: { library?: { name?: string } }) => l.library?.name)
+        .filter((name: string | undefined): name is string => Boolean(name))
+    )
+  } catch {
+    // If listing fails, attempt to install everything — arduino-cli is a no-op if already present
+  }
+
+  const missing = requiredLibs.filter(name => !installed.has(name))
+  if (missing.length === 0) return
+
+  console.log(`📚 Installing missing Arduino libraries: ${missing.join(', ')}`)
+  for (const lib of missing) {
+    try {
+      execSync(`arduino-cli lib install "${lib}"`, { stdio: 'pipe', encoding: 'utf-8' })
+      console.log(`   ✅ ${lib}`)
+    } catch (err) {
+      const stderr = (err as { stderr?: Buffer | string })?.stderr?.toString() || ''
+      if (stderr.includes('already exists')) {
+        // 📦 Library is on disk from a prior install — treat as success
+        console.log(`   ✅ ${lib} (already installed)`)
+        continue
+      }
+      console.error(`❌ Failed to install Arduino library: ${lib}`)
+      if (stderr) console.error(stderr)
+      process.exit(1)
+    }
+  }
+}
+
 export interface ArduinoBoard {
   port: string
   boardName: string
@@ -123,13 +169,22 @@ export function findArduinoBoards(): ArduinoBoard[] {
     const ports = data.detected_ports || data || []
     for (const entry of Array.isArray(ports) ? ports : []) {
       const port = entry.port?.address
+      if (!port) continue
       const matchingBoards = entry.matching_boards || []
-      if (port && matchingBoards.length > 0) {
+      if (matchingBoards.length > 0) {
         boards.push({
           port,
           boardName: matchingBoards[0].name || 'Unknown',
           fqbn: matchingBoards[0].fqbn || '',
         })
+        continue
+      }
+      // 🔌 Boards without USB VID/PID (Nano clones, CH340) don't self-identify.
+      // Include them if they look like a USB serial port so the user can still pick them.
+      const protocolLabel: string = entry.port?.protocol_label || ''
+      const hasUsbProps = Boolean(entry.port?.properties?.vid)
+      if (protocolLabel.toLowerCase().includes('usb') || hasUsbProps) {
+        boards.push({ port, boardName: 'Unknown (USB serial)', fqbn: '' })
       }
     }
 

--- a/io/src/deja-arduino/deja-arduino.ino
+++ b/io/src/deja-arduino/deja-arduino.ino
@@ -75,7 +75,7 @@ void loop()
     handleInput();
   }
 
-  static unsigned long lastChangeTime[sizeof(SENSORPINS) / sizeof(SENSORPINS[0])] = {0}; // Array to store last change times
+#if ENABLE_SENSORS
   unsigned long currentTime = millis();
 
   for (int i = 0; i < (sizeof(SENSORPINS) / sizeof(SENSORPINS[0])); i++)
@@ -92,6 +92,7 @@ void loop()
       lastChangeTime[i] = currentTime;   // Update last change time
     }
   }
+#endif
 }
 
 void handleInput()


### PR DESCRIPTION
## Summary

- 📚 Auto-install required Arduino libraries during deploy (`Adafruit PWM Servo Driver Library`, `ArduinoJson`, `TurnoutPulser`) via a new `ensureArduinoLibs()` helper in `scripts/lib/detect.ts`. Treats "already exists" as success so stale library directories don't block the flow.
- 🔌 Include USB serial ports without a self-identifying VID/PID in board detection so Arduino Nano clones (CH340, FTDI) can actually be selected from the deploy prompt. Previously the prompt errored with "No Arduino boards detected" even when a clone was clearly plugged in.
- 🛠️ Guard the sensor-reading block in \`deja-arduino.ino\` with \`#if ENABLE_SENSORS\` and remove a duplicate shadowing \`lastChangeTime\` declaration. Fixes a compile error on devices that have sensors disabled (e.g. betatrack) where \`SENSORPINS\` is a zero-length array.

## Test plan

- [x] 🚂 \`pnpm run deploy\` on betatrack (Nano clone, sensors disabled) compiles and uploads successfully
- [ ] Verify sketch still compiles on a Mega with \`ENABLE_SENSORS=true\`
- [ ] Verify \`ensureArduinoLibs\` is a no-op on a system that already has all libraries installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)