### PR TITLE
fix(cloud): 🛠️ sensor form bugs + device details sensors/signals

### DIFF
--- a/apps/cloud/src/Layout/Devices/DeviceDetails.vue
+++ b/apps/cloud/src/Layout/Devices/DeviceDetails.vue
@@ -6,7 +6,7 @@ import { doc, setDoc, serverTimestamp } from 'firebase/firestore'
 import { db } from '@repo/firebase-config'
 import { useStorage, useClipboard } from '@vueuse/core'
 import { useColors } from '@/Core/UI/useColors'
-import { deviceTypes, useTurnouts, useEfx, useLayout, useLocos, type Device, type Effect, type Loco, type Turnout, efxTypes } from '@repo/modules'
+import { deviceTypes, useTurnouts, useEfx, useLayout, useLocos, useSignals, useSensors, type Device, type Effect, type Loco, type Turnout, type Signal, type Sensor, efxTypes } from '@repo/modules'
 import { StatusPulse, TrackOutputConfig } from '@repo/ui'
 import { useTrackOutputs, type TrackOutput } from '@repo/dccex'
 import { useNotification } from '@repo/ui'
@@ -15,6 +15,8 @@ import { useDeviceConfig } from './useDeviceConfig'
 const { getDevice, getDevices } = useLayout()
 const { getTurnoutsByDevice } = useTurnouts()
 const { getEffectsByDevice } = useEfx()
+const { getSensorsByDevice } = useSensors()
+const { getSignalsByDevice } = useSignals()
 const { getLocos } = useLocos()
 const { colors, DEFAULT_COLOR } = useColors()
 const { notify } = useNotification()
@@ -24,6 +26,8 @@ const deviceIdParam = route.currentRoute.value.params.deviceId || ''
 const deviceId = Array.isArray(deviceIdParam) ? deviceIdParam[0] : deviceIdParam
 const turnouts = useCollection(getTurnoutsByDevice(deviceId))
 const effects = useCollection(getEffectsByDevice(deviceId))
+const sensors = getSensorsByDevice(deviceId)
+const signals = getSignalsByDevice(deviceId)
 const locos = getLocos()
 
 const layoutId = useStorage<string | null>('@DEJA/layoutId', null)
@@ -37,10 +41,20 @@ onMounted(async () => {
 
 const deviceType = computed(() => deviceTypes.find((type) => type.value === device.value?.type))
 
+// 🔀 Client-side sorting (Firestore composite indexes aren't deployed for these)
+const sortedSensors = computed<Sensor[]>(() =>
+  [...((sensors?.value ?? []) as Sensor[])].sort((a, b) => (a.index ?? 0) - (b.index ?? 0))
+)
+const sortedSignals = computed<Signal[]>(() =>
+  [...((signals?.value ?? []) as Signal[])].sort((a, b) => (a.name || '').localeCompare(b.name || ''))
+)
+
 const { isArduino, isPicoW, isDccEx, arduinoConfigH, picoConfigJson, dccExAutomationH } = useDeviceConfig({
   device,
   effects: computed(() => (effects.value ?? []) as Effect[]),
   turnouts: computed(() => (turnouts.value ?? []) as Turnout[]),
+  sensors: sortedSensors,
+  signals: sortedSignals,
   locos: computed(() => (locos.value ?? []) as Loco[]),
   layoutId: computed(() => layoutId.value ?? ''),
 })
@@ -370,7 +384,7 @@ function handleBack() {
               {{ effects ? effects.length : 0 }}
             </v-chip>
           </div>
-          
+
           <v-table density="compact" hover v-if="effects && effects.length > 0" class="border rounded text-caption">
             <thead class="bg-grey-darken-4">
               <tr>
@@ -396,6 +410,90 @@ function handleBack() {
           </v-table>
           <div v-else class="text-caption text-grey italic pa-2 border rounded bg-white/5">
             No effects configured.
+          </div>
+        </v-col>
+
+        <!-- Sensors List -->
+        <v-col cols="12" md="6">
+          <div class="d-flex align-center mb-3">
+            <v-icon icon="mdi-radar" class="mr-2 text-cyan"></v-icon>
+            <h3 class="text-h6 font-weight-medium">Sensors</h3>
+            <v-chip size="x-small" class="ml-2" variant="tonal" color="cyan">
+              {{ sortedSensors.length }}
+            </v-chip>
+          </div>
+
+          <v-table density="compact" hover v-if="sortedSensors.length > 0" class="border rounded text-caption">
+            <thead class="bg-grey-darken-4">
+              <tr>
+                <th class="text-left py-1 px-2 font-weight-bold">Idx</th>
+                <th class="text-left py-1 px-2 font-weight-bold">Name</th>
+                <th class="text-center py-1 px-2 font-weight-bold">Pin</th>
+                <th class="text-center py-1 px-2 font-weight-bold">Type</th>
+                <th class="text-center py-1 px-2 font-weight-bold">State</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="sensor in sortedSensors" :key="sensor?.id" class="cursor-pointer hover:bg-white/5">
+                <td class="font-mono text-grey py-1 px-2">{{ sensor?.index ?? '--' }}</td>
+                <td class="font-weight-medium py-1 px-2 truncate max-w-[120px]" :title="sensor?.name">{{ sensor?.name || 'Unnamed' }}</td>
+                <td class="text-center font-mono text-grey-lighten-1 py-1 px-2">{{ sensor?.pin ?? '--' }}</td>
+                <td class="text-center py-1 px-2">
+                  <v-chip size="x-small" variant="tonal" class="text-uppercase">{{ sensor?.type || '--' }}</v-chip>
+                </td>
+                <td class="text-center py-1 px-2">
+                  <v-icon
+                    :color="sensor?.state ? 'green' : 'grey'"
+                    size="small"
+                  >
+                    {{ sensor?.state ? 'mdi-checkbox-marked-circle' : 'mdi-circle-outline' }}
+                  </v-icon>
+                </td>
+              </tr>
+            </tbody>
+          </v-table>
+          <div v-else class="text-caption text-grey italic pa-2 border rounded bg-white/5">
+            No sensors configured.
+          </div>
+        </v-col>
+
+        <!-- Signals List -->
+        <v-col cols="12" md="6">
+          <div class="d-flex align-center mb-3">
+            <v-icon icon="mdi-traffic-light" class="mr-2 text-red"></v-icon>
+            <h3 class="text-h6 font-weight-medium">Signals</h3>
+            <v-chip size="x-small" class="ml-2" variant="tonal" color="red">
+              {{ sortedSignals.length }}
+            </v-chip>
+          </div>
+
+          <v-table density="compact" hover v-if="sortedSignals.length > 0" class="border rounded text-caption">
+            <thead class="bg-grey-darken-4">
+              <tr>
+                <th class="text-left py-1 px-2 font-weight-bold">Name</th>
+                <th class="text-center py-1 px-2 font-weight-bold">Pins (R/Y/G)</th>
+                <th class="text-center py-1 px-2 font-weight-bold">Aspect</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="signal in sortedSignals" :key="signal?.id" class="cursor-pointer hover:bg-white/5">
+                <td class="font-weight-medium py-1 px-2 truncate max-w-[140px]" :title="signal?.name">{{ signal?.name || 'Unnamed' }}</td>
+                <td class="text-center py-1 px-2 font-mono text-grey-lighten-1">
+                  <span class="text-red-lighten-2">{{ signal?.red ?? '-' }}</span>/<span class="text-yellow-lighten-2">{{ signal?.yellow ?? '-' }}</span>/<span class="text-green-lighten-2">{{ signal?.green ?? '-' }}</span>
+                </td>
+                <td class="text-center py-1 px-2">
+                  <v-icon
+                    size="small"
+                    :color="signal?.aspect === 'red' ? 'red' : signal?.aspect === 'yellow' ? 'yellow' : signal?.aspect === 'green' ? 'green' : 'grey'"
+                  >
+                    mdi-circle
+                  </v-icon>
+                </td>
+              </tr>
+            </tbody>
+          </v-table>
+          <div v-else class="text-caption text-grey italic pa-2 border rounded bg-white/5">
+            No signals configured.
           </div>
         </v-col>
       </v-row>

--- a/apps/cloud/src/Layout/Devices/useDeviceConfig.ts
+++ b/apps/cloud/src/Layout/Devices/useDeviceConfig.ts
@@ -8,17 +8,19 @@ import {
   generatePicoSettings,
   generatePicoConfig,
 } from '@repo/modules'
-import type { Device, Effect, Loco, Turnout } from '@repo/modules'
+import type { Device, Effect, Loco, Turnout, Sensor, Signal } from '@repo/modules'
 
 interface UseDeviceConfigOptions {
   device: Ref<Device | null>
   effects: Ref<Effect[]> | ComputedRef<Effect[]>
   turnouts: Ref<Turnout[]> | ComputedRef<Turnout[]>
+  sensors?: Ref<Sensor[]> | ComputedRef<Sensor[]>
+  signals?: Ref<Signal[]> | ComputedRef<Signal[]>
   locos?: Ref<Loco[]> | ComputedRef<Loco[]>
   layoutId?: Ref<string> | ComputedRef<string>
 }
 
-export function useDeviceConfig({ device, effects, turnouts, locos, layoutId }: UseDeviceConfigOptions) {
+export function useDeviceConfig({ device, effects, turnouts, sensors, signals, locos, layoutId }: UseDeviceConfigOptions) {
   const isArduino = computed(() =>
     ['deja-arduino', 'deja-arduino-led'].includes(device.value?.type || '')
   )
@@ -27,6 +29,23 @@ export function useDeviceConfig({ device, effects, turnouts, locos, layoutId }: 
 
   const isDccEx = computed(() => device.value?.type === 'dcc-ex')
 
+  // 🛰 Sensor/signal pin arrays for Arduino config.h
+  const sensorPins = computed<string[]>(() =>
+    (sensors?.value ?? [])
+      .filter((s) => s.pin !== undefined && s.pin !== null)
+      .map((s) => String(s.pin))
+  )
+
+  const signalPins = computed<number[]>(() => {
+    const pins: number[] = []
+    for (const sig of signals?.value ?? []) {
+      if (typeof sig.red === 'number') pins.push(sig.red)
+      if (typeof sig.yellow === 'number') pins.push(sig.yellow)
+      if (typeof sig.green === 'number') pins.push(sig.green)
+    }
+    return pins
+  })
+
   // 🔧 Arduino config.h
   const arduinoConfigH = computed(() => {
     if (!device.value) return ''
@@ -34,6 +53,8 @@ export function useDeviceConfig({ device, effects, turnouts, locos, layoutId }: 
       device: device.value,
       effects: effects.value,
       turnouts: turnouts.value,
+      sensorPins: sensorPins.value,
+      signalPins: signalPins.value,
     })
   })
 

--- a/apps/cloud/src/Sensors/SensorForm.vue
+++ b/apps/cloud/src/Sensors/SensorForm.vue
@@ -249,6 +249,8 @@ async function submit() {
           <v-select
             v-model="type"
             :items="sensorTypes"
+            item-title="label"
+            item-value="value"
             variant="outlined"
             density="compact"
             color="teal"
@@ -261,6 +263,10 @@ async function submit() {
           <v-select
             v-model="inputType"
             :items="sensorInputTypes"
+            item-title="label"
+            item-value="value"
+            :rules="[(v) => !!v || 'Input type is required']"
+            required
             variant="outlined"
             density="compact"
             color="teal"

--- a/firestore.rules
+++ b/firestore.rules
@@ -79,6 +79,24 @@ service cloud.firestore {
         allow read: if isAuth();
         allow write: if isLayoutOwner(layoutId);
       }
+
+      // Sensors - layout owner only
+      match /sensors/{sensorId} {
+        allow read: if isAuth();
+        allow write: if isLayoutOwner(layoutId);
+      }
+
+      // Blocks - layout owner only
+      match /blocks/{blockId} {
+        allow read: if isAuth();
+        allow write: if isLayoutOwner(layoutId);
+      }
+
+      // Automations - layout owner only
+      match /automations/{automationId} {
+        allow read: if isAuth();
+        allow write: if isLayoutOwner(layoutId);
+      }
     }
 
     // User preferences (backgrounds, settings, subscription) — each user owns their doc

--- a/packages/modules/sensors/useSensors.ts
+++ b/packages/modules/sensors/useSensors.ts
@@ -125,15 +125,17 @@ export const useSensors = () => {
   }
 
   function getSensorsByDevice(deviceId: string) {
-    if (!layoutId.value) return null
-    return useCollection<Sensor>(
-      query(
+    // ⚠️ Don't add orderBy — composite (device + sortField) index isn't deployed.
+    // Caller sorts client-side.
+    // 🔁 Use a reactive getter so VueFire re-evaluates when layoutId hydrates from localStorage.
+    const colGetter = () => {
+      if (!layoutId.value) return null
+      return query(
         collection(db, `layouts/${layoutId.value}/sensors`),
         where('device', '==', deviceId),
-        orderBy('index'),
-      ),
-      { ssrKey: `sensors-device-${deviceId}` },
-    )
+      )
+    }
+    return useCollection<Sensor>(colGetter, { ssrKey: `sensors-device-${deviceId}` })
   }
 
   return {

--- a/packages/modules/signals/useSignals.ts
+++ b/packages/modules/signals/useSignals.ts
@@ -7,6 +7,7 @@ import {
   query,
   serverTimestamp,
   setDoc,
+  where,
 } from 'firebase/firestore'
 import { useStorage } from '@vueuse/core'
 import { useCollection } from 'vuefire'
@@ -132,10 +133,25 @@ export const useSignals = () => {
     }
   }
 
+  function getSignalsByDevice(deviceId: string) {
+    // ⚠️ Don't add orderBy — composite (device + sortField) index isn't deployed.
+    // Caller sorts client-side.
+    // 🔁 Use a reactive getter so VueFire re-evaluates when layoutId hydrates from localStorage.
+    const colGetter = () => {
+      if (!layoutId.value) return null
+      return query(
+        collection(db, `layouts/${layoutId.value}/signals`),
+        where('device', '==', deviceId),
+      )
+    }
+    return useCollection<Signal>(colGetter, { ssrKey: `signals-device-${deviceId}` })
+  }
+
   return {
     deleteSignal,
     getSignal,
     getSignals,
+    getSignalsByDevice,
     setSignal,
     setSignalAspect,
     signalsCol,


### PR DESCRIPTION
## Summary

Fixes several bugs around the sensor form and wires sensors/signals into the device details page.

### 🛠 Sensor form
- **`[object Object]` rendering** — Sensor Type & Input Type `v-select`s were missing `item-title`/`item-value`, so Vuetify was stringifying the full option object. Added both attributes.
- **Required Input Type** — the default `'normally-open'` doesn't match any entry in `sensorInputTypes`, so the field was silently empty on new forms. Marked `required` with a rule so users are forced to pick a valid value.

### 🛡 Firestore rules
Three new subcollections (`sensors`, `blocks`, `automations`) had no rules — saving a sensor was failing with `Missing or insufficient permissions`. Added rules matching the existing layout-owner-only pattern used by `turnouts`/`signals`/`devices`. Deployed to `dejacloud-563d6`.

### 📄 Device details page
The device details page now lists **Sensors** and **Signals** next to the existing Turnouts & Effects tables, scoped to the current device:
- Sensors table: idx, name, pin, type, state
- Signals table: name, R/Y/G pins, current aspect dot
- Added `getSignalsByDevice` to `useSignals` (parallel to the existing `getSensorsByDevice`).
- Client-side sort for both (by `index` / `name`) to avoid requiring Firestore composite indexes.

### 🔧 Arduino config.h
`generateArduinoConfig` already accepted `sensorPins` / `signalPins`, but `useDeviceConfig` wasn't passing them. Now threads sensors & signals through and derives:
- `sensorPins` from `sensor.pin`
- `signalPins` flattened from `signal.red/yellow/green`

Result: `ENABLE_SENSORS`, `ENABLE_SIGNALS`, `int SENSORPINS[]`, `int SIGNALPINS[]` populate from live Firebase data.

### ⚡ VueFire reactive getter fix
`getSensorsByDevice` / `getSignalsByDevice` were passing a **concrete one-shot query** to `useCollection`. If `@DEJA/layoutId` hadn't hydrated from localStorage at the exact moment the composable ran, the ref got stuck on `null` forever and lists were empty. Rewrote both to use a **reactive getter function** so VueFire re-evaluates when `layoutId` changes — matching the idiom already used by `getSensors` / `getSignals`.

## Test plan

- [x] Open sensor form → Sensor Type / Input Type dropdowns show proper labels (not `[object Object]`)
- [x] Save a sensor → no Firestore permissions error
- [x] Open a device details page → Sensors and Signals lists populate (scoped to that device)
- [x] Expand **Preview config.h** on an Arduino device → `ENABLE_SENSORS true`, `ENABLE_SIGNALS true`, and `SENSORPINS[]` / `SIGNALPINS[]` arrays populated
- [x] `pnpm --filter=deja-cloud run type-check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)