### PR TITLE
✨ Redesign speedometer & throttle layout with speed display setting

### DIFF
--- a/apps/throttle/src/throttle/ButtonsThrottle.vue
+++ b/apps/throttle/src/throttle/ButtonsThrottle.vue
@@ -9,6 +9,7 @@ import ThrottleActionMenu from '@/throttle/ThrottleActionMenu.vue'
 import RoadnameLogo from '@/throttle/RoadnameLogo.vue'
 import { ConsistIndicator, LocoNumberPlate, FunctionsSpeedDial } from '@repo/ui'
 import { ROADNAMES } from '@repo/modules'
+import type { SpeedDisplayType } from '@repo/modules'
 import { useThrottle } from '@/throttle/useThrottle'
 
 const props = defineProps({
@@ -16,6 +17,7 @@ const props = defineProps({
   showFunctions: { type: Boolean, default: true },
   showSpeedometer: { type: Boolean, default: true },
   showConsist: { type: Boolean, default: true },
+  speedDisplayType: { type: String as () => SpeedDisplayType, default: 'dial' },
 })
 
 const address = toRef(props, 'address')
@@ -41,15 +43,22 @@ async function clearLoco() {
   <main v-if="throttle" class="@container flex flex-col gap-2 p-2 overflow-hidden w-full h-full flex-1 shadow-xl relative">
     <ThrottleHeader class="bg-gradient-to-r from-slate-700/20 to-blue-900/20">
       <template v-slot:left>
-        <div class="flex flex-row items-center justify-center gap-1 px-4" style="background: rgba(var(--v-theme-surface), 0.6)">
+        <div class="flex flex-row items-center justify-center gap-1 px-1 @[640px]:px-4 min-w-0" style="background: rgba(var(--v-theme-surface), 0.6)">
           <LocoNumberPlate
             v-if="loco"
             :address="loco.address"
             :color="loco.meta?.roadname ? ROADNAMES.find(r => r.value === loco.meta?.roadname)?.color : undefined"
-            size="sm"
+            size="xs"
+            class="hidden @[400px]:block"
           />
-          <v-spacer class="w-2 md:w-6" />
-          <h1 class="text-xl md:text-4xl font-bold tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-cyan-400 drop-shadow-lg">
+          <LocoNumberPlate
+            v-if="loco"
+            :address="loco.address"
+            :color="loco.meta?.roadname ? ROADNAMES.find(r => r.value === loco.meta?.roadname)?.color : undefined"
+            size="xs"
+            class="@[400px]:hidden"
+          />
+          <h1 class="text-sm @[400px]:text-base @[640px]:text-xl @[960px]:text-4xl font-bold tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-cyan-400 drop-shadow-lg truncate">
             {{ loco?.name }}
           </h1>
         </div>
@@ -59,12 +68,24 @@ async function clearLoco() {
       </template>
     </ThrottleHeader>
 
-    <section class="w-full h-full flex flex-col @[640px]:flex-row @[640px]:items-center justify-around flex-grow relative z-10">
-      <!-- Desktop left: Consist + Speedometer -->
-      <section v-if="loco" class="hidden @[640px]:flex flex-col gap-4 items-center justify-center flex-1">
-        <ConsistIndicator v-if="showConsist" :loco="loco" />
-        <Speedometer v-if="showSpeedometer" :speed="currentSpeed" :address="address" :size="200" :show-label="false" />
-        <div v-if="showConsist && loco.consist?.length" class="grid grid-cols-2 gap-3">
+    <!-- 🖥️ Desktop: 3-column layout -->
+    <section class="w-full hidden @[640px]:flex flex-row items-stretch justify-around flex-grow relative z-10" style="max-height: 800px;">
+      <!-- Left col: Function buttons + Logo -->
+      <section v-if="loco" class="flex flex-col items-center justify-around flex-1">
+        <FunctionsSpeedDial v-if="showFunctions" :loco="loco" />
+        <RoadnameLogo :roadname="loco.meta?.roadname" size="2xl" />
+      </section>
+
+      <!-- Middle col: Speedometer + EZ Consist -->
+      <section class="flex flex-col items-center justify-around flex-1">
+        <!-- 🎛️ Speed display: dial or digital based on setting -->
+        <template v-if="showSpeedometer">
+          <Speedometer v-if="speedDisplayType === 'dial'" :speed="currentSpeed" :address="address" :size="200" :show-label="false" />
+          <CurrentSpeed v-else :speed="currentSpeed" />
+        </template>
+        <ConsistIndicator v-if="showConsist && loco" :loco="loco" />
+        <!-- 🚂 Consist speedometers -->
+        <div v-if="showConsist && loco?.consist?.length" class="grid grid-cols-2 gap-3">
           <Speedometer
             v-for="cloco in loco.consist"
             :key="cloco.address"
@@ -76,31 +97,33 @@ async function clearLoco() {
         </div>
       </section>
 
-      <!-- Desktop center: Logo + Functions -->
-      <section v-if="loco" class="hidden @[640px]:flex flex-col gap-2 items-center justify-center flex-1">
-        <RoadnameLogo :roadname="loco.meta?.roadname" size="2xl" />
-        <FunctionsSpeedDial v-if="showFunctions" :loco="loco" />
-      </section>
-
-      <!-- Mobile: Consist -->
-      <div v-if="loco && showConsist" class="flex @[640px]:hidden justify-center order-1">
-        <ConsistIndicator :loco="loco" />
-      </div>
-
-      <!-- Desktop right / Mobile: Speed display + buttons -->
-      <section class="flex flex-col gap-2 mb-2 items-center justify-center flex-1 order-2" style="max-height: 60vh;">
-        <CurrentSpeed :speed="currentSpeed" />
+      <!-- Right col: Throttle controls -->
+      <section class="flex flex-col items-center justify-around flex-1">
         <ThrottleButtonControls @update:currentSpeed="handleAdjustSpeed" @stop="handleStop" />
       </section>
+    </section>
 
-      <!-- Mobile: Functions -->
-      <section v-if="loco && showFunctions" class="flex @[640px]:hidden flex-col gap-2 items-center justify-center order-3">
-        <FunctionsSpeedDial :loco="loco" />
-      </section>
+    <!-- 📱 Mobile: speedometer top, then 2-column below -->
+    <section class="w-full flex @[640px]:hidden flex-col flex-grow relative z-10 gap-1">
+      <!-- 🎛️ Speedometer at top -->
+      <div v-if="showSpeedometer" class="flex justify-center py-2 mx-2 rounded-lg border border-white/10 bg-white/[0.03]">
+        <Speedometer v-if="speedDisplayType === 'dial'" :speed="currentSpeed" :address="address" :size="140" :show-label="false" />
+        <CurrentSpeed v-else :speed="currentSpeed" />
+      </div>
 
-      <!-- Mobile: Logo -->
-      <div v-if="loco" class="flex @[640px]:hidden justify-center order-4 mb-2">
-        <RoadnameLogo :roadname="loco.meta?.roadname" size="xl" />
+      <!-- 📱 Two columns -->
+      <div class="flex flex-row flex-grow min-h-0 gap-1 mx-2">
+        <!-- Left col: EZ Consist + Functions -->
+        <section class="flex flex-col items-center justify-around flex-1 rounded-lg border border-white/10 bg-white/[0.03] py-2">
+          <ConsistIndicator v-if="showConsist && loco" :loco="loco" />
+          <FunctionsSpeedDial v-if="loco && showFunctions" :loco="loco" />
+          <RoadnameLogo v-if="loco" :roadname="loco.meta?.roadname" size="lg" />
+        </section>
+
+        <!-- Right col: Throttle controls -->
+        <section class="flex flex-col items-center justify-around flex-1 rounded-lg border border-white/10 bg-white/[0.03] py-2">
+          <ThrottleButtonControls @update:currentSpeed="handleAdjustSpeed" @stop="handleStop" />
+        </section>
       </div>
     </section>
   </main>

--- a/apps/throttle/src/throttle/CurrentSpeed.vue
+++ b/apps/throttle/src/throttle/CurrentSpeed.vue
@@ -1,32 +1,98 @@
 <script setup lang="ts">
-defineProps({
+import { computed } from 'vue'
+
+const props = defineProps({
   speed: {
     type: Number,
-    required: true
-  }
-});
+    required: true,
+  },
+})
+
+const isForward = computed(() => props.speed >= 0)
+const displaySpeed = computed(() => Math.abs(props.speed))
 </script>
+
 <template>
   <div class="flex justify-center">
-    <span class="
-      current-speed 
-      min-w-16
-      @[1024px]:min-w-24
-      shadow-blue-500/50 
-      text-center 
-      text-xl
-      @[960px]:text-2xl
-      @[1024px]:text-3xl 
-      p-3
-      rounded-xl 
-      shadow-inner 
-      bg-gradient-to-r 
-      from-purple-500 
-      to-pink-600">{{ speed }}</span>
+    <div class="speed-panel">
+      <!-- ⚡ Purple accent stripe -->
+      <div class="speed-panel__accent" />
+      <!-- 🚂 Speed readout -->
+      <div class="speed-panel__body">
+        <span
+          class="speed-panel__direction"
+          :class="isForward ? 'text-purple-300' : 'text-red-400'"
+        >
+          {{ isForward ? 'FWD' : 'REV' }}
+        </span>
+        <span class="speed-panel__value">{{ displaySpeed }}</span>
+      </div>
+    </div>
   </div>
 </template>
+
 <style scoped>
-  .current-speed {
-    box-shadow: inset 0 0 12px 12px rgba(0,0,0,.5);
+.speed-panel {
+  display: flex;
+  min-width: 4.5rem;
+  border: 1px solid rgba(168, 85, 247, 0.35);
+  border-radius: 4px;
+  overflow: hidden;
+  background: linear-gradient(180deg, rgba(30, 20, 50, 0.95) 0%, rgba(15, 10, 30, 0.98) 100%);
+  box-shadow:
+    0 0 12px rgba(168, 85, 247, 0.15),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.speed-panel__accent {
+  width: 4px;
+  flex-shrink: 0;
+  background: linear-gradient(180deg, #a855f7 0%, #7c3aed 100%);
+}
+
+.speed-panel__body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  padding: 0.35rem 0.75rem;
+  gap: 0;
+}
+
+.speed-panel__direction {
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  line-height: 1;
+}
+
+.speed-panel__value {
+  font-size: 1.5rem;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.1;
+  color: #e9d5ff;
+  text-shadow: 0 0 8px rgba(168, 85, 247, 0.4);
+}
+
+/* 📱 Container query scaling */
+@container (min-width: 960px) {
+  .speed-panel__value {
+    font-size: 1.75rem;
   }
+}
+
+@container (min-width: 1024px) {
+  .speed-panel {
+    min-width: 6rem;
+  }
+  .speed-panel__value {
+    font-size: 2rem;
+  }
+  .speed-panel__direction {
+    font-size: 0.65rem;
+  }
+}
 </style>

--- a/apps/throttle/src/throttle/Dashboard.vue
+++ b/apps/throttle/src/throttle/Dashboard.vue
@@ -15,6 +15,7 @@ const props = defineProps({
   showFunctions: { type: Boolean, default: true },
   showSpeedometer: { type: Boolean, default: true },
   showConsist: { type: Boolean, default: true },
+  speedDisplayType: { type: String, default: 'dial' },
 })
 
 const address = toRef(props, 'address')
@@ -234,19 +235,17 @@ onBeforeUnmount(() => {
 
 <template>
   <main v-if="throttle" class="@container proto-throttle-wrapper flex flex-col gap-2 p-2 overflow-hidden w-full h-full flex-1 relative">
-    <!-- Header (consistent with other variants) -->
+    <!-- Header -->
     <ThrottleHeader class="bg-gradient-to-r from-slate-700/20 to-blue-900/20">
       <template v-slot:left>
-        <div class="flex flex-row items-center justify-center gap-1 px-4" style="background: rgba(var(--v-theme-surface), 0.6)">
+        <div class="flex flex-row items-center justify-center gap-1 px-1 @[640px]:px-4 min-w-0" style="background: rgba(var(--v-theme-surface), 0.6)">
           <LocoNumberPlate
             v-if="loco"
             :address="loco.address"
             :color="loco.meta?.roadname ? ROADNAMES.find(r => r.value === loco.meta?.roadname)?.color : undefined"
-            size="sm"
+            size="xs"
           />
-          <ConsistIndicator v-if="loco && showConsist" :loco="loco" />
-          <v-spacer class="w-2 md:w-6" />
-          <h1 class="text-xl md:text-4xl font-bold tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-cyan-400 drop-shadow-lg">
+          <h1 class="text-sm @[400px]:text-base @[640px]:text-xl @[960px]:text-4xl font-bold tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-cyan-400 drop-shadow-lg truncate">
             {{ loco?.name }}
           </h1>
         </div>
@@ -256,31 +255,21 @@ onBeforeUnmount(() => {
       </template>
     </ThrottleHeader>
 
-    <section class="w-full h-full flex flex-col @[640px]:flex-row justify-center @[640px]:items-center gap-4 flex-grow relative z-10">
-      <!-- Desktop left: Consist + Speedometer -->
-      <section v-if="loco" class="hidden @[640px]:flex flex-col gap-4 items-center justify-center flex-1">
-        <ConsistIndicator v-if="showConsist" :loco="loco" />
-        <Speedometer v-if="showSpeedometer" :speed="currentSpeed" :address="address" :size="200" :show-label="false" />
-        <div v-if="showConsist && loco.consist?.length" class="grid grid-cols-2 gap-3">
-          <Speedometer
-            v-for="cloco in loco.consist"
-            :key="cloco.address"
-            :speed="currentSpeed"
-            :address="cloco.address"
-            :size="120"
-            :show-label="true"
-          />
-        </div>
-      </section>
-
-      <!-- Desktop center: Logo + Functions -->
-      <section v-if="loco" class="hidden @[640px]:flex flex-col gap-2 items-center justify-center flex-1">
+    <!-- 🖥️ Desktop: 3-column layout -->
+    <section class="w-full hidden @[640px]:flex flex-row items-stretch justify-around flex-grow relative z-10" style="max-height: 800px;">
+      <!-- Left col: Functions + Logo -->
+      <section v-if="loco" class="flex flex-col items-center justify-around flex-1">
+        <FunctionsSpeedDial :loco="loco" />
         <RoadnameLogo :roadname="loco.meta?.roadname" size="2xl" />
-        <FunctionsSpeedDial v-if="showFunctions" :loco="loco" />
       </section>
 
-      <!-- Desktop right: Device body -->
-      <section class="proto-device mx-auto w-full max-w-[360px] flex flex-col items-center gap-0 @[640px]:flex-none overflow-y-auto">
+      <!-- Middle col: EZ Consist -->
+      <section v-if="loco" class="flex flex-col items-center justify-around flex-1">
+        <ConsistIndicator v-if="showConsist" :loco="loco" />
+      </section>
+
+      <!-- Right col: Device body -->
+      <section class="proto-device mx-auto w-full max-w-[360px] flex flex-col items-center gap-0 flex-none overflow-y-auto">
 
         <!-- 1. Status LED + Horn Handle -->
         <div class="device-top-row w-full flex items-center justify-between px-4 py-2">
@@ -436,14 +425,146 @@ onBeforeUnmount(() => {
         <!-- Bottom of device -->
         <div class="device-bottom-cap"></div>
       </section>
-
     </section>
 
-    <!-- Mobile-only: consist, functions, logo -->
-    <section v-if="loco" class="flex @[640px]:hidden flex-col items-center gap-2 mt-2">
-      <ConsistIndicator v-if="showConsist" :loco="loco" />
-      <FunctionsSpeedDial v-if="showFunctions" :loco="loco" />
-      <RoadnameLogo :roadname="loco.meta?.roadname" size="xl" />
+    <!-- 📱 Mobile: only the dashboard device -->
+    <section class="w-full flex @[640px]:hidden flex-col items-center flex-grow relative z-10 overflow-y-auto">
+      <section class="proto-device mx-auto w-full max-w-[360px] flex flex-col items-center gap-0">
+
+        <!-- 1. Status LED + Horn Handle -->
+        <div class="device-top-row w-full flex items-center justify-between px-4 py-2">
+          <div class="status-led" :class="{ 'led-on': statusLedOn }"></div>
+          <div class="horn-container">
+            <v-icon
+              size="32"
+              class="horn-icon select-none"
+              :class="{ 'horn-active': hornActive }"
+              @pointerdown="hornDown"
+              @pointerup="hornUp"
+              @pointercancel="(e) => hornUp(e as PointerEvent)"
+              @pointerleave="(e) => hornUp(e as PointerEvent)"
+              style="cursor: pointer; touch-action: none;"
+            >mdi-bugle</v-icon>
+          </div>
+        </div>
+
+        <!-- 2. LCD Screen -->
+        <div class="lcd-bezel">
+          <div class="lcd-screen">
+            <div class="lcd-row lcd-row-top">
+              <span class="lcd-dir">{{ displayDirection }}</span>
+              <span class="lcd-speed-label">SPD</span>
+              <span class="lcd-speed">{{ displaySpeed }}</span>
+            </div>
+            <div class="lcd-row lcd-row-mid">
+              <span class="lcd-loco-name">{{ displayLocoName }}</span>
+            </div>
+            <div class="lcd-row lcd-row-bottom">
+              <span class="lcd-addr">ADDR:{{ displayAddress }}</span>
+              <span class="lcd-notch">N:{{ displayNotch }}</span>
+            </div>
+            <div class="lcd-indicators">
+              <span class="lcd-indicator" :class="{ invisible: !bellActive }">🔔 BELL</span>
+              <span class="lcd-indicator" :class="{ invisible: !hornActive }">📯 HORN</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- 3. Speed Buttons -->
+        <div class="nav-buttons-grid">
+          <button class="nav-btn" :class="{ 'nav-btn-active': pressedButton === 'down5' }" @click="handleDown5Btn">-5</button>
+          <button class="nav-btn" :class="{ 'nav-btn-active': pressedButton === 'up5' }" @click="handleUp5Btn">+5</button>
+          <button class="nav-btn" :class="{ 'nav-btn-active': pressedButton === 'down' }" @click="handleDownBtn">-1</button>
+          <button class="nav-btn" :class="{ 'nav-btn-active': pressedButton === 'up' }" @click="handleUpBtn">+1</button>
+        </div>
+
+        <!-- 4. Notch Markings -->
+        <div class="notch-markings">
+          <span
+            v-for="(label, i) in NOTCH_LABELS"
+            :key="label"
+            class="notch-label"
+            :class="{ 'notch-active': i <= localNotch && i > 0, 'notch-current': localNotch === i }"
+          >{{ label }}</span>
+        </div>
+
+        <!-- 5. Throttle Slider -->
+        <div class="throttle-slider-area">
+          <div class="slider-track">
+            <input
+              type="range"
+              min="0"
+              max="8"
+              :value="localNotch"
+              @input="(e) => setNotch(Number((e.target as HTMLInputElement).value))"
+              class="throttle-range"
+              orient="vertical"
+            />
+          </div>
+        </div>
+
+        <!-- 6. Reverser -->
+        <div class="reverser-area">
+          <span class="reverser-end-label" :class="localDirection === 'REV' ? 'text-red-400' : 'opacity-40'">REV</span>
+          <v-switch
+            :model-value="localDirection === 'FWD'"
+            @update:model-value="toggleDirection"
+            :disabled="currentSpeed !== 0"
+            color="blue"
+            hide-details
+            density="compact"
+            inset
+            class="reverser-switch"
+          />
+          <span class="reverser-end-label" :class="localDirection === 'FWD' ? 'text-green-400' : 'opacity-40'">FWD</span>
+        </div>
+
+        <!-- 7. Bell Icon -->
+        <div class="bell-area">
+          <div class="bell-container">
+            <v-icon
+              size="32"
+              class="bell-icon select-none"
+              :class="{ 'bell-icon-active': bellActive }"
+              @click="toggleBell"
+              style="cursor: pointer;"
+            >mdi-bell</v-icon>
+          </div>
+        </div>
+
+        <!-- 8. Brake Slider -->
+        <div class="brake-slider-area">
+          <span class="brake-label">BRAKE</span>
+          <div class="brake-track">
+            <input
+              type="range"
+              min="0"
+              max="10"
+              v-model.number="brakeLevel"
+              class="brake-range"
+              :style="{ background: brakeGradient }"
+            />
+          </div>
+        </div>
+
+        <!-- 9. Headlight Knobs -->
+        <div class="headlight-knobs">
+          <div class="knob-group">
+            <span class="knob-label">REAR</span>
+            <button class="headlight-knob" :class="{ 'knob-on': rearHeadlight !== 'OFF' }" @click="cycleRearHeadlight">
+              <v-icon size="16" class="knob-value">{{ headlightIcon(rearHeadlight) }}</v-icon>
+            </button>
+          </div>
+          <div class="knob-group">
+            <span class="knob-label">FRONT</span>
+            <button class="headlight-knob" :class="{ 'knob-on': frontHeadlight !== 'OFF' }" @click="cycleFrontHeadlight">
+              <v-icon size="16" class="knob-value">{{ headlightIcon(frontHeadlight) }}</v-icon>
+            </button>
+          </div>
+        </div>
+
+        <div class="device-bottom-cap"></div>
+      </section>
     </section>
   </main>
 

--- a/apps/throttle/src/throttle/SliderThrottle.vue
+++ b/apps/throttle/src/throttle/SliderThrottle.vue
@@ -16,6 +16,7 @@ const props = defineProps({
   showFunctions: { type: Boolean, default: true },
   showSpeedometer: { type: Boolean, default: true },
   showConsist: { type: Boolean, default: true },
+  speedDisplayType: { type: String, default: 'dial' },
 })
 
 const address = toRef(props, 'address')
@@ -67,16 +68,14 @@ async function clearLoco() {
   <main v-if="throttle" class="@container flex flex-col gap-2 p-2 overflow-hidden w-full h-full flex-1 shadow-xl relative">
     <ThrottleHeader class="bg-gradient-to-r from-slate-700/20 to-blue-900/20">
       <template v-slot:left>
-        <div class="flex flex-row items-center justify-center gap-1 px-4" style="background: rgba(var(--v-theme-surface), 0.6)">
+        <div class="flex flex-row items-center justify-center gap-1 px-1 @[640px]:px-4 min-w-0" style="background: rgba(var(--v-theme-surface), 0.6)">
           <LocoNumberPlate
             v-if="loco"
             :address="loco.address"
             :color="loco.meta?.roadname ? ROADNAMES.find(r => r.value === loco.meta?.roadname)?.color : undefined"
-            size="sm"
+            size="xs"
           />
-          <ConsistIndicator v-if="loco && showConsist" :loco="loco" />
-          <v-spacer class="w-2 md:w-6" />
-          <h1 class="text-xl md:text-4xl font-bold tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-cyan-400 drop-shadow-lg">
+          <h1 class="text-sm @[400px]:text-base @[640px]:text-xl @[960px]:text-4xl font-bold tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-cyan-400 drop-shadow-lg truncate">
             {{ loco?.name }}
           </h1>
         </div>
@@ -86,12 +85,22 @@ async function clearLoco() {
       </template>
     </ThrottleHeader>
 
-    <section class="w-full h-full flex flex-col @[640px]:flex-row @[640px]:items-center justify-around flex-grow relative z-10">
-      <!-- Desktop left: Consist + Speedometer -->
-      <section v-if="loco" class="hidden @[640px]:flex flex-col gap-4 items-center justify-center flex-1">
-        <ConsistIndicator v-if="showConsist" :loco="loco" />
-        <Speedometer v-if="showSpeedometer" :speed="currentSpeed" :address="address" :size="200" :show-label="false" />
-        <div v-if="showConsist && loco.consist?.length" class="grid grid-cols-2 gap-3">
+    <!-- 🖥️ Desktop: 3-column layout -->
+    <section class="w-full hidden @[640px]:flex flex-row items-stretch justify-around flex-grow relative z-10" style="max-height: 800px;">
+      <!-- Left col: Function buttons + Logo -->
+      <section v-if="loco" class="flex flex-col items-center justify-around flex-1">
+        <FunctionsSpeedDial v-if="showFunctions" :loco="loco" />
+        <RoadnameLogo :roadname="loco.meta?.roadname" size="2xl" />
+      </section>
+
+      <!-- Middle col: Speedometer + EZ Consist -->
+      <section class="flex flex-col items-center justify-around flex-1">
+        <template v-if="showSpeedometer">
+          <Speedometer v-if="speedDisplayType === 'dial'" :speed="currentSpeed" :address="address" :size="200" :show-label="false" />
+          <CurrentSpeed v-else :speed="currentSpeed" />
+        </template>
+        <ConsistIndicator v-if="showConsist && loco" :loco="loco" />
+        <div v-if="showConsist && loco?.consist?.length" class="grid grid-cols-2 gap-3">
           <Speedometer
             v-for="cloco in loco.consist"
             :key="cloco.address"
@@ -103,20 +112,8 @@ async function clearLoco() {
         </div>
       </section>
 
-      <!-- Desktop center: Logo + Functions -->
-      <section v-if="loco" class="hidden @[640px]:flex flex-col gap-2 items-center justify-center flex-1">
-        <RoadnameLogo :roadname="loco.meta?.roadname" size="2xl" />
-        <FunctionsSpeedDial v-if="showFunctions" :loco="loco" />
-      </section>
-
-      <!-- Mobile: Consist -->
-      <div v-if="loco && showConsist" class="flex @[640px]:hidden justify-center">
-        <ConsistIndicator :loco="loco" />
-      </div>
-
-      <!-- Slider + speed + direction -->
-      <section class="flex flex-col items-center justify-center flex-1 py-2" style="height: 100%; min-height: 0;">
-        <CurrentSpeed :speed="currentSpeed" />
+      <!-- Right col: Slider throttle controls -->
+      <section class="flex flex-col items-center justify-around flex-1 py-2">
         <v-slider
           v-model="sliderVal"
           direction="vertical"
@@ -154,12 +151,65 @@ async function clearLoco() {
           @click="handleStop"
         />
       </section>
+    </section>
 
-      <!-- Mobile: Functions + Logo -->
-      <section v-if="loco" class="flex @[640px]:hidden flex-col gap-2 items-center">
-        <FunctionsSpeedDial v-if="showFunctions" :loco="loco" />
-        <RoadnameLogo :roadname="loco.meta?.roadname" size="xl" />
-      </section>
+    <!-- 📱 Mobile: speedometer top, then 2-column below -->
+    <section class="w-full flex @[640px]:hidden flex-col flex-grow relative z-10 gap-1">
+      <!-- 🎛️ Speedometer at top -->
+      <div v-if="showSpeedometer" class="flex justify-center py-2 mx-2 rounded-lg border border-white/10 bg-white/[0.03]">
+        <Speedometer v-if="speedDisplayType === 'dial'" :speed="currentSpeed" :address="address" :size="140" :show-label="false" />
+        <CurrentSpeed v-else :speed="currentSpeed" />
+      </div>
+
+      <!-- 📱 Two columns -->
+      <div class="flex flex-row flex-grow min-h-0 gap-1 mx-2">
+        <!-- Left col: EZ Consist + Functions -->
+        <section class="flex flex-col items-center justify-around flex-1 rounded-lg border border-white/10 bg-white/[0.03] py-2">
+          <ConsistIndicator v-if="showConsist && loco" :loco="loco" />
+          <FunctionsSpeedDial v-if="loco && showFunctions" :loco="loco" />
+          <RoadnameLogo v-if="loco" :roadname="loco.meta?.roadname" size="lg" />
+        </section>
+
+        <!-- Right col: Slider controls -->
+        <section class="flex flex-col items-center justify-around flex-1 rounded-lg border border-white/10 bg-white/[0.03] py-2">
+          <v-slider
+            v-model="sliderVal"
+            direction="vertical"
+            step="1"
+            max="126"
+            thumb-label="always"
+            track-size="40"
+            thumb-size="28"
+            color="purple"
+            track-color="purple-darken-4"
+            track-fill-color="purple-darken-2"
+            thumb-color="purple"
+            style="flex: 1; min-height: 0; width: 80px;"
+          />
+          <div class="flex items-center gap-2 mt-2">
+            <span class="text-xs font-bold" :class="isForward ? 'opacity-40' : 'text-red-400'">REV</span>
+            <v-switch
+              :model-value="isForward"
+              @update:model-value="toggleDirection"
+              color="purple"
+              hide-details
+              density="compact"
+              inset
+              class="lever-switch"
+            />
+            <span class="text-xs font-bold" :class="isForward ? 'text-green-400' : 'opacity-40'">FWD</span>
+          </div>
+          <v-btn
+            icon="mdi-stop-circle-outline"
+            color="red"
+            size="large"
+            variant="tonal"
+            class="mt-3"
+            aria-label="Stop"
+            @click="handleStop"
+          />
+        </section>
+      </div>
     </section>
   </main>
 

--- a/apps/throttle/src/throttle/Speedometer.vue
+++ b/apps/throttle/src/throttle/Speedometer.vue
@@ -24,178 +24,241 @@ const props = defineProps({
   },
 })
 
-// SVG coordinate system — everything centered at (100, 100) in a 200x200 viewBox
+// 🎯 SVG coordinate system — centered at (100, 100) in 200x200 viewBox
 const cx = 100
 const cy = 100
-const radius = 64
-const needleLen = radius * 0.8
+const outerRadius = 80
+const innerRadius = 62
+const needleLen = innerRadius - 4
 
+// 🔄 Needle rotation: -135° (min) → +135° (max) = 270° sweep
 const rotation = computed(() => {
-  const safeSpeed = Math.min(Math.max(props.speed, 0), props.max)
-  const ratio = safeSpeed / props.max
-  return -135 + ratio * 270
+  const safeSpeed = Math.min(Math.max(Math.abs(props.speed), 0), props.max)
+  return -135 + (safeSpeed / props.max) * 270
 })
 
+// 🎨 Speed-dependent color (green → amber → red)
 const speedColor = computed(() => {
-  const ratio = props.speed / props.max
-  if (ratio < 0.3) return '#10b981'
-  if (ratio < 0.7) return '#f59e0b'
-  return '#ef4444'
+  const ratio = Math.abs(props.speed) / props.max
+  if (ratio < 0.3) return '#10b981'  // emerald-500
+  if (ratio < 0.7) return '#f59e0b'  // amber-500
+  return '#ef4444'                     // red-500
 })
 
-// Generate tick marks
+// 📐 Generate tick marks — every unit of 10, with minor ticks at 5
 const tickMarks = computed(() => {
   const ticks = []
-  const minorTickCount = 20
-  const majorTickCount = 6
+  const step = 5
+  const count = Math.floor(props.max / step)
 
-  for (let i = 0; i <= minorTickCount; i++) {
-    const ratio = i / minorTickCount
+  for (let i = 0; i <= count; i++) {
+    const value = i * step
+    const ratio = value / props.max
     const angle = -135 + ratio * 270
-    const isMajor = i % (minorTickCount / (majorTickCount - 1)) === 0
-    const tickLength = isMajor ? 8 : 4
-    const tickRadius = radius + (isMajor ? 0 : 4)
+    const isMajor = value % 10 === 0
+    const tickOuter = outerRadius - 2
+    const tickInner = isMajor ? tickOuter - 10 : tickOuter - 5
 
-    const rad = angle * Math.PI / 180
-    const startX = cx + (tickRadius - tickLength) * Math.cos(rad)
-    const startY = cy + (tickRadius - tickLength) * Math.sin(rad)
-    const endX = cx + tickRadius * Math.cos(rad)
-    const endY = cy + tickRadius * Math.sin(rad)
+    const rad = (angle * Math.PI) / 180
+    const x1 = cx + tickInner * Math.cos(rad)
+    const y1 = cy + tickInner * Math.sin(rad)
+    const x2 = cx + tickOuter * Math.cos(rad)
+    const y2 = cy + tickOuter * Math.sin(rad)
 
-    ticks.push({ startX, startY, endX, endY, isMajor, value: Math.round(ratio * props.max) })
+    ticks.push({ x1, y1, x2, y2, isMajor, value })
   }
 
   return ticks
 })
 
-// Generate value labels for major ticks
-const valueLabels = computed(() => {
+// 🔢 Number labels at every 10
+const numberLabels = computed(() => {
   const labels = []
-  const majorTickCount = 6
+  const step = 10
+  const count = Math.floor(props.max / step)
+  const labelRadius = outerRadius - 18
 
-  for (let i = 0; i < majorTickCount; i++) {
-    const ratio = i / (majorTickCount - 1)
+  for (let i = 0; i <= count; i++) {
+    const value = i * step
+    const ratio = value / props.max
     const angle = -135 + ratio * 270
-    const value = Math.round(ratio * props.max)
-    const labelRadius = radius + 18
+    const rad = (angle * Math.PI) / 180
 
-    const rad = angle * Math.PI / 180
-    const x = cx + labelRadius * Math.cos(rad)
-    const y = cy + labelRadius * Math.sin(rad)
-
-    labels.push({ x, y, value, angle })
+    labels.push({
+      x: cx + labelRadius * Math.cos(rad),
+      y: cy + labelRadius * Math.sin(rad),
+      value,
+    })
   }
 
   return labels
 })
+
+// 💡 LED speed display — pad to 3 digits
+const ledSpeed = computed(() => String(Math.abs(props.speed)).padStart(3, '0'))
 </script>
 
 <template>
   <div class="flex flex-col items-center gap-2">
-    <!-- SVG Speedometer -->
     <svg
       :width="size"
       :height="size"
       class="drop-shadow-lg"
       viewBox="0 0 200 200"
     >
-      <!-- Background circle -->
+      <defs>
+        <!-- 🌑 Dark face gradient -->
+        <radialGradient id="dialFace" cx="50%" cy="45%" r="55%">
+          <stop offset="0%" stop-color="#1a1a2e" />
+          <stop offset="100%" stop-color="#0d0d1a" />
+        </radialGradient>
+        <!-- ✨ Needle glow -->
+        <filter id="needleGlow">
+          <feGaussianBlur stdDeviation="2" result="blur" />
+          <feMerge>
+            <feMergeNode in="blur" />
+            <feMergeNode in="SourceGraphic" />
+          </feMerge>
+        </filter>
+        <!-- 📺 LCD screen glow -->
+        <filter id="lcdGlow">
+          <feGaussianBlur stdDeviation="1.5" result="blur" />
+          <feMerge>
+            <feMergeNode in="blur" />
+            <feMergeNode in="SourceGraphic" />
+          </feMerge>
+        </filter>
+      </defs>
+
+      <!-- 🔲 Outer ring -->
       <circle
-        :cx="cx"
-        :cy="cy"
-        :r="radius + 2"
-        fill="white"
-        stroke="#374151"
-        stroke-width="3"
+        :cx="cx" :cy="cy" :r="outerRadius"
+        fill="none"
+        stroke="#4b5563"
+        stroke-width="2.5"
+        opacity="0.6"
       />
 
-      <!-- Inner circle for depth -->
+      <!-- ⚫ Dial face -->
       <circle
-        :cx="cx"
-        :cy="cy"
-        :r="radius - 2"
-        fill="#f8fafc"
-        stroke="#e2e8f0"
-        stroke-width="1"
+        :cx="cx" :cy="cy" :r="outerRadius - 1"
+        fill="url(#dialFace)"
       />
 
-      <!-- Tick marks -->
-      <g v-for="tick in tickMarks" :key="`tick-${tick.value}-${tick.startX}`">
-        <line
-          :x1="tick.startX"
-          :y1="tick.startY"
-          :x2="tick.endX"
-          :y2="tick.endY"
-          :stroke="tick.isMajor ? '#374151' : '#9ca3af'"
-          :stroke-width="tick.isMajor ? 2 : 1"
-          stroke-linecap="round"
+      <!-- 📏 Tick marks -->
+      <line
+        v-for="tick in tickMarks"
+        :key="`t-${tick.value}`"
+        :x1="tick.x1" :y1="tick.y1"
+        :x2="tick.x2" :y2="tick.y2"
+        :stroke="tick.isMajor ? '#e5e7eb' : '#4b5563'"
+        :stroke-width="tick.isMajor ? 2 : 1"
+        stroke-linecap="round"
+        :opacity="tick.isMajor ? 0.9 : 0.5"
+      />
+
+      <!-- 🔢 Number labels (every 10) -->
+      <text
+        v-for="label in numberLabels"
+        :key="`n-${label.value}`"
+        :x="label.x" :y="label.y"
+        text-anchor="middle"
+        dominant-baseline="central"
+        class="dial-number"
+      >
+        {{ label.value }}
+      </text>
+
+      <!-- 📍 Needle -->
+      <line
+        :x1="cx" :y1="cy"
+        :x2="cx + needleLen * Math.cos((rotation * Math.PI) / 180)"
+        :y2="cy + needleLen * Math.sin((rotation * Math.PI) / 180)"
+        :stroke="speedColor"
+        stroke-width="2.5"
+        stroke-linecap="round"
+        filter="url(#needleGlow)"
+        class="dial-needle"
+      />
+
+      <!-- ⚙️ Center hub -->
+      <circle :cx="cx" :cy="cy" r="4" fill="#6b7280" />
+      <circle :cx="cx" :cy="cy" r="2" fill="#d1d5db" />
+
+      <!-- 📺 LCD speed readout at bottom -->
+      <g>
+        <!-- LCD bezel -->
+        <rect
+          :x="cx - 32" :y="cy + 22"
+          width="64" height="30"
+          rx="3"
+          fill="#111827"
+          stroke="#374151"
+          stroke-width="1.5"
         />
-      </g>
-
-      <!-- Value labels -->
-      <g v-for="label in valueLabels" :key="`label-${label.value}`">
+        <!-- LCD inner screen -->
+        <rect
+          :x="cx - 29" :y="cy + 25"
+          width="58" height="24"
+          rx="2"
+          fill="#0c1a0c"
+        />
+        <!-- LCD ghost digits (unlit segments) -->
         <text
-          :x="label.x"
-          :y="label.y"
+          :x="cx" :y="cy + 37.5"
           text-anchor="middle"
           dominant-baseline="central"
-          class="speedometer-label"
+          class="lcd-ghost"
         >
-          {{ label.value }}
+          888
+        </text>
+        <!-- LCD active digits -->
+        <text
+          :x="cx" :y="cy + 37.5"
+          text-anchor="middle"
+          dominant-baseline="central"
+          class="lcd-digits"
+          filter="url(#lcdGlow)"
+        >
+          {{ ledSpeed }}
         </text>
       </g>
-
-      <!-- Needle -->
-      <line
-        :x1="cx"
-        :y1="cy"
-        :x2="cx + needleLen * Math.cos(rotation * Math.PI / 180)"
-        :y2="cy + needleLen * Math.sin(rotation * Math.PI / 180)"
-        :stroke="speedColor"
-        stroke-width="3"
-        stroke-linecap="round"
-        class="speedometer-needle"
-      />
-
-      <!-- Center dot -->
-      <circle
-        :cx="cx"
-        :cy="cy"
-        r="4"
-        fill="#374151"
-      />
-
-      <!-- Current speed display -->
-      <text
-        :x="cx"
-        :y="cy + 24"
-        text-anchor="middle"
-        dominant-baseline="middle"
-        class="speedometer-speed"
-      >
-        {{ speed }}
-      </text>
     </svg>
 
-    <!-- Address label -->
-    <div v-if="showLabel" class="text-center bg-gray-400/20 px-2 py-1 rounded-md">
-      <v-label class="text-lg font-bold">#{{ address }}</v-label>
+    <!-- 🏷️ Address label -->
+    <div v-if="showLabel" class="text-center bg-gray-800/40 border border-gray-600/30 px-2 py-1 rounded">
+      <v-label class="text-lg font-bold text-gray-300">#{{ address }}</v-label>
     </div>
   </div>
 </template>
 
 <style scoped>
-.speedometer-needle {
+.dial-needle {
   transition: x2 0.3s ease-out, y2 0.3s ease-out;
 }
-.speedometer-label {
-  font-size: 10px;
-  font-weight: 500;
-  fill: #9ca3af;
+
+.dial-number {
+  font-size: 8px;
+  font-weight: 600;
+  fill: #d1d5db;
+  opacity: 0.85;
 }
-.speedometer-speed {
-  font-size: 14px;
-  font-weight: 700;
-  fill: #374151;
+
+/* 📺 LCD "888" ghost segments — dim unlit look */
+.lcd-ghost {
+  font-family: 'Courier New', 'Consolas', monospace;
+  font-size: 18px;
+  font-weight: 900;
+  fill: #1a3a1a;
+  letter-spacing: 0.15em;
+}
+
+/* 📺 LCD active digits — green LED glow */
+.lcd-digits {
+  font-family: 'Courier New', 'Consolas', monospace;
+  font-size: 18px;
+  font-weight: 900;
+  fill: #22c55e;
+  letter-spacing: 0.15em;
 }
 </style>

--- a/apps/throttle/src/throttle/ThrottleHeader.vue
+++ b/apps/throttle/src/throttle/ThrottleHeader.vue
@@ -3,7 +3,7 @@
 </script>
 <template>
   <header
-    class="p-2 text-lg bg-transparent flex items-center justify-between relative flex-wrap gap-2"
+    class="p-1 @[640px]:p-2 text-lg bg-transparent flex items-center justify-between relative flex-nowrap gap-1 @[640px]:gap-2 min-h-0"
   >
     <slot name="prepend"></slot>
     <section class="flex items-center gap-2">

--- a/apps/throttle/src/throttle/useThrottleSettings.ts
+++ b/apps/throttle/src/throttle/useThrottleSettings.ts
@@ -1,9 +1,10 @@
 import { computed } from 'vue'
 import type { ComputedRef } from 'vue'
-import { useUserPreferences, type ThrottleSettings, type ThrottleVariant } from '@repo/modules'
+import { useUserPreferences, type ThrottleSettings, type ThrottleVariant, type SpeedDisplayType } from '@repo/modules'
 
 const DEFAULTS: ThrottleSettings = {
   variant: 'buttons',
+  speedDisplayType: 'dial',
   showFunctions: true,
   showSpeedometer: true,
   showConsist: true,
@@ -15,12 +16,17 @@ export function useThrottleSettings() {
   const settings: ComputedRef<ThrottleSettings> = getPreference('throttleSettings', DEFAULTS)
 
   const variant = computed(() => settings.value.variant)
+  const speedDisplayType = computed(() => settings.value.speedDisplayType ?? 'dial')
   const showFunctions = computed(() => settings.value.showFunctions)
   const showSpeedometer = computed(() => settings.value.showSpeedometer)
   const showConsist = computed(() => settings.value.showConsist)
 
   async function setVariant(value: ThrottleVariant) {
     await setPreference('throttleSettings', { ...settings.value, variant: value })
+  }
+
+  async function setSpeedDisplayType(value: SpeedDisplayType) {
+    await setPreference('throttleSettings', { ...settings.value, speedDisplayType: value })
   }
 
   async function setShowFunctions(value: boolean) {
@@ -37,10 +43,12 @@ export function useThrottleSettings() {
 
   return {
     variant,
+    speedDisplayType,
     showFunctions,
     showSpeedometer,
     showConsist,
     setVariant,
+    setSpeedDisplayType,
     setShowFunctions,
     setShowSpeedometer,
     setShowConsist,

--- a/apps/throttle/src/views/SettingsView.vue
+++ b/apps/throttle/src/views/SettingsView.vue
@@ -22,8 +22,8 @@ const { themePreference, setTheme } = useThemeSwitcher()
 const { mdAndUp } = useDisplay()
 
 const {
-  variant, showFunctions, showSpeedometer, showConsist,
-  setVariant, setShowFunctions, setShowSpeedometer, setShowConsist,
+  variant, speedDisplayType, showFunctions, showSpeedometer, showConsist,
+  setVariant, setSpeedDisplayType, setShowFunctions, setShowSpeedometer, setShowConsist,
 } = useThrottleSettings()
 
 const {
@@ -289,6 +289,25 @@ const backgroundPages = [
             </div>
             <div class="settings-row__value">
               <v-switch :model-value="showSpeedometer" @update:model-value="(v) => setShowSpeedometer(!!v)" color="primary" density="compact" hide-details />
+            </div>
+          </div>
+          <div class="settings-row">
+            <div class="settings-row__label">
+              <span class="settings-row__name">Speed Display</span>
+              <span class="settings-row__desc">Choose between round gauge dial or digital number readout</span>
+            </div>
+            <div class="settings-row__value">
+              <v-btn-toggle
+                :model-value="speedDisplayType"
+                @update:model-value="(v: string) => v && setSpeedDisplayType(v as 'dial' | 'digital')"
+                mandatory
+                density="compact"
+                color="primary"
+                variant="outlined"
+              >
+                <v-btn value="dial" size="small">🎛️ Dial</v-btn>
+                <v-btn value="digital" size="small">🔢 Digital</v-btn>
+              </v-btn-toggle>
             </div>
           </div>
           <div class="settings-row">

--- a/apps/throttle/src/views/ThrottleView.vue
+++ b/apps/throttle/src/views/ThrottleView.vue
@@ -48,7 +48,7 @@ useSwipe(throttleNavRef, {
     },
   },)
 
-const { variant, showFunctions, showSpeedometer, showConsist } = useThrottleSettings()
+const { variant, speedDisplayType, showFunctions, showSpeedometer, showConsist } = useThrottleSettings()
 
 const variantMap = {
   buttons: ButtonsThrottle,
@@ -62,6 +62,7 @@ const settingsProps = computed(() => ({
   showFunctions: showFunctions.value,
   showSpeedometer: showSpeedometer.value,
   showConsist: showConsist.value,
+  speedDisplayType: speedDisplayType.value,
 }))
 
 watch(() => route.params.address, (newVal) => {

--- a/packages/modules/preferences/types.ts
+++ b/packages/modules/preferences/types.ts
@@ -4,9 +4,11 @@ export interface AppBackgroundPrefs {
 }
 
 export type ThrottleVariant = 'buttons' | 'slider' | 'dashboard'
+export type SpeedDisplayType = 'dial' | 'digital'
 
 export interface ThrottleSettings {
   variant: ThrottleVariant
+  speedDisplayType: SpeedDisplayType
   showFunctions: boolean
   showSpeedometer: boolean
   showConsist: boolean


### PR DESCRIPTION
## Summary

- 🎛️ **Redesigned CurrentSpeed** — angular dark panel with purple accent stripe and FWD/REV direction indicator (replaces rounded gradient pill)
- 🔢 **Redesigned Speedometer SVG** — dark dial face, numbered tick marks every 10, embedded LCD readout with green glow and ghost "888" digits
- ⚙️ **New speed display setting** — users choose between round dial gauge or digital number readout (`SpeedDisplayType: 'dial' | 'digital'`), defaults to dial
- 📐 **3-column desktop layout** — left (functions + logo), middle (speedometer + EZ Consist), right (throttle controls) with `justify-around` and max-height 800px
- 📱 **Mobile layout** — speedometer top panel, 2-column below (consist + functions | controls) with bordered panel separation
- 🗜️ **Compact header** — `flex-nowrap`, smaller number plate (`xs`), truncated title on narrow screens
- 🎮 **Dashboard** — shows FunctionsSpeedDial in desktop left column, mobile shows only the dashboard device

### Files changed
- `CurrentSpeed.vue` — full redesign
- `Speedometer.vue` — full redesign (LCD readout, dark theme, numbered ticks)
- `ButtonsThrottle.vue` — 3-column desktop + 2-column mobile layout
- `SliderThrottle.vue` — same layout update
- `Dashboard.vue` — functions panel + compact header + mobile-only device
- `ThrottleHeader.vue` — nowrap + compact padding
- `useThrottleSettings.ts` — added `speedDisplayType` setting
- `SettingsView.vue` — added speed display type toggle
- `ThrottleView.vue` — passes new setting prop
- `packages/modules/preferences/types.ts` — added `SpeedDisplayType` type

## Test plan
- [ ] Verify ButtonsThrottle 3-column layout on desktop
- [ ] Verify SliderThrottle 3-column layout on desktop
- [ ] Verify Dashboard shows functions in left column on desktop
- [ ] Verify mobile layout: speedometer top, 2-column below with panel borders
- [ ] Verify header stays single-row on narrow screens
- [ ] Toggle speed display setting between Dial and Digital in Settings
- [ ] Verify FWD/REV indicator on CurrentSpeed reflects direction

🤖 Generated with [Claude Code](https://claude.com/claude-code)