### PR TITLE
chore(skills): 🌙 force dark mode in /capture-screenshots

### DIFF
--- a/.claude/skills/capture-screenshots/SKILL.md
+++ b/.claude/skills/capture-screenshots/SKILL.md
@@ -8,6 +8,8 @@ user_invocable: true
 
 Capture screenshots of DEJA.js app views using Playwright MCP (headless browser).
 
+> 🌙 **Dark mode is mandatory.** Every screenshot must render in the dark theme regardless of the OS `prefers-color-scheme` setting — DEJA.js is a dark-first brand and mixed-theme screenshots look broken in docs and marketing. Step 3 of the Procedure below seeds `localStorage`, overrides `matchMedia`, and forces the Tailwind `.dark` class before any capture runs. Do not skip it.
+
 ## Prerequisites
 
 - `.claude/launch.json` must exist (dev server configs)
@@ -61,10 +63,48 @@ Navigate to the app's root URL first:
 mcp__playwright__browser_navigate({ url: "http://localhost:<port>" })
 ```
 
-Then set localStorage values using `mcp__playwright__browser_evaluate`:
+Then set localStorage values using `mcp__playwright__browser_evaluate`. **Seed the theme to `dark` in the same call as the layout — dark mode is mandatory for every screenshot, regardless of the OS `prefers-color-scheme`:**
+
 ```javascript
-mcp__playwright__browser_evaluate({ function: "() => { localStorage.setItem('@DEJA/layoutId', '<layout-id>') }" })
+mcp__playwright__browser_evaluate({ function: `() => {
+  // 🗺️ Layout ID — used by every DEJA app
+  localStorage.setItem('@DEJA/layoutId', '<layout-id>');
+
+  // 🌙 Force dark mode across every DEJA app, regardless of OS preference.
+  // Different apps read from different keys — seed them all:
+  localStorage.setItem('@DEJA/theme', 'dark');           // Vuetify apps (throttle/cloud/monitor/tour) via useStorage
+  localStorage.setItem('theme', 'dark');                 // dejajs-www (Next.js)
+  localStorage.setItem('vuetify:theme', 'dark');         // Vuetify default persistence key
+  localStorage.setItem('darkMode', 'true');              // legacy fallback
+
+  // 🎨 Tailwind dark variant: add the class to <html> so utilities like
+  // dark:bg-gray-950 render correctly before Vue/React hydrates.
+  document.documentElement.classList.add('dark');
+  document.documentElement.classList.remove('light');
+
+  // 🖥️ Override window.matchMedia so any '(prefers-color-scheme: dark)'
+  // query resolves to true and '(prefers-color-scheme: light)' to false.
+  // This wins over the OS setting for the rest of the session.
+  const origMatchMedia = window.matchMedia.bind(window);
+  window.matchMedia = (query) => {
+    if (query.includes('prefers-color-scheme: dark')) {
+      return { matches: true, media: query, onchange: null, addListener: () => {}, removeListener: () => {}, addEventListener: () => {}, removeEventListener: () => {}, dispatchEvent: () => false };
+    }
+    if (query.includes('prefers-color-scheme: light')) {
+      return { matches: false, media: query, onchange: null, addListener: () => {}, removeListener: () => {}, addEventListener: () => {}, removeEventListener: () => {}, dispatchEvent: () => false };
+    }
+    return origMatchMedia(query);
+  };
+}` })
 ```
+
+After seeding, **reload the page once** so the app reads the fresh localStorage on boot (some stores only read on init, not on the fly):
+
+```
+mcp__playwright__browser_navigate({ url: "http://localhost:<port>" })
+```
+
+> 🌙 **Why this matters:** the DEJA brand is dark-first. Marketing screenshots and docs must always show the dark theme so the site renders consistently no matter who runs the skill. The four localStorage keys + `matchMedia` override + `.dark` class cover every theme mechanism used across the monorepo (Vuetify, Next.js, and direct Tailwind variants).
 
 If using email/password login (not DEMO_MODE):
 1. Navigate to `/login`


### PR DESCRIPTION
## Summary

Every DEJA.js app is **dark-first**, but screenshots produced by `/capture-screenshots` were rendering in whatever mode the runner's OS `prefers-color-scheme` happened to be. Mixed-theme screenshots look broken in docs and marketing — so dark mode is now **mandatory** and enforced by the skill itself rather than relying on the runner's OS.

## What changed

Only `.claude/skills/capture-screenshots/SKILL.md` — a single-file skill update. No app code changes.

1. **Top-of-file note** stating dark mode is mandatory, with the brand rationale.
2. **Expanded Step 3 (Set Up App State)** to seed every theme mechanism used across the monorepo, in the same `browser_evaluate` call that already seeds `@DEJA/layoutId`:
   - `localStorage.@DEJA/theme = 'dark'` — Vuetify apps via `useStorage` (throttle / cloud / monitor / tour)
   - `localStorage.theme = 'dark'` — dejajs-www Next.js site
   - `localStorage.vuetify:theme = 'dark'` — Vuetify default persistence key
   - `localStorage.darkMode = 'true'` — legacy fallback
   - `document.documentElement.classList.add('dark')` / `.remove('light')` — Tailwind `dark:` variants
   - `window.matchMedia` override so any `prefers-color-scheme: dark` query resolves to `true` regardless of OS setting
3. **Reload navigate** after seeding so the app re-reads `localStorage` on fresh boot — some stores only read on init.

The `matchMedia` override persists for the session (same-origin navigations keep the window state), and `localStorage` persists across same-origin navigates, so subsequent screenshots in the same run stay in dark mode without further intervention.

## Why this is belt-and-suspenders

Different apps use different theme mechanisms:

| App | Mechanism |
|---|---|
| throttle / cloud / monitor / tour | Vuetify 3 + `useStorage` reading `@DEJA/theme` |
| dejajs-www | Custom `ThemeProvider` reading `theme` localStorage key |
| Any Tailwind utility | Reads `<html class="dark">` directly |
| Any component using `matchMedia` | OS-dependent unless overridden |

Seeding only one of these would leave gaps. Seeding all of them makes the skill robust to any app in the monorepo, current or future.

## Test plan

- [ ] Run `/capture-screenshots throttle --views home` on a fresh macOS session with OS theme set to **Light** — confirm screenshot renders in dark
- [ ] Run `/capture-screenshots cloud --views dashboard` with OS theme set to **Light** — confirm dark
- [ ] Run `/capture-screenshots monitor --views dashboard` with OS theme set to **Dark** — confirm dark (no regression)
- [ ] Spot check the seeded localStorage via `mcp__playwright__browser_evaluate({ function: '() => Object.fromEntries(Object.entries(localStorage).filter(([k]) => k.toLowerCase().includes(\"theme\")))' })` — confirm all four keys are set
- [ ] Spot check `document.documentElement.className` — confirms `dark` class is present
- [ ] Spot check `window.matchMedia('(prefers-color-scheme: light)').matches` — confirms `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)