### PR TITLE
fix(ci): 🤖 changelog bot opens PR instead of direct push

### DIFF
--- a/.changeset/fix-changelog-bot-pr-workflow.md
+++ b/.changeset/fix-changelog-bot-pr-workflow.md
@@ -1,0 +1,5 @@
+---
+"deja": patch
+---
+
+changed: **[ci]** 🤖 Changelog bot now opens a PR instead of pushing directly to `main` — works around branch protection that rejected the previous direct-push approach. `changeset-check` skips PRs authored by the bot so the automated flow doesn't deadlock.

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,12 +12,13 @@ concurrency:
 
 jobs:
   process-changesets:
-    # Skip if the push was made by the changelog bot
+    # 🛑 Skip if the push was made by the changelog bot itself
     if: "!contains(github.event.head_commit.message, '[changelog-bot]')"
     runs-on: ubuntu-latest
 
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout
@@ -35,11 +36,48 @@ jobs:
         if: steps.check.outputs.count != '0'
         run: node .github/scripts/process-changesets.mjs
 
-      - name: Commit changes
+      # 🤖 Open a PR with the changelog update. Direct push to main is blocked
+      # by branch protection (requires PR + successful preview deployments), so
+      # the bot commits on a temporary branch and opens a PR instead.
+      #
+      # The resulting PR skips `changeset-check` (see changeset-check.yml) and
+      # is marked auto-merge so it lands as soon as required checks pass.
+      - name: Create pull request
         if: steps.check.outputs.count != '0'
+        id: cpr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: chore/changelog-bot-update
+          delete-branch: true
+          base: main
+          commit-message: 'docs: update changelog [changelog-bot]'
+          title: 'docs: update changelog [changelog-bot]'
+          body: |
+            🤖 **Automated changelog update**
+
+            This PR was opened by the `Process Changesets` workflow after detecting accumulated changesets on `main`. It:
+
+            - Moves all entries from `.changeset/*.md` into `CHANGELOG.md` under `[Unreleased]`
+            - Deletes the processed changeset files
+
+            ## Next steps
+            1. Wait for required checks to pass
+            2. Merge this PR
+            3. Run `/release-notes` on `main` to cut the next version
+
+            > This PR is exempt from `changeset-check` (see `.github/workflows/changeset-check.yml`).
+          labels: |
+            changelog-bot
+          author: 'github-actions[bot] <github-actions[bot]@users.noreply.github.com>'
+          committer: 'github-actions[bot] <github-actions[bot]@users.noreply.github.com>'
+
+      - name: Enable auto-merge
+        if: steps.cpr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add CHANGELOG.md .changeset/
-          git diff --cached --quiet || git commit -m "docs: update changelog [changelog-bot]"
-          git push
+          gh pr merge ${{ steps.cpr.outputs.pull-request-number }} \
+            --auto \
+            --squash \
+            --repo ${{ github.repository }}

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -6,6 +6,12 @@ on:
 
 jobs:
   check-changeset:
+    # 🤖 Skip for the changelog bot — its PR only deletes changesets, so it
+    # can't satisfy "every PR must add a changeset" by design.
+    if: |
+      github.event.pull_request.user.login != 'github-actions[bot]' &&
+      !contains(github.event.pull_request.title, '[changelog-bot]') &&
+      !contains(github.event.pull_request.labels.*.name, 'changelog-bot')
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
Fixes the `Process Changesets` workflow that failed after the v1.6.0 release cycle — branch protection rejected the bot's direct push to `main` with:

> remote: error: GH006: Protected branch update failed for refs/heads/main.
> - Missing successful active Preview – deja-js-cloud and Preview – deja-js-throttle deployments.
> - Changes must be made through a pull request.

## Changes

### `.github/workflows/changelog.yml`
- Replaces the `git add` / `git commit` / `git push` steps with `peter-evans/create-pull-request@v6`
- Bot commits to a temporary branch `chore/changelog-bot-update` and opens a PR to `main` instead of pushing directly
- Adds an "Enable auto-merge" step so the PR lands automatically when required checks pass
- New `pull-requests: write` permission

### `.github/workflows/changeset-check.yml`
- Skips `check-changeset` for PRs authored by `github-actions[bot]`, titled with `[changelog-bot]`, or labeled `changelog-bot`
- Without this, the bot's PR would deadlock — it only deletes `.changeset/*.md` files, never adds one, so the "every PR must include a changeset" rule is unsatisfiable by design for this PR

## Why this is needed
During the v1.6.0 release, 42 accumulated changesets on `preview` could not be processed automatically. I had to manually run `process-changesets.mjs`, commit the result on a recovery branch (`chore/process-changesets-v1.6`), and open PR #301 to land it. This fix makes the automated flow work end-to-end next time.

## Test plan
- [ ] `check-changeset` passes on this PR (it adds a changeset so the rule is satisfied)
- [ ] After merge to `preview`, staging deployments succeed
- [ ] Next `preview → main` merge with accumulated changesets: bot opens an auto-mergeable PR to `main` without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)