### PR TITLE
fix(throttle): mobile UI CSS fixes, conductor layout, and settings consolidation 🎨📱

### DIFF
--- a/apps/cloud/src/User/SignOut/SignOut.vue
+++ b/apps/cloud/src/User/SignOut/SignOut.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { signOut } from 'firebase/auth'
 import { useCurrentUser, useFirebaseAuth } from 'vuefire'
+import { useRouter } from 'vue-router'
 import { createLogger } from '@repo/utils'
 import { useNotification } from '@repo/ui'
 
@@ -8,14 +9,17 @@ const log = createLogger('Auth')
 
 const auth = useFirebaseAuth()
 const user = useCurrentUser()
+const router = useRouter()
 const { notify } = useNotification()
 
 function handleSignOut() {
   if (auth) {
-    signOut(auth).catch((reason) => {
-      log.error('Failed signOut', reason)
-      notify.error('Failed to sign out. Please try again.')
-    })
+    signOut(auth)
+      .then(() => router.push('/login'))
+      .catch((reason) => {
+        log.error('Failed signOut', reason)
+        notify.error('Failed to sign out. Please try again.')
+      })
   }
 }
 </script>

--- a/apps/cloud/src/auth/Signout.vue
+++ b/apps/cloud/src/auth/Signout.vue
@@ -1,16 +1,22 @@
 <script setup lang="ts">
 import { signOut } from 'firebase/auth'
 import { useCurrentUser, useFirebaseAuth } from 'vuefire'
+import { useRouter } from 'vue-router'
 import { createLogger } from '@repo/utils'
 
 const log = createLogger('Auth')
 const auth = useFirebaseAuth()
 const user = useCurrentUser()
+const router = useRouter()
 
 function handleSignOut() {
-  auth && signOut(auth).catch((reason) => {
-    log.error('Failed signOut', reason)
-  })
+  if (auth) {
+    signOut(auth)
+      .then(() => router.push('/login'))
+      .catch((reason) => {
+        log.error('Failed signOut', reason)
+      })
+  }
 }
 </script>
 

--- a/apps/throttle/src/command-palette/CommandPalette.vue
+++ b/apps/throttle/src/command-palette/CommandPalette.vue
@@ -185,10 +185,12 @@ watch(displayedCommands, () => {
   }
 })
 
+const isTouchDevice = window.matchMedia('(pointer: coarse)').matches
+
 watch(isOpen, async (open) => {
   if (open) {
     await nextTick()
-    inputRef.value?.focus()
+    if (!isTouchDevice) inputRef.value?.focus()
   } else {
     errorText.value = null
   }
@@ -204,7 +206,7 @@ async function runCommand(cmd: Command) {
   if (cmd.children) {
     push(cmd.id)
     await nextTick()
-    inputRef.value?.focus()
+    if (!isTouchDevice) inputRef.value?.focus()
     return
   }
   errorText.value = null
@@ -367,6 +369,37 @@ function cycleCurrentIndex(control: CycleControl): number {
     @update:model-value="onDialogUpdate"
   >
     <v-card class="cp-card pa-0">
+      <!-- 🔍 Search input — pinned at top -->
+      <div class="cp-input-row">
+        <v-icon size="20" class="cp-chevron">mdi-chevron-right</v-icon>
+        <div v-if="headerLabel" class="cp-breadcrumb">{{ headerLabel }}</div>
+        <input
+          ref="inputRef"
+          v-model="query"
+          type="text"
+          class="cp-input"
+          placeholder="Search or type #42 to open throttle…"
+          @keydown="onKeydown"
+        />
+        <span class="cp-esc-hint">Esc</span>
+      </div>
+
+      <!-- 📜 Scrollable content below search -->
+      <div class="cp-scroll-area">
+
+      <!-- 🧭 Quick nav grid -->
+      <div v-if="showInlineThrottles" class="cp-nav-grid">
+        <button
+          v-for="item in DEFAULT_MENU_CONFIG"
+          :key="item.name"
+          class="cp-nav-item"
+          @click="navigateToMenuItem(item)"
+        >
+          <v-icon size="22" :class="`text-${item.color}-400`">{{ item.icon }}</v-icon>
+          <span class="cp-nav-item__label">{{ item.label }}</span>
+        </button>
+      </div>
+
       <!-- 📱 Mobile-only connection status -->
       <div v-if="showMobileStatus" class="cp-mobile-status">
         <ConnectionStatus
@@ -381,31 +414,6 @@ function cycleCurrentIndex(control: CycleControl): number {
       <div v-if="showPaletteControls" class="cp-controls">
         <UserProfile />
         <TrackPower @toggle="paletteTrackPowerToggle" />
-      </div>
-      <!-- 🧭 Quick nav grid — always visible at root level -->
-      <div v-if="showInlineThrottles" class="cp-nav-grid">
-        <button
-          v-for="item in DEFAULT_MENU_CONFIG"
-          :key="item.name"
-          class="cp-nav-item"
-          @click="navigateToMenuItem(item)"
-        >
-          <v-icon size="22" :class="`text-${item.color}-400`">{{ item.icon }}</v-icon>
-          <span class="cp-nav-item__label">{{ item.label }}</span>
-        </button>
-      </div>
-      <div class="cp-input-row">
-        <v-icon size="20" class="cp-chevron">mdi-chevron-right</v-icon>
-        <div v-if="headerLabel" class="cp-breadcrumb">{{ headerLabel }}</div>
-        <input
-          ref="inputRef"
-          v-model="query"
-          type="text"
-          class="cp-input"
-          placeholder="Search or type #42 to open throttle…"
-          @keydown="onKeydown"
-        />
-        <span class="cp-esc-hint">Esc</span>
       </div>
 
       <div class="cp-results" role="listbox">
@@ -521,6 +529,8 @@ function cycleCurrentIndex(control: CycleControl): number {
 
       <div v-if="errorText" class="cp-error">{{ errorText }}</div>
 
+      </div><!-- /cp-scroll-area -->
+
       <div class="cp-footer">
         <span><kbd>↑↓</kbd> navigate</span>
         <span><kbd>←→</kbd> adjust</span>
@@ -540,6 +550,14 @@ function cycleCurrentIndex(control: CycleControl): number {
   max-height: 70vh;
   display: flex;
   flex-direction: column;
+}
+
+.cp-scroll-area {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(148, 163, 184, 0.2) transparent;
 }
 
 .cp-mobile-status {

--- a/apps/throttle/src/command-palette/commands/settings.ts
+++ b/apps/throttle/src/command-palette/commands/settings.ts
@@ -3,8 +3,6 @@ import { useRoute, useRouter } from 'vue-router'
 import { useThemeSwitcher, type ThemeMode } from '@repo/ui'
 import type { Command, CycleControl, ToggleControl } from '../types'
 import { useThrottleSettings } from '@/throttle/useThrottleSettings'
-import { useConductorSettings } from '@/conductor/useConductorSettings'
-import { useQuickMenu } from '@/quick-menu/useQuickMenu'
 
 type ThrottleVariant = 'buttons' | 'slider' | 'dashboard'
 type ConductorRightPanel =
@@ -51,22 +49,13 @@ export function useSettingsCommands(): ComputedRef<Command[]> {
   const {
     variant: throttleVariant,
     showFunctions,
-    showSpeedometer,
     showConsist,
+    rightPanel: conductorRightPanel,
     setVariant: setThrottleVariant,
     setShowFunctions,
-    setShowSpeedometer,
     setShowConsist,
-  } = useThrottleSettings()
-
-  const {
-    variant: conductorVariant,
-    rightPanel: conductorRightPanel,
-    setVariant: setConductorVariant,
     setRightPanel: setConductorRightPanel,
-  } = useConductorSettings()
-
-  const { quickMenuVisible } = useQuickMenu()
+  } = useThrottleSettings()
 
   function buildThemeCommand(): Command {
     const control: CycleControl<ThemeMode> = {
@@ -147,8 +136,8 @@ export function useSettingsCommands(): ComputedRef<Command[]> {
     // 🎨 Always-visible core items
     commands.push(buildThemeCommand())
 
-    // 🏎️ Throttle-route contextual items
-    if (routeName === 'throttle' || routeName === 'throttles') {
+    // 🏎️ Throttle-route contextual items (also shown on conductor)
+    if (routeName === 'throttle' || routeName === 'throttles' || routeName === 'conductor') {
       commands.push(
         buildVariantCommand(
           'settings.throttle.variant',
@@ -165,27 +154,11 @@ export function useSettingsCommands(): ComputedRef<Command[]> {
           setShowFunctions,
         ),
         buildToggleCommand(
-          'settings.toggle.speedometer',
-          'Show speedometer',
-          'mdi-speedometer',
-          showSpeedometer.value,
-          setShowSpeedometer,
-        ),
-        buildToggleCommand(
           'settings.toggle.consist',
           'Show consist',
           'mdi-train-car-flatbed-car',
           showConsist.value,
           setShowConsist,
-        ),
-        buildToggleCommand(
-          'settings.toggle.quickMenu',
-          'Quick menu visible',
-          'mdi-menu',
-          quickMenuVisible.value,
-          (next) => {
-            quickMenuVisible.value = next
-          },
         ),
       )
     }
@@ -193,13 +166,6 @@ export function useSettingsCommands(): ComputedRef<Command[]> {
     // 🎛️ Conductor-route contextual items
     if (routeName === 'conductor') {
       commands.push(
-        buildVariantCommand(
-          'settings.conductor.variant',
-          'Conductor variant',
-          VARIANT_OPTIONS,
-          conductorVariant.value,
-          setConductorVariant,
-        ),
         {
           id: 'settings.conductor.rightPanel',
           title: 'Right panel',

--- a/apps/throttle/src/conductor/ConductorLayout.vue
+++ b/apps/throttle/src/conductor/ConductorLayout.vue
@@ -13,12 +13,12 @@ import {
   SignalList,
   DeviceConnectionList,
 } from '@repo/ui'
-import { useConductorSettings } from '@/conductor/useConductorSettings'
+import { useThrottleSettings } from '@/throttle/useThrottleSettings'
 
 const { getThrottles } = useLocos()
 const throttles = getThrottles()
 
-const { variant, rightPanel } = useConductorSettings()
+const { variant, rightPanel, speedDisplayType, showFunctions, showSpeedometer, showConsist } = useThrottleSettings()
 
 const variantMap = {
   buttons: ButtonsThrottle,
@@ -51,33 +51,33 @@ watch(throttles, (newThrottles) => {
   <main class="@container relative">
     <div class="conductor-layout grid grid-cols-1 @[960px]:grid-cols-3 gap-2 w-full">
 
-      <!-- Column 1: Throttle list -->
-      <div class="rounded border-1 border-green-500 border-opacity-50 order-2 @[960px]:!order-1 overflow-hidden min-h-[70vh] @[960px]:min-h-0" style="background: rgba(var(--v-theme-surface), 0.2)">
-        <div class="@container h-full overflow-hidden p-4">
+      <!-- Column 1: Throttle list (compact) -->
+      <div class="rounded border-1 border-green-500 border-opacity-50 order-2 @[960px]:!order-1 overflow-hidden min-h-[40vh] @[960px]:min-h-0" style="background: rgba(var(--v-theme-surface), 0.2)">
+        <div class="@container h-full overflow-hidden p-2">
           <div v-if="throttles?.length" class="relative h-full w-full">
             <ThrottleList />
           </div>
         </div>
       </div>
 
-      <!-- Column 2: Swipeable throttle controls -->
-      <div class="order-1 @[960px]:!order-2 overflow-hidden min-h-[90vh] @[960px]:min-h-0" style="background: rgba(var(--v-theme-surface), 0.2)">
+      <!-- Column 2: Swipeable throttle controls (compact) -->
+      <div class="order-1 @[960px]:!order-2 overflow-hidden min-h-[60vh] @[960px]:min-h-0" style="background: rgba(var(--v-theme-surface), 0.2)">
         <div class="@container h-full overflow-hidden">
           <ThrottleSwipeContainer
             v-if="throttles && throttles.length > 0"
             :throttles="throttles"
             :model-value="activeThrottleAddress"
             :variant-component="variantComponent"
-            :variant-props="{ showSpeedometer: false, showConsist: false }"
+            :variant-props="{ showSpeedometer: showSpeedometer, showConsist: showConsist, showFunctions: showFunctions, speedDisplayType: speedDisplayType }"
             @update:model-value="activeThrottleAddress = $event"
           />
         </div>
       </div>
 
-      <!-- Column 3: Right panel -->
-      <div class="order-3 overflow-hidden min-h-[70vh] @[960px]:min-h-0" style="background: rgba(var(--v-theme-surface), 0.2)">
-        <div class="@container h-full overflow-y-auto p-4">
-          <component :is="rightPanelComponent" />
+      <!-- Column 3: Right panel (full-width items) -->
+      <div class="order-3 overflow-hidden min-h-[40vh] @[960px]:min-h-0 conductor-right-panel" style="background: rgba(var(--v-theme-surface), 0.2)">
+        <div class="@container h-full overflow-y-auto p-2">
+          <component :is="rightPanelComponent" compact />
         </div>
       </div>
 
@@ -104,5 +104,32 @@ watch(throttles, (newThrottles) => {
   .conductor-layout {
     height: calc(100vh - var(--v-layout-bottom) - var(--v-layout-top));
   }
+}
+</style>
+
+<!-- 🔀 Unscoped styles to override Vuetify's @media responsive grid inside conductor right panel -->
+<style>
+/* Force all list items to full width in conductor right panel */
+.conductor-right-panel .v-col,
+.conductor-right-panel .v-col-12,
+.conductor-right-panel [class*="v-col-sm"],
+.conductor-right-panel [class*="v-col-md"],
+.conductor-right-panel [class*="v-col-lg"],
+.conductor-right-panel [class*="v-col-xl"],
+.conductor-right-panel [class*="v-col-xxl"] {
+  flex: 0 0 100% !important;
+  max-width: 100% !important;
+}
+
+/* CTC switches — 2 per row, centered */
+.conductor-right-panel .v-col-auto {
+  flex: 0 0 50% !important;
+  max-width: 50% !important;
+  display: flex;
+  justify-content: center;
+}
+
+.conductor-right-panel .v-row {
+  justify-content: center;
 }
 </style>

--- a/apps/throttle/src/core/Menu/FooterMenu.vue
+++ b/apps/throttle/src/core/Menu/FooterMenu.vue
@@ -1,28 +1,34 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed } from 'vue'
 import { useMenu } from './useMenu'
 import { useRoute } from 'vue-router'
 
 const route = useRoute()
-const active = ref(route.path)
 const { menuFavorites, handleMenu } = useMenu()
 
+// Reactively match current route to a favorite menu item
+const active = computed(() => {
+  const name = route.name?.toString()
+  if (!name) return undefined
+  const match = menuFavorites.value.find(item => item.name === name)
+  return match?.name
+})
 </script>
 <template>
   <v-footer app class="bg-transparent">
     <v-container fluid class="p-0">
       <v-row class="pt-2 pb-3 px-0">
-        <v-spacer />        
-        <v-btn-toggle 
+        <v-spacer />
+        <v-btn-toggle
           class="border-2 border-primary"
-          divided 
-          rounded="pill" 
-          variant="flat" 
-          v-model="active">
+          divided
+          rounded="pill"
+          variant="flat"
+          :model-value="active">
           <v-btn v-for="item in menuFavorites"
             :key="item.label"
             class="sm:px-12"
-            :class="$route.path === item.name ? `bg-${item.color}-500` : `text-${item.color}-500`"
+            :class="route.name === item.name ? `bg-${item.color}-500` : `text-${item.color}-500`"
             @click="handleMenu(item)"
             :color="item.color"
             :icon="item.icon"

--- a/apps/throttle/src/core/Menu/useMenu.ts
+++ b/apps/throttle/src/core/Menu/useMenu.ts
@@ -77,9 +77,10 @@ const defaultFavorites = [
     'conductor',
     'throttle',
     'effects',
-    'routes',
+    'roster',
     'turnouts',
-    'signals'    
+    'signals',
+    'settings'
 ]
 
 export function useMenu() {

--- a/apps/throttle/src/quick-menu/MiniThrottleControl.vue
+++ b/apps/throttle/src/quick-menu/MiniThrottleControl.vue
@@ -62,7 +62,7 @@ const emit = defineEmits<{
         color="amber"
         @click.stop="emit('park', address)"
       >
-        <v-icon size="16">mdi-parking</v-icon>
+        <v-icon size="16">mdi-eject</v-icon>
       </v-btn>
     </div>
   </div>

--- a/apps/throttle/src/routes/Routes.vue
+++ b/apps/throttle/src/routes/Routes.vue
@@ -8,7 +8,11 @@ import TamarackJunction from './maps/tam/TamarackJunction.vue'
 import PayetteSub from './maps/tam/PayetteSub.vue'
 import './route-styles.css'
 
-const activeMap = ref('PayetteSub')
+const props = defineProps({
+  compact: { type: Boolean, default: false },
+})
+
+const activeMap = ref(props.compact ? 'RoutesList' : 'PayetteSub')
 
 const { runRoute, isRunning, percentComplete } = useLayoutRoutes()
 const {
@@ -34,24 +38,27 @@ const handleMapClickWithHaptic = (event: Event) => {
   <div class="relative">
     <PageHeader title="Routes" icon="mdi-routes" color="blue">
       <template #actions>
-        <v-btn
-          v-for="map in ['TamarackJunction', 'PayetteSub']"
-          :key="map"
-          :variant="activeMap === map ? 'flat' : 'outlined'"
-          color="primary"
-          prepend-icon="mdi-map"
-          size="small"
-          @click="activeMap = map; vibrate('light')"
-        >
-        {{ map }}
-        </v-btn>
-        <v-btn
-          :variant="activeMap === 'RoutesList' ? 'flat' : 'outlined'"
-          prepend-icon="mdi-format-list-bulleted"
-          color="primary"
-          size="small"
-          @click="activeMap = 'RoutesList'; vibrate('light')"
-        >Routes List</v-btn>
+        <div class="flex flex-wrap gap-1">
+          <v-btn
+            v-if="!compact"
+            v-for="map in ['TamarackJunction', 'PayetteSub']"
+            :key="map"
+            :variant="activeMap === map ? 'flat' : 'outlined'"
+            color="primary"
+            prepend-icon="mdi-map"
+            size="x-small"
+            @click="activeMap = map; vibrate('light')"
+          >
+          {{ map }}
+          </v-btn>
+          <v-btn
+            :variant="activeMap === 'RoutesList' ? 'flat' : 'outlined'"
+            prepend-icon="mdi-format-list-bulleted"
+            color="primary"
+            :size="compact ? 'x-small' : 'small'"
+            @click="activeMap = 'RoutesList'; vibrate('light')"
+          >Routes</v-btn>
+        </div>
       </template>
     </PageHeader>
     <main>

--- a/apps/throttle/src/throttle/ButtonsThrottle.vue
+++ b/apps/throttle/src/throttle/ButtonsThrottle.vue
@@ -18,6 +18,7 @@ const props = defineProps({
   showSpeedometer: { type: Boolean, default: true },
   showConsist: { type: Boolean, default: true },
   speedDisplayType: { type: String as () => SpeedDisplayType, default: 'dial' },
+  compact: { type: Boolean, default: false },
 })
 
 const address = toRef(props, 'address')
@@ -58,7 +59,10 @@ async function clearLoco() {
             size="xs"
             class="@[400px]:hidden"
           />
-          <h1 class="text-sm @[400px]:text-base @[640px]:text-xl @[960px]:text-4xl font-bold tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-cyan-400 drop-shadow-lg truncate">
+          <h1
+            class="font-bold tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-cyan-400 drop-shadow-lg truncate min-w-0"
+            :class="compact ? 'text-sm' : 'text-sm @[400px]:text-base @[640px]:text-xl @[960px]:text-4xl'"
+          >
             {{ loco?.name }}
           </h1>
         </div>
@@ -68,8 +72,8 @@ async function clearLoco() {
       </template>
     </ThrottleHeader>
 
-    <!-- 🖥️ Desktop: 3-column layout -->
-    <section class="w-full hidden @[640px]:flex flex-row items-stretch justify-around flex-grow relative z-10" style="max-height: 800px;">
+    <!-- 🖥️ Desktop: 3-column layout (hidden in compact/conductor mode) -->
+    <section v-if="!compact" class="w-full hidden @[640px]:flex flex-row items-stretch justify-around flex-grow relative z-10" style="max-height: 800px;">
       <!-- Left col: Function buttons + Logo -->
       <section v-if="loco" class="flex flex-col items-center justify-around flex-1">
         <FunctionsSpeedDial v-if="showFunctions" :loco="loco" />
@@ -78,13 +82,11 @@ async function clearLoco() {
 
       <!-- Middle col: Speedometer + EZ Consist -->
       <section class="flex flex-col items-center justify-around flex-1">
-        <!-- 🎛️ Speed display: dial or digital based on setting -->
         <template v-if="showSpeedometer">
           <Speedometer v-if="speedDisplayType === 'dial'" :speed="currentSpeed" :address="address" :size="200" :show-label="false" />
           <CurrentSpeed v-else :speed="currentSpeed" />
         </template>
         <ConsistIndicator v-if="showConsist && loco" :loco="loco" />
-        <!-- 🚂 Consist speedometers -->
         <div v-if="showConsist && loco?.consist?.length" class="grid grid-cols-2 gap-3">
           <Speedometer
             v-for="cloco in loco.consist"
@@ -103,24 +105,25 @@ async function clearLoco() {
       </section>
     </section>
 
-    <!-- 📱 Mobile: speedometer top, then 2-column below -->
-    <section class="w-full flex @[640px]:hidden flex-col flex-grow relative z-10 gap-1">
-      <!-- 🎛️ Speedometer at top -->
-      <div v-if="showSpeedometer" class="flex justify-center py-2 mx-2 rounded-lg border border-white/10 bg-white/[0.03]">
-        <Speedometer v-if="speedDisplayType === 'dial'" :speed="currentSpeed" :address="address" :size="140" :show-label="false" />
+    <!-- 📱 Mobile layout (or compact/conductor mode) -->
+    <section class="w-full flex flex-col flex-1 min-h-0 relative z-10 gap-1" :class="compact ? '' : '@[640px]:hidden'">
+      <!-- 🎛️ Speedometer + EZ Consist at top (not in compact) -->
+      <div v-if="showSpeedometer && !compact" class="flex flex-col items-center gap-1 py-2 mx-2 rounded-lg border border-white/10 bg-white/[0.03]">
+        <Speedometer v-if="speedDisplayType === 'dial'" :speed="currentSpeed" :address="address" :size="180" :show-label="false" />
         <CurrentSpeed v-else :speed="currentSpeed" />
+        <ConsistIndicator v-if="showConsist && loco" :loco="loco" />
       </div>
 
-      <!-- 📱 Two columns -->
-      <div class="flex flex-row flex-grow min-h-0 gap-1 mx-2">
-        <!-- Left col: EZ Consist + Functions -->
-        <section class="flex flex-col items-center justify-around flex-1 rounded-lg border border-white/10 bg-white/[0.03] py-2">
-          <ConsistIndicator v-if="showConsist && loco" :loco="loco" />
+      <!-- Two columns (or single column in compact) -->
+      <div class="flex flex-row flex-1 min-h-0 overflow-hidden gap-1 mx-2">
+        <!-- Left col: Functions + Logo (hidden in compact) -->
+        <section v-if="!compact" class="flex flex-col items-center justify-around flex-1 rounded-lg border border-white/10 bg-white/[0.03] py-2">
           <FunctionsSpeedDial v-if="loco && showFunctions" :loco="loco" />
         </section>
 
-        <!-- Right col: Throttle controls -->
+        <!-- Right col (or full width in compact): Throttle controls -->
         <section class="flex flex-col items-center justify-around flex-1 rounded-lg border border-white/10 bg-white/[0.03] py-2">
+          <CurrentSpeed v-if="compact" :speed="currentSpeed" />
           <ThrottleButtonControls @update:currentSpeed="handleAdjustSpeed" @stop="handleStop" />
         </section>
       </div>

--- a/apps/throttle/src/throttle/CurrentSpeed.vue
+++ b/apps/throttle/src/throttle/CurrentSpeed.vue
@@ -6,6 +6,10 @@ const props = defineProps({
     type: Number,
     required: true,
   },
+  compact: {
+    type: Boolean,
+    default: false,
+  },
 })
 
 const isForward = computed(() => props.speed >= 0)
@@ -14,7 +18,7 @@ const displaySpeed = computed(() => Math.abs(props.speed))
 
 <template>
   <div class="flex justify-center">
-    <div class="speed-panel">
+    <div class="speed-panel" :class="{ 'speed-panel--compact': compact }">
       <!-- ⚡ Purple accent stripe -->
       <div class="speed-panel__accent" />
       <!-- 🚂 Speed readout -->
@@ -75,6 +79,25 @@ const displaySpeed = computed(() => Math.abs(props.speed))
   line-height: 1.1;
   color: #e9d5ff;
   text-shadow: 0 0 8px rgba(168, 85, 247, 0.4);
+}
+
+/* 🔹 Compact mode — horizontal, smaller */
+.speed-panel--compact {
+  min-width: auto;
+}
+.speed-panel--compact .speed-panel__body {
+  flex-direction: row;
+  gap: 0.25rem;
+  padding: 0.2rem 0.5rem;
+}
+.speed-panel--compact .speed-panel__direction {
+  font-size: 0.5rem;
+}
+.speed-panel--compact .speed-panel__value {
+  font-size: 1rem;
+}
+.speed-panel--compact .speed-panel__accent {
+  width: 3px;
 }
 
 /* 📱 Container query scaling */

--- a/apps/throttle/src/throttle/Dashboard.vue
+++ b/apps/throttle/src/throttle/Dashboard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, ref, toRef, watch } from 'vue'
+import { computed, onBeforeUnmount, ref, toRef, unref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import ThrottleHeader from '@/throttle/ThrottleHeader.vue'
 import ThrottleActionMenu from '@/throttle/ThrottleActionMenu.vue'
@@ -32,12 +32,12 @@ const {
 const { vibrate } = useHaptics()
 const $router = useRouter()
 
-// 🎛️ Notch-to-speed mapping (IDLE + 8 notches)
-const NOTCH_SPEEDS = [0, 16, 32, 48, 64, 80, 96, 112, 126]
-const NOTCH_LABELS = ['IDLE', '1', '2', '3', '4', '5', '6', '7', '8']
+// 🎛️ Notch labels for the speed bar
+const NOTCH_LABELS = ['0', '16', '32', '48', '64', '80', '96', '112', '126']
 
 // 🔧 Local state
-const localNotch = ref(0)
+const localSpeed = ref(0)
+const functionsOpen = ref(false)
 const localDirection = ref<'FWD' | 'REV'>('FWD')
 const brakeLevel = ref(0)
 const bellActive = ref(false)
@@ -64,20 +64,9 @@ const brakeGradient = computed(() => {
   return `linear-gradient(90deg, #eab308 0%, #ef4444 ${pct}%, #374151 ${pct}%, #374151 100%)`
 })
 
-// Sync localNotch from external speed changes
+// Sync localSpeed from external speed changes
 watch(currentSpeed, (speed) => {
-  const absSpeed = Math.abs(speed)
-  // Find the closest notch
-  let closest = 0
-  let minDiff = Infinity
-  NOTCH_SPEEDS.forEach((ns, i) => {
-    const diff = Math.abs(absSpeed - ns)
-    if (diff < minDiff) {
-      minDiff = diff
-      closest = i
-    }
-  })
-  localNotch.value = closest
+  localSpeed.value = Math.abs(speed)
   if (speed < 0) {
     localDirection.value = 'REV'
   } else if (speed > 0) {
@@ -91,17 +80,18 @@ const displaySpeed = computed(() => {
   return String(absSpeed).padStart(3, '0')
 })
 
-const displayNotch = computed(() => NOTCH_LABELS[localNotch.value])
+const displayNotch = computed(() => {
+  if (localSpeed.value === 0) return 'IDLE'
+  return String(localSpeed.value)
+})
 const displayDirection = computed(() => localDirection.value)
-const displayLocoName = computed(() => loco?.name ?? '---')
+const displayLocoName = computed(() => unref(loco)?.name ?? '---')
 const displayAddress = computed(() => String(props.address).padStart(4, '0'))
 
-// 🎚️ Throttle notch control
-function setNotch(notch: number) {
-  if (notch < 0 || notch > 8) return
-  localNotch.value = notch
-  vibrate('medium')
-  const speed = NOTCH_SPEEDS[notch]
+// 🎚️ Throttle slider control (direct speed 0–126)
+function setThrottleSpeed(speed: number) {
+  if (speed < 0 || speed > 126) return
+  localSpeed.value = speed
   const signedSpeed = localDirection.value === 'REV' ? -speed : speed
   setSpeed(signedSpeed)
 }
@@ -202,7 +192,7 @@ watch(brakeLevel, (level) => {
   }
 
   if (level > 0) {
-    localNotch.value = 0
+    localSpeed.value = 0
 
     if (Math.abs(currentSpeed.value) < 1) return
 
@@ -271,23 +261,26 @@ onBeforeUnmount(() => {
       <!-- Right col: Device body -->
       <section class="proto-device mx-auto w-full max-w-[360px] flex flex-col items-center gap-0 flex-none overflow-y-auto">
 
-        <!-- 1. Status LED + Horn Handle -->
-        <div class="device-top-row w-full flex items-center justify-between px-4 py-2">
-          <!-- Status LED -->
+        <!-- 1. Status LED + Stop/Eject + Functions + Horn -->
+        <div class="device-top-row w-full flex items-center gap-2 px-4 py-1">
           <div class="status-led" :class="{ 'led-on': statusLedOn }"></div>
-          <!-- Horn icon -->
+          <div class="flex-grow" />
+          <v-btn icon size="x-small" color="red" variant="tonal" @click="handleStop" title="Stop"><v-icon size="14">mdi-stop</v-icon></v-btn>
+          <v-btn icon size="x-small" variant="text" color="red-lighten-1" @click="clearLoco" title="Eject"><v-icon size="14">mdi-eject</v-icon></v-btn>
+          <v-btn v-if="loco && showFunctions" icon size="x-small" variant="text" color="grey-lighten-1" @click="functionsOpen = !functionsOpen"><v-icon size="16">mdi-train</v-icon></v-btn>
           <div class="horn-container">
-            <v-icon
-              size="32"
-              class="horn-icon select-none"
-              :class="{ 'horn-active': hornActive }"
-              @pointerdown="hornDown"
-              @pointerup="hornUp"
-              @pointercancel="(e) => hornUp(e as PointerEvent)"
-              @pointerleave="(e) => hornUp(e as PointerEvent)"
-              style="cursor: pointer; touch-action: none;"
-            >mdi-bugle</v-icon>
+            <v-icon size="24" class="horn-icon select-none" :class="{ 'horn-active': hornActive }" @pointerdown="hornDown" @pointerup="hornUp" @pointercancel="(e) => hornUp(e as PointerEvent)" @pointerleave="(e) => hornUp(e as PointerEvent)" style="cursor: pointer; touch-action: none;">mdi-bugle</v-icon>
           </div>
+        </div>
+
+        <!-- Functions panel (toggleable) -->
+        <div v-if="functionsOpen && loco" class="px-4 py-1">
+          <FunctionsSpeedDial :loco="loco" />
+        </div>
+
+        <!-- EZ Consist (own row above LCD) -->
+        <div v-if="showConsist && loco?.consist?.length" class="w-full px-4 py-1">
+          <ConsistIndicator :loco="loco" />
         </div>
 
         <!-- 2. LCD Screen -->
@@ -313,51 +306,36 @@ onBeforeUnmount(() => {
           </div>
         </div>
 
-        <!-- 3. Speed Buttons: Row 1: -5, +5 | Row 2: -1, +1 -->
-        <div class="nav-buttons-grid">
-          <button
-            class="nav-btn"
-            :class="{ 'nav-btn-active': pressedButton === 'down5' }"
-            @click="handleDown5Btn"
-          >-5</button>
-          <button
-            class="nav-btn"
-            :class="{ 'nav-btn-active': pressedButton === 'up5' }"
-            @click="handleUp5Btn"
-          >+5</button>
-          <button
-            class="nav-btn"
-            :class="{ 'nav-btn-active': pressedButton === 'down' }"
-            @click="handleDownBtn"
-          >-1</button>
-          <button
-            class="nav-btn"
-            :class="{ 'nav-btn-active': pressedButton === 'up' }"
-            @click="handleUpBtn"
-          >+1</button>
+        <!-- 3. Speed Buttons: single row -->
+        <div class="nav-buttons-row">
+          <button class="nav-btn-sm" :class="{ 'nav-btn-active': pressedButton === 'down5' }" @click="handleDown5Btn">-5</button>
+          <button class="nav-btn-sm" :class="{ 'nav-btn-active': pressedButton === 'down' }" @click="handleDownBtn">-1</button>
+          <button class="nav-btn-sm" :class="{ 'nav-btn-active': pressedButton === 'up' }" @click="handleUpBtn">+1</button>
+          <button class="nav-btn-sm" :class="{ 'nav-btn-active': pressedButton === 'up5' }" @click="handleUp5Btn">+5</button>
         </div>
 
-        <!-- 4. Notch Markings -->
+        <!-- 4. Notch markers -->
         <div class="notch-markings">
           <span
             v-for="(label, i) in NOTCH_LABELS"
-            :key="label"
+            :key="i"
             class="notch-label"
-            :class="{ 'notch-active': i <= localNotch && i > 0, 'notch-current': localNotch === i }"
-          >{{ label }}</span>
+            :class="{ 'notch-active': localSpeed >= Number(label) && Number(label) > 0 }"
+          >{{ i === 0 ? 'IDLE' : i }}</span>
         </div>
 
-        <!-- 5. Throttle Slider (vertical, 9 positions) -->
-        <div class="throttle-slider-area">
+        <!-- 5. Throttle Slider (0–126, step=1) -->
+        <div class="throttle-slider-area" @touchstart.stop @pointerdown.stop>
           <div class="slider-track">
             <input
               type="range"
               min="0"
-              max="8"
-              :value="localNotch"
-              @input="(e) => setNotch(Number((e.target as HTMLInputElement).value))"
+              max="126"
+              step="1"
+              :value="localSpeed"
+              @input="(e) => setThrottleSpeed(Number((e.target as HTMLInputElement).value))"
               class="throttle-range"
-              orient="vertical"
+              style="touch-action: none;"
             />
           </div>
         </div>
@@ -369,11 +347,11 @@ onBeforeUnmount(() => {
             :model-value="localDirection === 'FWD'"
             @update:model-value="toggleDirection"
             :disabled="currentSpeed !== 0"
-            color="blue"
+            color="purple"
             hide-details
             density="compact"
             inset
-            class="reverser-switch"
+            class="lever-switch"
           />
           <span class="reverser-end-label" :class="localDirection === 'FWD' ? 'text-green-400' : 'opacity-40'">FWD</span>
         </div>
@@ -427,25 +405,28 @@ onBeforeUnmount(() => {
       </section>
     </section>
 
-    <!-- 📱 Mobile: only the dashboard device -->
-    <section class="w-full flex @[640px]:hidden flex-col items-center flex-grow relative z-10 overflow-y-auto">
-      <section class="proto-device mx-auto w-full max-w-[360px] flex flex-col items-center gap-0">
+    <!-- 📱 Mobile: dashboard device -->
+    <section class="w-full flex @[640px]:hidden flex-col flex-1 min-h-0 relative z-10">
+      <section class="proto-device mx-auto w-full max-w-[360px] flex flex-col items-center gap-0 flex-1 min-h-0 overflow-y-auto">
 
-        <!-- 1. Status LED + Horn Handle -->
-        <div class="device-top-row w-full flex items-center justify-between px-4 py-2">
+        <!-- 1. Status LED + Functions + Horn -->
+        <div class="device-top-row w-full flex items-center gap-2 px-4 py-1">
           <div class="status-led" :class="{ 'led-on': statusLedOn }"></div>
+          <div class="flex-grow" />
+          <v-btn v-if="loco && showFunctions" icon size="x-small" variant="text" color="grey-lighten-1" @click="functionsOpen = !functionsOpen"><v-icon size="16">mdi-train</v-icon></v-btn>
           <div class="horn-container">
-            <v-icon
-              size="32"
-              class="horn-icon select-none"
-              :class="{ 'horn-active': hornActive }"
-              @pointerdown="hornDown"
-              @pointerup="hornUp"
-              @pointercancel="(e) => hornUp(e as PointerEvent)"
-              @pointerleave="(e) => hornUp(e as PointerEvent)"
-              style="cursor: pointer; touch-action: none;"
-            >mdi-bugle</v-icon>
+            <v-icon size="24" class="horn-icon select-none" :class="{ 'horn-active': hornActive }" @pointerdown="hornDown" @pointerup="hornUp" @pointercancel="(e) => hornUp(e as PointerEvent)" @pointerleave="(e) => hornUp(e as PointerEvent)" style="cursor: pointer; touch-action: none;">mdi-bugle</v-icon>
           </div>
+        </div>
+
+        <!-- Functions panel -->
+        <div v-if="functionsOpen && loco" class="px-4 py-1">
+          <FunctionsSpeedDial :loco="loco" />
+        </div>
+
+        <!-- EZ Consist (own row) -->
+        <div v-if="showConsist && loco?.consist?.length" class="w-full px-4 py-1">
+          <ConsistIndicator :loco="loco" />
         </div>
 
         <!-- 2. LCD Screen -->
@@ -470,80 +451,45 @@ onBeforeUnmount(() => {
           </div>
         </div>
 
-        <!-- 3. Speed Buttons -->
-        <div class="nav-buttons-grid">
-          <button class="nav-btn" :class="{ 'nav-btn-active': pressedButton === 'down5' }" @click="handleDown5Btn">-5</button>
-          <button class="nav-btn" :class="{ 'nav-btn-active': pressedButton === 'up5' }" @click="handleUp5Btn">+5</button>
-          <button class="nav-btn" :class="{ 'nav-btn-active': pressedButton === 'down' }" @click="handleDownBtn">-1</button>
-          <button class="nav-btn" :class="{ 'nav-btn-active': pressedButton === 'up' }" @click="handleUpBtn">+1</button>
+        <!-- 3. Speed buttons (single row, full width) -->
+        <div class="nav-buttons-row">
+          <button class="nav-btn-sm" :class="{ 'nav-btn-active': pressedButton === 'down5' }" @click="handleDown5Btn">-5</button>
+          <button class="nav-btn-sm" :class="{ 'nav-btn-active': pressedButton === 'down' }" @click="handleDownBtn">-1</button>
+          <button class="nav-btn-sm" :class="{ 'nav-btn-active': pressedButton === 'up' }" @click="handleUpBtn">+1</button>
+          <button class="nav-btn-sm" :class="{ 'nav-btn-active': pressedButton === 'up5' }" @click="handleUp5Btn">+5</button>
         </div>
 
-        <!-- 4. Notch Markings -->
+        <!-- 4. Notch markers -->
         <div class="notch-markings">
-          <span
-            v-for="(label, i) in NOTCH_LABELS"
-            :key="label"
-            class="notch-label"
-            :class="{ 'notch-active': i <= localNotch && i > 0, 'notch-current': localNotch === i }"
-          >{{ label }}</span>
+          <span v-for="(label, i) in NOTCH_LABELS" :key="i" class="notch-label" :class="{ 'notch-active': localSpeed >= Number(label) && Number(label) > 0 }">{{ i === 0 ? 'IDLE' : i }}</span>
         </div>
 
-        <!-- 5. Throttle Slider -->
-        <div class="throttle-slider-area">
+        <!-- 5. Throttle Slider (0–126, step=1) -->
+        <div class="throttle-slider-area" @touchstart.stop @pointerdown.stop>
           <div class="slider-track">
-            <input
-              type="range"
-              min="0"
-              max="8"
-              :value="localNotch"
-              @input="(e) => setNotch(Number((e.target as HTMLInputElement).value))"
-              class="throttle-range"
-              orient="vertical"
-            />
+            <input type="range" min="0" max="126" step="1" :value="localSpeed" @input="(e) => setThrottleSpeed(Number((e.target as HTMLInputElement).value))" class="throttle-range" style="touch-action: none;" />
           </div>
         </div>
 
         <!-- 6. Reverser -->
         <div class="reverser-area">
           <span class="reverser-end-label" :class="localDirection === 'REV' ? 'text-red-400' : 'opacity-40'">REV</span>
-          <v-switch
-            :model-value="localDirection === 'FWD'"
-            @update:model-value="toggleDirection"
-            :disabled="currentSpeed !== 0"
-            color="blue"
-            hide-details
-            density="compact"
-            inset
-            class="reverser-switch"
-          />
+          <v-switch :model-value="localDirection === 'FWD'" @update:model-value="toggleDirection" :disabled="currentSpeed !== 0" color="purple" hide-details density="compact" inset class="lever-switch" />
           <span class="reverser-end-label" :class="localDirection === 'FWD' ? 'text-green-400' : 'opacity-40'">FWD</span>
         </div>
 
-        <!-- 7. Bell Icon -->
+        <!-- 7. Bell -->
         <div class="bell-area">
           <div class="bell-container">
-            <v-icon
-              size="32"
-              class="bell-icon select-none"
-              :class="{ 'bell-icon-active': bellActive }"
-              @click="toggleBell"
-              style="cursor: pointer;"
-            >mdi-bell</v-icon>
+            <v-icon size="28" class="bell-icon select-none" :class="{ 'bell-icon-active': bellActive }" @click="toggleBell" style="cursor: pointer;">mdi-bell</v-icon>
           </div>
         </div>
 
-        <!-- 8. Brake Slider -->
+        <!-- 8. Brake -->
         <div class="brake-slider-area">
           <span class="brake-label">BRAKE</span>
           <div class="brake-track">
-            <input
-              type="range"
-              min="0"
-              max="10"
-              v-model.number="brakeLevel"
-              class="brake-range"
-              :style="{ background: brakeGradient }"
-            />
+            <input type="range" min="0" max="10" v-model.number="brakeLevel" class="brake-range" :style="{ background: brakeGradient }" style="touch-action: none;" />
           </div>
         </div>
 
@@ -740,26 +686,24 @@ onBeforeUnmount(() => {
   to { opacity: 1; }
 }
 
-/* ── Navigation Buttons ───────────────────────────────────── */
-.nav-buttons-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-template-rows: 1fr 1fr;
-  gap: 6px;
-  padding: 8px 24px;
+/* ── Navigation Buttons (single row) ──────────────────────── */
+.nav-buttons-row {
+  display: flex;
+  gap: 4px;
+  padding: 4px 16px;
   width: 100%;
 }
 
-.nav-btn {
-  width: 100%;
-  height: 36px;
+.nav-btn-sm {
+  flex: 1;
+  height: 28px;
   border-radius: 6px;
   background: linear-gradient(180deg, #3d4f6a 0%, #2a3a52 100%);
   border: 1px solid #4a5f7a;
   color: #c8d6e5;
   font-size: 11px;
   font-weight: 700;
-  letter-spacing: 1px;
+  letter-spacing: 0.5px;
   cursor: pointer;
   box-shadow:
     0 2px 4px rgba(0,0,0,0.3),
@@ -769,12 +713,10 @@ onBeforeUnmount(() => {
   user-select: none;
 }
 
-.nav-btn:active,
-.nav-btn.nav-btn-active {
+.nav-btn-sm:active,
+.nav-btn-sm.nav-btn-active {
   transform: translateY(1px);
-  box-shadow:
-    0 1px 2px rgba(0,0,0,0.3),
-    inset 0 2px 4px rgba(0,0,0,0.3);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.3), inset 0 2px 4px rgba(0,0,0,0.3);
   background: linear-gradient(180deg, #2a3a52 0%, #1e2d40 100%);
 }
 
@@ -798,12 +740,7 @@ onBeforeUnmount(() => {
 
 .notch-label.notch-active {
   color: #4ade80;
-}
-
-.notch-label.notch-current {
-  color: #4ade80;
-  text-shadow: 0 0 6px rgba(74, 222, 128, 0.5);
-  font-size: 12px;
+  text-shadow: 0 0 4px rgba(74, 222, 128, 0.3);
 }
 
 /* ── Throttle Slider ──────────────────────────────────────── */
@@ -1073,19 +1010,18 @@ onBeforeUnmount(() => {
   20%, 40%, 60%, 80% { transform: translateX(2px); }
 }
 
-/* ── Reverser switch lever styling ───────────────────────── */
-.reverser-switch :deep(.v-switch__track) {
-  height: 40px;
-  width: 80px;
-  border-radius: 20px;
+/* ── Reverser switch lever styling (matches SliderThrottle) */
+.lever-switch :deep(.v-switch__track) {
+  height: 28px;
+  border-radius: 14px;
   opacity: 1;
   background: linear-gradient(180deg, #1e293b 0%, #334155 100%);
   border: 2px solid #475569;
   box-shadow: inset 0 2px 4px rgba(0,0,0,0.3);
 }
-.reverser-switch :deep(.v-switch__thumb) {
-  width: 36px;
-  height: 36px;
+.lever-switch :deep(.v-switch__thumb) {
+  width: 24px;
+  height: 24px;
   background: linear-gradient(180deg, #94a3b8 0%, #64748b 100%);
   border: 1px solid #cbd5e1;
   box-shadow: 0 2px 6px rgba(0,0,0,0.3);

--- a/apps/throttle/src/throttle/DashboardTile.vue
+++ b/apps/throttle/src/throttle/DashboardTile.vue
@@ -1,0 +1,279 @@
+<script setup lang="ts">
+import { computed, ref, toRef, unref, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import CurrentSpeed from './CurrentSpeed.vue'
+import { LocoNumberPlate } from '@repo/ui'
+import { ROADNAMES } from '@repo/modules'
+import { useThrottle } from './useThrottle'
+
+const props = defineProps({
+  address: {
+    type: Number,
+    required: true
+  }
+})
+
+const $router = useRouter()
+const addressRef = toRef(props, 'address')
+const {
+  currentSpeed,
+  setSpeed,
+  loco,
+  releaseThrottle,
+  stop: handleStop,
+  throttle,
+} = useThrottle(addressRef)
+
+const localSpeed = ref(0)
+const localDirection = ref<'FWD' | 'REV'>('FWD')
+
+// Sync from external speed changes
+watch(currentSpeed, (speed) => {
+  localSpeed.value = Math.abs(speed)
+  if (speed < 0) localDirection.value = 'REV'
+  else if (speed > 0) localDirection.value = 'FWD'
+})
+
+function setThrottleSpeed(speed: number) {
+  if (speed < 0 || speed > 126) return
+  localSpeed.value = speed
+  const signedSpeed = localDirection.value === 'REV' ? -speed : speed
+  setSpeed(signedSpeed)
+}
+
+function toggleDirection(val: boolean | null) {
+  if (currentSpeed.value !== 0) return
+  localDirection.value = val ? 'FWD' : 'REV'
+}
+
+const locoColor = computed(() => {
+  const l = unref(loco)
+  const roadname = l?.meta?.roadname
+  if (!roadname) return undefined
+  return ROADNAMES.find(r => r.value === roadname)?.color
+})
+
+const borderStyle = computed(() => {
+  const color = locoColor.value
+  if (!color) return 'border-color: rgba(148, 163, 184, 0.3)'
+  const colorMap: Record<string, string> = {
+    orange: 'rgb(251, 146, 60)', sky: 'rgb(56, 189, 248)',
+    yellow: 'rgb(250, 204, 21)', red: 'rgb(248, 113, 113)',
+    indigo: 'rgb(129, 140, 248)', blue: 'rgb(96, 165, 250)',
+    green: 'rgb(74, 222, 128)', lime: 'rgb(163, 230, 53)',
+    purple: 'rgb(192, 132, 252)', emerald: 'rgb(52, 211, 153)',
+    cyan: 'rgb(34, 211, 238)', amber: 'rgb(251, 191, 36)',
+    pink: 'rgb(244, 114, 182)', teal: 'rgb(45, 212, 191)',
+    rose: 'rgb(251, 113, 133)', violet: 'rgb(167, 139, 250)',
+  }
+  return `border-color: ${colorMap[color] || 'rgba(148, 163, 184, 0.3)'}`
+})
+
+function openThrottle() {
+  $router.push({ name: 'throttle', params: { address: props.address } })
+}
+
+function handleEject() {
+  handleStop()
+  releaseThrottle()
+}
+</script>
+
+<template>
+  <main v-if="throttle" class="dashboard-tile rounded-xl shadow-lg relative" :style="borderStyle">
+    <!-- 🖥️ LCD-style top bar: direction + speed + name + nameplate -->
+    <div class="lcd-bar">
+      <div class="lcd-bar__left">
+        <span class="lcd-bar__dir" :class="localDirection === 'FWD' ? 'text-green-400' : 'text-red-400'">
+          {{ localDirection }}
+        </span>
+        <span class="lcd-bar__speed">{{ localSpeed }}</span>
+      </div>
+      <span class="lcd-bar__name">{{ loco?.name || throttle.address }}</span>
+      <div class="lcd-bar__right">
+        <v-btn icon size="x-small" variant="text" color="red-lighten-1" @click="handleEject" title="Eject loco">
+          <v-icon size="14">mdi-eject</v-icon>
+        </v-btn>
+        <component
+          v-if="loco"
+          :is="loco.consist?.length ? 'v-badge' : 'div'"
+          :color="loco.consist?.length ? 'primary' : undefined"
+          :content="loco.consist?.length"
+          class="cursor-pointer"
+          @click="openThrottle"
+        >
+          <LocoNumberPlate :address="loco.address" :color="locoColor" size="sm" />
+        </component>
+      </div>
+    </div>
+
+    <!-- 🎚️ Throttle slider (0–126) -->
+    <div class="slider-row">
+      <input
+        type="range"
+        min="0"
+        max="126"
+        step="1"
+        :value="localSpeed"
+        @input="(e) => setThrottleSpeed(Number((e.target as HTMLInputElement).value))"
+        class="tile-throttle-range"
+      />
+    </div>
+
+    <!-- ⏹️ Stop + Reverser row -->
+    <div class="controls-row">
+      <v-btn size="x-small" color="red" variant="tonal" @click="handleStop" class="rounded-lg">
+        <v-icon size="14">mdi-stop</v-icon>
+      </v-btn>
+      <div class="flex items-center gap-1">
+        <span class="text-[10px] font-bold" :class="localDirection === 'REV' ? 'text-red-400' : 'opacity-40'">R</span>
+        <v-switch
+          :model-value="localDirection === 'FWD'"
+          @update:model-value="toggleDirection"
+          :disabled="currentSpeed !== 0"
+          color="purple"
+          hide-details
+          density="compact"
+          inset
+          class="tile-lever-switch"
+        />
+        <span class="text-[10px] font-bold" :class="localDirection === 'FWD' ? 'text-green-400' : 'opacity-40'">F</span>
+      </div>
+    </div>
+  </main>
+
+  <main v-else>
+    <div class="flex items-center justify-center h-full">
+      <p class="opacity-50">Loading...</p>
+    </div>
+  </main>
+</template>
+
+<style scoped>
+.dashboard-tile {
+  border: 2px solid #3a506e;
+  background: linear-gradient(180deg, #2e4268 0%, #263752 40%, #1e2d45 100%);
+  border-radius: 16px;
+  padding: 6px;
+  box-shadow:
+    0 4px 16px rgba(0, 0, 0, 0.4),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+/* 🖥️ LCD bar: top row */
+.lcd-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 4px;
+  padding: 2px 4px;
+  background: rgba(0, 0, 0, 0.3);
+  border-radius: 6px;
+  margin-bottom: 2px;
+}
+
+.lcd-bar__left {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+  min-width: 0;
+}
+
+.lcd-bar__dir {
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.5px;
+  font-family: 'Courier New', monospace;
+}
+
+.lcd-bar__speed {
+  font-size: 18px;
+  font-weight: 900;
+  font-variant-numeric: tabular-nums;
+  color: #e9d5ff;
+  text-shadow: 0 0 6px rgba(168, 85, 247, 0.4);
+  font-family: 'Courier New', monospace;
+  line-height: 1;
+}
+
+.lcd-bar__name {
+  flex: 1;
+  text-align: center;
+  font-size: 11px;
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.8);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.lcd-bar__right {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+/* 🎚️ Slider row */
+.slider-row {
+  padding: 2px 6px;
+}
+
+.tile-throttle-range {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 16px;
+  background: linear-gradient(180deg, #111827 0%, #1a202c 100%);
+  border-radius: 8px;
+  border: 1px solid #374151;
+  box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.4);
+  outline: none;
+  cursor: pointer;
+}
+
+.tile-throttle-range::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: linear-gradient(180deg, #6b7280 0%, #4b5563 40%, #374151 100%);
+  border: 2px solid #9ca3af;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
+  cursor: grab;
+}
+
+.tile-throttle-range::-moz-range-thumb {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: linear-gradient(180deg, #6b7280 0%, #4b5563 40%, #374151 100%);
+  border: 2px solid #9ca3af;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
+  cursor: grab;
+}
+
+/* ⏹️ Controls row */
+.controls-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 6px 2px;
+}
+
+/* 🔀 Mini lever switch */
+.tile-lever-switch :deep(.v-switch__track) {
+  height: 18px;
+  border-radius: 9px;
+  opacity: 1;
+  background: linear-gradient(180deg, #1e293b 0%, #334155 100%);
+  border: 1px solid #475569;
+}
+.tile-lever-switch :deep(.v-switch__thumb) {
+  width: 16px;
+  height: 16px;
+  background: linear-gradient(180deg, #94a3b8 0%, #64748b 100%);
+  border: 1px solid #cbd5e1;
+}
+</style>

--- a/apps/throttle/src/throttle/QuickAddLoco.vue
+++ b/apps/throttle/src/throttle/QuickAddLoco.vue
@@ -1,0 +1,114 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+
+const emit = defineEmits<{
+  add: [address: number]
+}>()
+
+const address = ref('')
+
+const parsedAddress = computed<number | null>(() => {
+  if (!address.value) return null
+  const trimmed = address.value.trim()
+  if (!/^\d+$/.test(trimmed)) return null
+  const n = Number(trimmed)
+  if (!Number.isInteger(n) || n < 1 || n > 9999) return null
+  return n
+})
+
+function submit() {
+  const addr = parsedAddress.value
+  if (addr === null) return
+  emit('add', addr)
+  address.value = ''
+}
+</script>
+
+<template>
+  <form class="quick-add" @submit.prevent="submit">
+    <div class="quick-add__field">
+      <label class="quick-add__label">DCC Address</label>
+      <input
+        v-model="address"
+        type="text"
+        inputmode="numeric"
+        pattern="[0-9]*"
+        placeholder="e.g. 3"
+        class="quick-add__input quick-add__input--mono"
+        @keyup.enter="submit"
+      />
+    </div>
+    <v-btn
+      icon
+      size="small"
+      color="green"
+      variant="tonal"
+      :disabled="!parsedAddress"
+      @click="submit"
+    >
+      <v-icon size="18">mdi-plus</v-icon>
+    </v-btn>
+  </form>
+</template>
+
+<style scoped>
+.quick-add {
+  display: flex;
+  align-items: stretch;
+  gap: 8px;
+}
+
+.quick-add__field {
+  display: flex;
+  flex-direction: column;
+  padding: 4px 12px 4px;
+  background: rgba(2, 6, 23, 0.8);
+  border: 1.5px solid rgba(148, 163, 184, 0.2);
+  border-radius: 10px;
+  min-width: 0;
+  width: 110px;
+  transition: border-color 200ms ease, box-shadow 200ms ease;
+}
+
+.quick-add__field:focus-within {
+  border-color: rgba(74, 222, 128, 0.5);
+  box-shadow: 0 0 0 3px rgba(74, 222, 128, 0.1);
+}
+
+.quick-add__label {
+  font-size: 0.6rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(148, 163, 184, 0.5);
+  line-height: 1;
+}
+
+.quick-add__input {
+  display: block;
+  width: 100%;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: #e0f2fe;
+  font-size: 0.95rem;
+  line-height: 1.4;
+  padding: 0;
+}
+
+.quick-add__input::placeholder {
+  color: rgba(148, 163, 184, 0.3);
+}
+
+.quick-add__input--mono {
+  font-family: 'DM Mono', 'Courier New', monospace;
+  color: rgba(74, 222, 128, 0.8);
+}
+
+/* Hide number spinners */
+.quick-add__input::-webkit-outer-spin-button,
+.quick-add__input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+</style>

--- a/apps/throttle/src/throttle/SliderThrottle.vue
+++ b/apps/throttle/src/throttle/SliderThrottle.vue
@@ -153,19 +153,19 @@ async function clearLoco() {
       </section>
     </section>
 
-    <!-- 📱 Mobile: speedometer top, then 2-column below -->
-    <section class="w-full flex @[640px]:hidden flex-col flex-grow relative z-10 gap-1">
-      <!-- 🎛️ Speedometer at top -->
-      <div v-if="showSpeedometer" class="flex justify-center py-2 mx-2 rounded-lg border border-white/10 bg-white/[0.03]">
-        <Speedometer v-if="speedDisplayType === 'dial'" :speed="currentSpeed" :address="address" :size="140" :show-label="false" />
+    <!-- 📱 Mobile: speedometer + consist top, then 2-column below -->
+    <section class="w-full flex @[640px]:hidden flex-col flex-1 min-h-0 relative z-10 gap-1">
+      <!-- 🎛️ Speedometer + Consist at top -->
+      <div v-if="showSpeedometer" class="flex flex-col items-center gap-1 py-2 mx-2 rounded-lg border border-white/10 bg-white/[0.03]">
+        <Speedometer v-if="speedDisplayType === 'dial'" :speed="currentSpeed" :address="address" :size="180" :show-label="false" />
         <CurrentSpeed v-else :speed="currentSpeed" />
+        <ConsistIndicator v-if="showConsist && loco" :loco="loco" />
       </div>
 
       <!-- 📱 Two columns -->
-      <div class="flex flex-row flex-grow min-h-0 gap-1 mx-2">
-        <!-- Left col: EZ Consist + Functions -->
+      <div class="flex flex-row flex-1 min-h-0 gap-1 mx-2">
+        <!-- Left col: Functions -->
         <section class="flex flex-col items-center justify-around flex-1 rounded-lg border border-white/10 bg-white/[0.03] py-2">
-          <ConsistIndicator v-if="showConsist && loco" :loco="loco" />
           <FunctionsSpeedDial v-if="loco && showFunctions" :loco="loco" />
         </section>
 

--- a/apps/throttle/src/throttle/ThrottleActionMenu.vue
+++ b/apps/throttle/src/throttle/ThrottleActionMenu.vue
@@ -5,7 +5,7 @@ defineEmits(['consist', 'functions', 'park'])
   <v-btn-group color="light-blue">
     <v-btn 
       @click="$emit('park')"
-      icon="mdi-parking"
+      icon="mdi-eject"
       variant="tonal"
     />
   </v-btn-group>

--- a/apps/throttle/src/throttle/ThrottleButtonControls.vue
+++ b/apps/throttle/src/throttle/ThrottleButtonControls.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { ref } from 'vue'
+  import { ref, computed } from 'vue'
   import { useHaptics } from '@repo/ui'
 
   const props = defineProps({
@@ -8,6 +8,10 @@
       default: false
     },
     horizontal: {
+      type: Boolean,
+      default: false
+    },
+    compact: {
       type: Boolean,
       default: false
     }
@@ -61,8 +65,9 @@
     const isActive = pressedButton.value === buttonId
     return [
       'btn btn-accent relative h-auto mx-auto',
-      '@[960px]:w-24 p-3 @[400px]:p-3 @[640px]:p-4 @[1024px]:py-3 @[1024px]:px-8',
-      'min-h-[48px] min-w-[48px]',
+      props.compact
+        ? 'p-1 min-h-[32px] min-w-[32px]'
+        : '@[960px]:w-24 p-3 @[400px]:p-3 @[640px]:p-4 @[1024px]:py-3 @[1024px]:px-8 min-h-[48px] min-w-[48px]',
       'transition-all duration-deja-fast ease-deja-standard',
       'select-none',
       isActive
@@ -75,7 +80,9 @@
   function getStopBtnClasses() {
     const isActive = pressedButton.value === 'stop'
     return [
-      'rounded-3xl min-w-[48px] min-h-[48px] @[960px]:py-4 @[960px]:min-w-16',
+      props.compact
+        ? 'rounded-2xl min-w-[36px] min-h-[40px]'
+        : 'rounded-3xl min-w-[48px] min-h-[48px] @[960px]:py-4 @[960px]:min-w-16',
       'h-auto mx-auto relative z-10',
       'transition-all duration-deja-fast ease-deja-standard',
       'select-none',
@@ -85,12 +92,19 @@
     ].join(' ')
   }
 
-  const iconClasses = 'h-5 w-10 @[400px]:h-6 @[400px]:w-6 @[960px]:h-8 @[960px]:w-14 relative'
+  const iconClasses = computed(() =>
+    props.compact
+      ? 'h-3 w-6 relative'
+      : 'h-5 w-10 @[400px]:h-6 @[400px]:w-6 @[960px]:h-8 @[960px]:w-14 relative'
+  )
 
 </script>
 <template>
-  <div class="p-2 @[400px]:py-2 @[400px]:px-4 @[640px]:py-2 @[640px]:px-12 flex justify-stretch items-center flex-grow relative z-20"
-    :class="`${horizontal ? 'flex-row px-1' : 'flex-col '}`">
+  <div class="flex justify-stretch items-center flex-grow relative z-20"
+    :class="[
+      horizontal ? 'flex-row px-1' : 'flex-col',
+      compact ? 'p-0' : 'p-2 @[400px]:py-2 @[400px]:px-4 @[640px]:py-2 @[640px]:px-12'
+    ]">
     <v-btn
       class="flex-grow"
       :class="`${getBtnClasses('up5')} ${horizontal ? 'rounded-r-none rounded-l-3xl py-3' : 'rounded-b-none rounded-t-3xl'}`"
@@ -122,7 +136,7 @@
       />
     </v-btn>
     <v-btn
-      :class="`${getStopBtnClasses()} ${horizontal ? '@[960px]:h-36 rounded-none py-3 px-4' : 'w-28 py-6 @[960px]:w-36 rounded-3xl'}`"
+      :class="`${getStopBtnClasses()} ${compact ? (horizontal ? 'rounded-none py-1 px-2' : 'w-16 py-2 rounded-2xl') : (horizontal ? '@[960px]:h-36 rounded-none py-3 px-4' : 'w-28 py-6 @[960px]:w-36 rounded-3xl')}`"
       color="red"
       @click="handleStop"
       @pointerdown="(e: PointerEvent) => handlePointerDown(e, 'stop')"

--- a/apps/throttle/src/throttle/ThrottleList.vue
+++ b/apps/throttle/src/throttle/ThrottleList.vue
@@ -14,6 +14,8 @@ const locos = getLocos()
 const throttles = getThrottles()
 
 const isRosterOpen = ref(false)
+const isAddressMode = ref(false)
+const quickAddress = ref('')
 
 const throttleOrder = useStorage<number[]>('@DEJA/throttles/order', [])
 
@@ -24,15 +26,11 @@ const orderedThrottles = computed<Throttle[]>({
     const byOrder = [...list].sort((a, b) => {
       const indexA = order.indexOf(a.address)
       const indexB = order.indexOf(b.address)
-
-      if (indexA === -1 && indexB === -1) {
-        return a.address - b.address
-      }
+      if (indexA === -1 && indexB === -1) return a.address - b.address
       if (indexA === -1) return 1
       if (indexB === -1) return -1
       return indexA - indexB
     })
-
     return byOrder
   },
   set: (newOrder) => {
@@ -45,14 +43,9 @@ watch(
   (newThrottles) => {
     const items = (newThrottles || []) as unknown as Throttle[]
     const addresses = items.map((item) => item.address)
-    const filteredOrder = throttleOrder.value.filter((address) =>
-      addresses.includes(address)
-    )
-    const missingAddresses = addresses.filter(
-      (address) => !filteredOrder.includes(address)
-    )
+    const filteredOrder = throttleOrder.value.filter((address) => addresses.includes(address))
+    const missingAddresses = addresses.filter((address) => !filteredOrder.includes(address))
     const updatedOrder = [...filteredOrder, ...missingAddresses]
-
     if (
       updatedOrder.length !== throttleOrder.value.length ||
       updatedOrder.some((address, index) => address !== throttleOrder.value[index])
@@ -63,6 +56,13 @@ watch(
   { immediate: true }
 )
 
+async function handleAddByAddress() {
+  const addr = parseInt(quickAddress.value.trim())
+  if (!addr || isNaN(addr) || addr < 1) return
+  await acquireThrottle(addr)
+  quickAddress.value = ''
+  isAddressMode.value = false
+}
 </script>
 
 <template>
@@ -79,34 +79,78 @@ watch(
       class="throttle-list-grid"
       :animation="150"
     >
+      <template #header>
+        <!-- 🚂 Add Throttle card — first item in the list -->
+        <div class="basis-full @[600px]:basis-1/2 p-1">
+          <div class="add-card">
+            <div class="add-card__accent" />
+            <div class="add-card__body">
+              <span class="add-card__title">Add Throttle</span>
+
+              <!-- Default: two action buttons -->
+              <div v-if="!isAddressMode" class="add-card__actions">
+                <button class="add-card__btn" @click="isAddressMode = true">
+                  <v-icon size="16" class="mr-1">mdi-pound</v-icon>
+                  By Address
+                </button>
+                <button class="add-card__btn" @click="isRosterOpen = true">
+                  <v-icon size="16" class="mr-1">mdi-train</v-icon>
+                  From Roster
+                </button>
+              </div>
+
+              <!-- Address entry mode -->
+              <form v-else class="add-card__form" @submit.prevent="handleAddByAddress">
+                <input
+                  v-model="quickAddress"
+                  type="text"
+                  inputmode="numeric"
+                  pattern="[0-9]*"
+                  placeholder="DCC #"
+                  class="add-card__input"
+                  autofocus
+                />
+                <v-btn size="small" color="green" variant="tonal" :disabled="!quickAddress.trim()" @click="handleAddByAddress">
+                  <v-icon size="16">mdi-plus</v-icon>
+                </v-btn>
+                <v-btn size="small" variant="text" @click="isAddressMode = false; quickAddress = ''">
+                  <v-icon size="16">mdi-close</v-icon>
+                </v-btn>
+              </form>
+            </div>
+          </div>
+        </div>
+      </template>
       <template #item="{ element }">
         <div class="basis-full @[600px]:basis-1/2 p-1">
           <ThrottleTile v-if="element.address" :address="element.address" />
         </div>
       </template>
     </draggable>
-    <v-fab icon="mdi-plus" color="primary" size="56" @click="isRosterOpen = true"  app />
   </div>
-  <v-dialog v-model="isRosterOpen" max-width="800px">
-    <template v-slot:default>
-      <v-sheet class="p-4">
-        <v-row v-auto-animate class="flex justify-center">
-          <v-col cols="auto"
-            v-for="loco in locos"
-            :key="loco.address" 
-            >
-            <div class="m-2 cursor-pointer" @click="async () => { await acquireThrottle(loco.address); isRosterOpen = false }">
-              <LocoNumberPlate
-                :address="loco.address"
-                :color="loco.meta?.roadname ? ROADNAMES.find(r => r.value === loco.meta?.roadname)?.color : undefined"
-                size="sm"
-              />
-            </div>
-          </v-col>
-        </v-row>
-      </v-sheet>
-    </template>    
-  </v-dialog>
+
+  <!-- 🎸 Roster drawer -->
+  <v-navigation-drawer v-model="isRosterOpen" temporary location="right" width="320">
+    <div class="pa-4">
+      <div class="flex items-center justify-between mb-4">
+        <h3 class="text-lg font-bold text-amber-400">🚂 Roster</h3>
+        <v-btn icon size="small" variant="text" @click="isRosterOpen = false">
+          <v-icon>mdi-close</v-icon>
+        </v-btn>
+      </div>
+      <v-row v-auto-animate class="flex justify-center">
+        <v-col cols="auto" v-for="loco in locos" :key="loco.address">
+          <div class="m-1 cursor-pointer" @click="async () => { await acquireThrottle(loco.address); isRosterOpen = false }">
+            <LocoNumberPlate
+              :address="loco.address"
+              :color="loco.meta?.roadname ? ROADNAMES.find(r => r.value === loco.meta?.roadname)?.color : undefined"
+              size="sm"
+            />
+          </div>
+        </v-col>
+      </v-row>
+    </div>
+  </v-navigation-drawer>
 </template>
 
 <style scoped>
@@ -116,7 +160,6 @@ watch(
   display: flex;
   flex-direction: column;
   overflow-y: auto;
-  padding-bottom: 4rem;
 }
 
 .throttle-list-grid {
@@ -126,5 +169,101 @@ watch(
   align-items: flex-end;
   width: 100%;
   margin-top: auto;
+}
+
+/* 🚂 Add Throttle card */
+.add-card {
+  display: flex;
+  border-radius: 12px;
+  overflow: hidden;
+  background: rgba(var(--v-theme-surface), 0.5);
+  box-shadow:
+    0 2px 8px rgba(0, 0, 0, 0.3),
+    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  border: 1px dashed rgba(148, 163, 184, 0.25);
+}
+
+.add-card__accent {
+  width: 4px;
+  flex-shrink: 0;
+  background: rgba(74, 222, 128, 0.5);
+}
+
+.add-card__body {
+  flex: 1;
+  padding: 8px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.add-card__title {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(148, 163, 184, 0.6);
+}
+
+.add-card__actions {
+  display: flex;
+  gap: 6px;
+}
+
+.add-card__btn {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  background: rgba(var(--v-theme-surface), 0.4);
+  color: rgba(226, 232, 240, 0.8);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 150ms ease, border-color 150ms ease;
+}
+
+.add-card__btn:hover {
+  background: rgba(var(--v-theme-surface), 0.7);
+  border-color: rgba(148, 163, 184, 0.3);
+}
+
+.add-card__form {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.add-card__input {
+  flex: 1;
+  background: rgba(2, 6, 23, 0.8);
+  border: 1.5px solid rgba(148, 163, 184, 0.2);
+  border-radius: 8px;
+  padding: 6px 10px;
+  color: rgba(74, 222, 128, 0.8);
+  font-family: 'DM Mono', 'Courier New', monospace;
+  font-size: 14px;
+  outline: none;
+  min-width: 0;
+}
+
+.add-card__input:focus {
+  border-color: rgba(74, 222, 128, 0.5);
+  box-shadow: 0 0 0 3px rgba(74, 222, 128, 0.1);
+}
+
+.add-card__input::placeholder {
+  color: rgba(148, 163, 184, 0.3);
+}
+
+/* Hide number spinners */
+.add-card__input::-webkit-outer-spin-button,
+.add-card__input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
 }
 </style>

--- a/apps/throttle/src/throttle/ThrottleNavItem.vue
+++ b/apps/throttle/src/throttle/ThrottleNavItem.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { toRef } from 'vue'
+import { toRef, unref } from 'vue'
 import { useThrottle } from './useThrottle'
 import { useLocos } from '@repo/modules/locos'
 
@@ -15,7 +15,10 @@ const addressRef = toRef(props, 'address')
 const { loco, currentSpeed } = useThrottle(addressRef)
 const { getRoadname } = useLocos()
 
-const locoColor = () => loco?.meta?.color || getRoadname(loco?.meta?.roadname || '')?.color || 'green'
+const locoColor = () => {
+  const l = unref(loco)
+  return l?.meta?.color || getRoadname(l?.meta?.roadname || '')?.color || 'green'
+}
 </script>
 
 <template>

--- a/apps/throttle/src/throttle/ThrottleTile.vue
+++ b/apps/throttle/src/throttle/ThrottleTile.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { computed, toRef } from 'vue'
+import { computed, ref, toRef, unref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import ThrottleButtonControls from './ThrottleButtonControls.vue'
 import CurrentSpeed from './CurrentSpeed.vue'
-import RoadnameLogo from '@/throttle/RoadnameLogo.vue'
 import { LocoNumberPlate } from '@repo/ui'
+import { ROADNAMES } from '@repo/modules'
 import { useThrottle } from './useThrottle'
+import { useThrottleSettings } from './useThrottleSettings'
 
 const props = defineProps({
   address: {
@@ -19,59 +20,243 @@ const addressRef = toRef(props, 'address')
 const {
   adjustSpeed: handleAdjustSpeed,
   currentSpeed,
+  setSpeed,
   loco,
+  releaseThrottle,
   stop: handleStop,
   throttle,
 } = useThrottle(addressRef)
 
-const plateColor = computed(() => loco?.meta?.color || undefined)
+const { variant } = useThrottleSettings()
+
+// 🎚️ Slider/Dashboard local state
+const localSpeed = ref(Math.abs(currentSpeed.value))
+const localDirection = ref<'FWD' | 'REV'>(currentSpeed.value >= 0 ? 'FWD' : 'REV')
+
+watch(currentSpeed, (speed) => {
+  localSpeed.value = Math.abs(speed)
+  if (speed < 0) localDirection.value = 'REV'
+  else if (speed > 0) localDirection.value = 'FWD'
+})
+
+function setThrottleSpeed(speed: number) {
+  if (speed < 0 || speed > 126) return
+  localSpeed.value = speed
+  const signed = localDirection.value === 'REV' ? -speed : speed
+  setSpeed(signed)
+}
+
+function toggleDirection(val: boolean | null) {
+  if (currentSpeed.value !== 0) return
+  localDirection.value = val ? 'FWD' : 'REV'
+}
+
+const locoColor = computed(() => {
+  const l = unref(loco)
+  const roadname = l?.meta?.roadname
+  if (!roadname) return undefined
+  return ROADNAMES.find(r => r.value === roadname)?.color
+})
+
+const COLOR_MAP: Record<string, string> = {
+  orange: 'rgb(251, 146, 60)', sky: 'rgb(56, 189, 248)',
+  yellow: 'rgb(250, 204, 21)', red: 'rgb(248, 113, 113)',
+  indigo: 'rgb(129, 140, 248)', blue: 'rgb(96, 165, 250)',
+  green: 'rgb(74, 222, 128)', lime: 'rgb(163, 230, 53)',
+  purple: 'rgb(192, 132, 252)', emerald: 'rgb(52, 211, 153)',
+  cyan: 'rgb(34, 211, 238)', amber: 'rgb(251, 191, 36)',
+  pink: 'rgb(244, 114, 182)', teal: 'rgb(45, 212, 191)',
+  rose: 'rgb(251, 113, 133)', violet: 'rgb(167, 139, 250)',
+}
+
+const accentColor = computed(() =>
+  COLOR_MAP[locoColor.value ?? ''] ?? 'rgba(168, 85, 247, 0.5)'
+)
 
 function openThrottle() {
   $router.push({ name: 'throttle', params: { address: props.address } })
 }
+
+function handleEject() {
+  handleStop()
+  releaseThrottle()
+}
 </script>
+
 <template>
-  <main v-if="throttle" class="rounded-2xl shadow-xl relative bg-gradient-to-br from-violet-800 to-cyan-500 bg-gradient-border ">
-    <section class="p-1 flex flex-row flex-wrap items-center justify-between overflow-auto">
-      <div class="order-1 basis-1/3 pl-2" >
-        <CurrentSpeed
-          class="!justify-start drag-handle cursor-grab active:cursor-grabbing select-none"
-          :speed="currentSpeed"
-        />
+  <div v-if="throttle" @dblclick="openThrottle">
+
+    <!-- ═══════════════════════════════════════════════════════
+         🔘 BUTTONS variant
+         ═══════════════════════════════════════════════════════ -->
+    <div v-if="variant === 'buttons'" class="tile">
+      <div class="tile__accent" :style="{ background: accentColor }" />
+      <div class="tile__body">
+        <div class="tile__info">
+          <CurrentSpeed compact class="drag-handle cursor-grab active:cursor-grabbing select-none shrink-0" :speed="currentSpeed" />
+          <span class="tile__name">{{ loco?.name || address }}</span>
+          <div class="tile__actions">
+            <v-btn icon size="x-small" variant="text" color="red-lighten-1" @click.stop="handleEject" title="Eject"><v-icon size="14">mdi-eject</v-icon></v-btn>
+            <component v-if="loco" :is="loco.consist?.length ? 'v-badge' : 'div'" :color="loco.consist?.length ? 'primary' : undefined" :content="loco.consist?.length" class="cursor-pointer" @click.stop="openThrottle">
+              <LocoNumberPlate :address="loco.address" :color="locoColor" size="sm" />
+            </component>
+          </div>
+        </div>
+        <ThrottleButtonControls horizontal compact @stop="handleStop" @update:currentSpeed="handleAdjustSpeed" />
       </div>
-      <div class="flex-grow order-4 basis-full my-1">
-        <ThrottleButtonControls
-          horizontal
-          @stop="handleStop" 
-          @update:currentSpeed="handleAdjustSpeed" 
-        />
-      </div>
-      <div class="order-2 basis-1/3 py-2 flex justify-center text-base @[960px]:text-xl gap-2 items-center">
-        <RoadnameLogo :roadname="loco?.meta?.roadname" size="sm" />
-        <span class="bg-clip-text text-transparent bg-gradient-to-r from-violet-500 to-cyan-400 font-bold">{{loco?.name || throttle.address}}</span>
-      </div>
-      <div class="order-2 basis-1/3 pr-2 flex justify-end">
-        <component
-          :is="loco?.consist?.length ? 'v-badge' : 'div'"
-          :color="loco?.consist?.length ? 'primary' : undefined"
-          :content="loco?.consist?.length"
-          class="cursor-pointer"
-          @click="openThrottle"
-        >
-          <LocoNumberPlate
-            :address="loco?.address ?? props.address"
-            :color="plateColor"
-            size="sm"
-          />
-        </component>
-      </div>
-    </section>
-  </main>
-  <main v-else>
-    <div class="flex items-center justify-center h-full">
-      <p class="opacity-50">Loading throttle...</p>
-      {{address}}
-      {{throttle}}
     </div>
-  </main>
+
+    <!-- ═══════════════════════════════════════════════════════
+         🎚️ SLIDER variant
+         ═══════════════════════════════════════════════════════ -->
+    <div v-else-if="variant === 'slider'" class="tile">
+      <div class="tile__accent" :style="{ background: accentColor }" />
+      <div class="tile__body">
+        <div class="tile__info">
+          <CurrentSpeed compact class="drag-handle cursor-grab active:cursor-grabbing select-none shrink-0" :speed="currentSpeed" />
+          <span class="tile__name">{{ loco?.name || address }}</span>
+          <div class="tile__actions">
+            <v-btn icon size="x-small" variant="text" color="red-lighten-1" @click.stop="handleEject" title="Eject"><v-icon size="14">mdi-eject</v-icon></v-btn>
+            <component v-if="loco" :is="loco.consist?.length ? 'v-badge' : 'div'" :color="loco.consist?.length ? 'primary' : undefined" :content="loco.consist?.length" class="cursor-pointer" @click.stop="openThrottle">
+              <LocoNumberPlate :address="loco.address" :color="locoColor" size="sm" />
+            </component>
+          </div>
+        </div>
+        <div class="tile-slider">
+          <v-btn size="x-small" color="red" variant="tonal" class="shrink-0" @click.stop="handleStop"><v-icon size="14">mdi-stop</v-icon></v-btn>
+          <input type="range" min="0" max="126" step="1" :value="localSpeed" @input="(e) => setThrottleSpeed(Number((e.target as HTMLInputElement).value))" class="tile-slider__range" />
+          <div class="tile-slider__rev">
+            <span class="text-[9px] font-bold" :class="localDirection === 'REV' ? 'text-red-400' : 'opacity-30'">R</span>
+            <v-switch :model-value="localDirection === 'FWD'" @update:model-value="toggleDirection" :disabled="currentSpeed !== 0" color="purple" hide-details density="compact" inset class="tile-lever-switch" />
+            <span class="text-[9px] font-bold" :class="localDirection === 'FWD' ? 'text-green-400' : 'opacity-30'">F</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ═══════════════════════════════════════════════════════
+         🎛️ DASHBOARD variant — mini proto-device
+         ═══════════════════════════════════════════════════════ -->
+    <div v-else class="proto-tile">
+      <!-- Info bar -->
+      <div class="proto-tile__info">
+        <div class="proto-tile__lcd">
+          <span class="proto-tile__dir" :class="localDirection === 'FWD' ? 'text-green-400' : 'text-red-400'">{{ localDirection }}</span>
+          <span class="proto-tile__speed">{{ localSpeed }}</span>
+        </div>
+        <span class="proto-tile__name">{{ loco?.name || address }}</span>
+        <div class="tile__actions">
+          <v-btn icon size="x-small" variant="text" color="red-lighten-1" @click.stop="handleEject" title="Eject"><v-icon size="14">mdi-eject</v-icon></v-btn>
+          <component v-if="loco" :is="loco.consist?.length ? 'v-badge' : 'div'" :color="loco.consist?.length ? 'primary' : undefined" :content="loco.consist?.length" class="cursor-pointer" @click.stop="openThrottle">
+            <LocoNumberPlate :address="loco.address" :color="locoColor" size="sm" />
+          </component>
+        </div>
+      </div>
+      <!-- Slider -->
+      <div class="proto-tile__slider-row">
+        <v-btn size="x-small" color="red" variant="tonal" class="shrink-0 rounded-lg" @click.stop="handleStop"><v-icon size="14">mdi-stop</v-icon></v-btn>
+        <input type="range" min="0" max="126" step="1" :value="localSpeed" @input="(e) => setThrottleSpeed(Number((e.target as HTMLInputElement).value))" class="proto-tile__range" />
+      </div>
+      <!-- Reverser -->
+      <div class="proto-tile__rev-row">
+        <span class="text-[9px] font-bold" :class="localDirection === 'REV' ? 'text-red-400' : 'opacity-30'">REV</span>
+        <v-switch :model-value="localDirection === 'FWD'" @update:model-value="toggleDirection" :disabled="currentSpeed !== 0" color="purple" hide-details density="compact" inset class="tile-lever-switch" />
+        <span class="text-[9px] font-bold" :class="localDirection === 'FWD' ? 'text-green-400' : 'opacity-30'">FWD</span>
+      </div>
+    </div>
+  </div>
+
+  <div v-else class="tile tile--loading">
+    <p class="opacity-50 text-sm text-center py-4">Loading…</p>
+  </div>
 </template>
+
+<style scoped>
+/* ── Standard tile shell (buttons + slider) ──────────── */
+.tile {
+  display: flex;
+  border-radius: 12px;
+  overflow: hidden;
+  background: rgba(var(--v-theme-surface), 0.5);
+  box-shadow: 0 2px 8px rgba(0,0,0,0.3), inset 0 1px 0 rgba(255,255,255,0.04);
+}
+.tile__accent { width: 4px; flex-shrink: 0; }
+.tile__body { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; padding: 6px 6px 4px; }
+.tile__info { display: flex; align-items: center; gap: 6px; }
+.tile__name { flex: 1; min-width: 0; font-size: 12px; font-weight: 600; color: rgba(226,232,240,0.85); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; text-align: center; }
+.tile__actions { display: flex; align-items: center; gap: 2px; flex-shrink: 0; }
+.tile--loading { justify-content: center; align-items: center; min-height: 60px; }
+
+/* ── Slider variant controls ─────────────────────────── */
+.tile-slider { display: flex; align-items: center; gap: 4px; padding: 2px 0; }
+.tile-slider__range {
+  -webkit-appearance: none; appearance: none; flex: 1; height: 14px;
+  background: linear-gradient(180deg, #111827, #1a202c); border-radius: 7px;
+  border: 1px solid #374151; box-shadow: inset 0 1px 3px rgba(0,0,0,0.4); outline: none; cursor: pointer;
+}
+.tile-slider__range::-webkit-slider-thumb {
+  -webkit-appearance: none; width: 20px; height: 20px; border-radius: 50%;
+  background: linear-gradient(180deg, #6b7280, #4b5563 40%, #374151); border: 2px solid #9ca3af;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.4); cursor: grab;
+}
+.tile-slider__range::-moz-range-thumb {
+  width: 20px; height: 20px; border-radius: 50%;
+  background: linear-gradient(180deg, #6b7280, #4b5563 40%, #374151); border: 2px solid #9ca3af; cursor: grab;
+}
+.tile-slider__rev { display: flex; align-items: center; gap: 1px; flex-shrink: 0; }
+
+/* ── Dashboard variant — mini proto-device ───────────── */
+.proto-tile {
+  border-radius: 16px;
+  background: linear-gradient(180deg, #2e4268 0%, #263752 40%, #1e2d45 100%);
+  border: 2px solid #3a506e;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.06);
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.proto-tile__info { display: flex; align-items: center; gap: 6px; }
+.proto-tile__lcd {
+  display: flex; align-items: baseline; gap: 3px; flex-shrink: 0;
+  padding: 2px 6px; border-radius: 4px;
+  background: #0a1a0a; border: 1px solid #333;
+  font-family: 'Courier New', monospace;
+}
+.proto-tile__dir { font-size: 8px; font-weight: 800; letter-spacing: 0.5px; }
+.proto-tile__speed {
+  font-size: 16px; font-weight: 900; font-variant-numeric: tabular-nums;
+  color: #4ade80; text-shadow: 0 0 6px rgba(74,222,128,0.4); line-height: 1;
+}
+.proto-tile__name {
+  flex: 1; min-width: 0; font-size: 11px; font-weight: 600;
+  color: rgba(226,232,240,0.7); white-space: nowrap; overflow: hidden;
+  text-overflow: ellipsis; text-align: center;
+}
+.proto-tile__slider-row { display: flex; align-items: center; gap: 4px; }
+.proto-tile__range {
+  -webkit-appearance: none; appearance: none; flex: 1; height: 18px;
+  background: linear-gradient(180deg, #111827, #1a202c); border-radius: 9px;
+  border: 2px solid #374151; box-shadow: inset 0 2px 4px rgba(0,0,0,0.4); outline: none; cursor: pointer;
+}
+.proto-tile__range::-webkit-slider-thumb {
+  -webkit-appearance: none; width: 24px; height: 24px; border-radius: 50%;
+  background: linear-gradient(180deg, #6b7280, #4b5563 40%, #374151); border: 2px solid #9ca3af;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.4); cursor: grab;
+}
+.proto-tile__range::-moz-range-thumb {
+  width: 24px; height: 24px; border-radius: 50%;
+  background: linear-gradient(180deg, #6b7280, #4b5563 40%, #374151); border: 2px solid #9ca3af; cursor: grab;
+}
+.proto-tile__rev-row { display: flex; align-items: center; justify-content: center; gap: 4px; }
+
+/* ── Shared lever switch (mini) ──────────────────────── */
+.tile-lever-switch :deep(.v-switch__track) {
+  height: 16px; border-radius: 8px; opacity: 1;
+  background: linear-gradient(180deg, #1e293b, #334155); border: 1px solid #475569;
+}
+.tile-lever-switch :deep(.v-switch__thumb) {
+  width: 14px; height: 14px;
+  background: linear-gradient(180deg, #94a3b8, #64748b); border: 1px solid #cbd5e1;
+}
+</style>

--- a/apps/throttle/src/throttle/useThrottle.ts
+++ b/apps/throttle/src/throttle/useThrottle.ts
@@ -1,4 +1,4 @@
-import { computed, watch, type Ref } from 'vue'
+import { computed, watch, type Ref, type MaybeRef } from 'vue'
 import { useStorage } from '@vueuse/core'
 import { deleteDoc, doc, setDoc } from 'firebase/firestore'
 import { useDocument } from 'vuefire'
@@ -17,13 +17,12 @@ export const useThrottle = (address: Ref<number | null | undefined>) => {
   const layoutId = useStorage('@DEJA/layoutId', '')
   const { enqueue } = useCommandQueue()
 
-  const throttle = useDocument<Throttle>(
-    computed(() =>
-      address.value != null && !Number.isNaN(address.value)
-        ? doc(db, `layouts/${layoutId.value}/throttles`, address.value.toString())
-        : null
-    )
+  const docRef = computed(() =>
+    address.value
+      ? doc(db, `layouts/${layoutId.value}/throttles`, address.value.toString())
+      : null
   )
+  const throttle = useDocument<Throttle>(docRef)
 
   log.debug('throttle doc ref:', throttle)
 

--- a/apps/throttle/src/throttle/useThrottleSettings.ts
+++ b/apps/throttle/src/throttle/useThrottleSettings.ts
@@ -1,6 +1,6 @@
 import { computed } from 'vue'
 import type { ComputedRef } from 'vue'
-import { useUserPreferences, type ThrottleSettings, type ThrottleVariant, type SpeedDisplayType } from '@repo/modules'
+import { useUserPreferences, type ThrottleSettings, type ThrottleVariant, type TileVariant, type SpeedDisplayType, type ConductorRightPanel } from '@repo/modules'
 
 const DEFAULTS: ThrottleSettings = {
   variant: 'buttons',
@@ -16,13 +16,19 @@ export function useThrottleSettings() {
   const settings: ComputedRef<ThrottleSettings> = getPreference('throttleSettings', DEFAULTS)
 
   const variant = computed(() => settings.value.variant)
+  const tileVariant = computed(() => settings.value.tileVariant ?? 'default')
   const speedDisplayType = computed(() => settings.value.speedDisplayType ?? 'dial')
   const showFunctions = computed(() => settings.value.showFunctions)
   const showSpeedometer = computed(() => settings.value.showSpeedometer)
   const showConsist = computed(() => settings.value.showConsist)
+  const rightPanel = computed(() => settings.value.rightPanel ?? 'turnouts')
 
   async function setVariant(value: ThrottleVariant) {
     await setPreference('throttleSettings', { ...settings.value, variant: value })
+  }
+
+  async function setTileVariant(value: TileVariant) {
+    await setPreference('throttleSettings', { ...settings.value, tileVariant: value })
   }
 
   async function setSpeedDisplayType(value: SpeedDisplayType) {
@@ -41,17 +47,25 @@ export function useThrottleSettings() {
     await setPreference('throttleSettings', { ...settings.value, showConsist: value })
   }
 
+  async function setRightPanel(value: ConductorRightPanel) {
+    await setPreference('throttleSettings', { ...settings.value, rightPanel: value })
+  }
+
   return {
     variant,
+    tileVariant,
     speedDisplayType,
     showFunctions,
     showSpeedometer,
     showConsist,
     setVariant,
+    setTileVariant,
     setSpeedDisplayType,
     setShowFunctions,
     setShowSpeedometer,
     setShowConsist,
+    rightPanel,
+    setRightPanel,
   }
 }
 

--- a/apps/throttle/src/views/RosterView.vue
+++ b/apps/throttle/src/views/RosterView.vue
@@ -3,12 +3,25 @@ import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useLocos, ROADNAMES, type Loco } from '@repo/modules/locos'
 import { LocoRoster, PageHeader, ListControlBar, useListControls } from '@repo/ui'
-import RosterQuickAdd from '@/roster/RosterQuickAdd.vue'
+import QuickAddLoco from '@/throttle/QuickAddLoco.vue'
+import { useStorage } from '@vueuse/core'
+import { doc, setDoc, serverTimestamp } from 'firebase/firestore'
+import { db } from '@repo/firebase-config'
 import type { ListFilter } from '@repo/ui'
 
 const router = useRouter()
 const { getLocos } = useLocos()
 const locos = getLocos()
+const layoutId = useStorage('@DEJA/layoutId', '')
+
+async function handleQuickAddToRoster(address: number) {
+  if (!layoutId.value) return
+  await setDoc(
+    doc(db, `layouts/${layoutId.value}/locos`, String(address)),
+    { address, name: `Loco ${address}`, meta: { roadname: '' }, timestamp: serverTimestamp() },
+    { merge: true },
+  )
+}
 
 const locosList = computed(() =>
   locos.value ? (locos.value as Loco[]).map((l) => ({
@@ -71,7 +84,9 @@ function handleLocoSelect(loco: Loco) {
       </template>
     </PageHeader>
 
-    <RosterQuickAdd class="mx-4 mt-4" />
+    <div class="mx-4 mt-4">
+      <QuickAddLoco @add="handleQuickAddToRoster" />
+    </div>
 
     <LocoRoster
       :locos="rosterControls.filteredList.value"

--- a/apps/throttle/src/views/SettingsView.vue
+++ b/apps/throttle/src/views/SettingsView.vue
@@ -9,8 +9,6 @@ import { BackgroundSettings, ServerSetupInfo } from '@repo/ui'
 import { useThemeSwitcher, type ThemeMode } from '@repo/ui/src/composables/useThemeSwitcher'
 import { useDisplay } from 'vuetify'
 import { useThrottleSettings } from '@/throttle/useThrottleSettings'
-import { useConductorSettings } from '@/conductor/useConductorSettings'
-import { useQuickMenu } from '@/quick-menu/useQuickMenu'
 
 const user = useCurrentUser()
 const { plan, status, isTrialing, trialDaysLeft, subscription } = useSubscription()
@@ -18,18 +16,10 @@ const { themePreference, setTheme } = useThemeSwitcher()
 const { mdAndUp } = useDisplay()
 
 const {
-  variant, speedDisplayType, showFunctions, showSpeedometer, showConsist,
-  setVariant, setSpeedDisplayType, setShowFunctions, setShowSpeedometer, setShowConsist,
+  variant, speedDisplayType, showFunctions, showConsist,
+  rightPanel, setVariant, setSpeedDisplayType, setShowFunctions,
+  setShowConsist, setRightPanel,
 } = useThrottleSettings()
-
-const {
-  variant: conductorVariant,
-  rightPanel: conductorRightPanel,
-  setVariant: setConductorVariant,
-  setRightPanel: setConductorRightPanel,
-} = useConductorSettings()
-
-const { quickMenuVisible } = useQuickMenu()
 
 const planName = computed(() => PLAN_DISPLAY[plan.value].name)
 const planPrice = computed(() => {
@@ -89,8 +79,7 @@ const sections = [
   { id: 'account', label: 'Account', icon: 'mdi-account-circle-outline' },
   { id: 'billing', label: 'Billing', icon: 'mdi-credit-card-outline' },
   { id: 'appearance', label: 'Appearance', icon: 'mdi-palette-outline' },
-  { id: 'throttle', label: 'Throttle & Quick Menu', icon: 'mdi-speedometer' },
-  { id: 'conductor', label: 'Conductor', icon: 'mdi-account-hard-hat' },
+  { id: 'throttle', label: 'Throttle', icon: 'mdi-speedometer' },
   { id: 'server-setup', label: 'Server Setup', icon: 'mdi-download-outline' },
   { id: 'favorites', label: 'Favorites', icon: 'mdi-star-outline' },
   { id: 'backgrounds', label: 'Backgrounds', icon: 'mdi-image-outline' },
@@ -231,15 +220,6 @@ const backgroundPages = [
           </div>
           <div class="settings-row">
             <div class="settings-row__label">
-              <span class="settings-row__name">Speedometer</span>
-              <span class="settings-row__desc">Show speed gauge on desktop, auto-hide on small screens</span>
-            </div>
-            <div class="settings-row__value">
-              <v-switch :model-value="showSpeedometer" @update:model-value="(v) => setShowSpeedometer(!!v)" color="primary" density="compact" hide-details />
-            </div>
-          </div>
-          <div class="settings-row">
-            <div class="settings-row__label">
               <span class="settings-row__name">Speed Display</span>
               <span class="settings-row__desc">Choose between round gauge dial or digital number readout</span>
             </div>
@@ -268,50 +248,11 @@ const backgroundPages = [
           </div>
           <div class="settings-row">
             <div class="settings-row__label">
-              <span class="settings-row__name">Quick Menu</span>
-              <span class="settings-row__desc">Show draggable quick-access menu for throttles and cloud navigation</span>
+              <span class="settings-row__name">Conductor Right Panel</span>
+              <span class="settings-row__desc">Which module to show in the Conductor's right column</span>
             </div>
             <div class="settings-row__value">
-              <v-switch v-model="quickMenuVisible" color="primary" density="compact" hide-details />
-            </div>
-          </div>
-        </div>
-
-        <!-- Conductor -->
-        <div id="conductor" class="settings-section">
-          <div class="settings-section__header">
-            <v-icon size="20" class="settings-section__icon">mdi-account-hard-hat</v-icon>
-            <h2 class="settings-section__title">Conductor</h2>
-          </div>
-          <div class="settings-row">
-            <div class="settings-row__label">
-              <span class="settings-row__name">Throttle Style</span>
-              <span class="settings-row__desc">Throttle control style used inside the Conductor view</span>
-            </div>
-            <div class="settings-row__value">
-              <v-btn-toggle :model-value="conductorVariant" @update:model-value="(v) => setConductorVariant(v)" mandatory divided density="compact" variant="outlined" color="primary">
-                <v-btn value="buttons" size="small" class="text-none">
-                  <v-icon start size="16">mdi-gesture-tap-button</v-icon>
-                  <span class="hidden sm:inline">Buttons</span>
-                </v-btn>
-                <v-btn value="slider" size="small" class="text-none">
-                  <v-icon start size="16">mdi-tune-vertical</v-icon>
-                  <span class="hidden sm:inline">Slider</span>
-                </v-btn>
-                <v-btn value="dashboard" size="small" class="text-none">
-                  <v-icon start size="16">mdi-train</v-icon>
-                  <span class="hidden sm:inline">Dashboard</span>
-                </v-btn>
-              </v-btn-toggle>
-            </div>
-          </div>
-          <div class="settings-row">
-            <div class="settings-row__label">
-              <span class="settings-row__name">Right Panel</span>
-              <span class="settings-row__desc">Which component to load in the Conductor's right column</span>
-            </div>
-            <div class="settings-row__value">
-              <v-btn-toggle :model-value="conductorRightPanel" @update:model-value="(v) => setConductorRightPanel(v)" mandatory divided density="compact" variant="outlined" color="primary">
+              <v-btn-toggle :model-value="rightPanel" @update:model-value="(v) => setRightPanel(v)" mandatory divided density="compact" variant="outlined" color="primary">
                 <v-btn value="turnouts" size="small" class="text-none">
                   <v-icon start size="16">mdi-directions-fork</v-icon>
                   <span class="hidden sm:inline">Turnouts</span>

--- a/apps/throttle/src/views/ThrottleView.vue
+++ b/apps/throttle/src/views/ThrottleView.vue
@@ -1,13 +1,12 @@
-<script async setup lang="ts">
-import { computed, watch } from 'vue'
-import { useStorage } from '@vueuse/core'
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useLocos } from '@repo/modules/locos'
 import ThrottleNavItem from '@/throttle/ThrottleNavItem.vue'
+import ThrottleSwipeContainer from '@/throttle/ThrottleSwipeContainer.vue'
 import ButtonsThrottle from '@/throttle/ButtonsThrottle.vue'
 import SliderThrottle from '@/throttle/SliderThrottle.vue'
 import Dashboard from '@/throttle/Dashboard.vue'
-import ThrottleSwipeContainer from '@/throttle/ThrottleSwipeContainer.vue'
 import { useThrottleSettings } from '@/throttle/useThrottleSettings'
 import SaveToRosterChip from '@/throttle/SaveToRosterChip.vue'
 
@@ -15,15 +14,21 @@ const route = useRoute()
 const router = useRouter()
 const { getThrottles } = useLocos()
 const throttles = getThrottles()
-const lastThrottleAddress = useStorage<number>('@DEJA/lastThrottleAddress', throttles.value[0]?.address || 3)
 
 const routeAddr = computed(() => route.params.address ? parseInt(route.params.address.toString()) : NaN)
+const activeAddress = ref<number | null>(Number.isNaN(routeAddr.value) ? (throttles.value[0]?.address ?? null) : routeAddr.value)
 
-if (!Number.isNaN(routeAddr.value)) {
-  lastThrottleAddress.value = routeAddr.value
-} else if (lastThrottleAddress.value === undefined || Number.isNaN(lastThrottleAddress.value)) {
-  lastThrottleAddress.value = 3
-}
+// Sync route → activeAddress
+watch(routeAddr, (addr) => {
+  if (!Number.isNaN(addr)) activeAddress.value = addr
+})
+
+// Sync activeAddress → route (when swipe changes it)
+watch(activeAddress, (addr) => {
+  if (addr != null && addr !== routeAddr.value) {
+    router.replace({ name: 'throttle', params: { address: addr } })
+  }
+})
 
 const { variant, speedDisplayType, showFunctions, showSpeedometer, showConsist } = useThrottleSettings()
 
@@ -42,18 +47,8 @@ const settingsProps = computed(() => ({
   speedDisplayType: speedDisplayType.value,
 }))
 
-watch(() => route.params.address, (newVal) => {
-  lastThrottleAddress.value = parseInt(newVal?.toString())
-})
-
-function handleSwipeChange(newAddress: number) {
-  lastThrottleAddress.value = newAddress
-  router.replace({ name: 'throttle', params: { address: newAddress } })
-}
-
 function handleSelect(newAddress: number) {
-  lastThrottleAddress.value = newAddress
-  router.push({ name: 'throttle', params: { address: newAddress } })
+  activeAddress.value = newAddress
 }
 </script>
 
@@ -67,16 +62,28 @@ function handleSelect(newAddress: number) {
     <div class="absolute top-2 left-2 z-10">
       <SaveToRosterChip v-if="!Number.isNaN(routeAddr)" :address="routeAddr" />
     </div>
+
+    <!-- 🚂 Swipeable throttle controls -->
     <ThrottleSwipeContainer
-      v-if="throttles?.length"
+      v-if="throttles && throttles.length > 0"
       :throttles="throttles"
-      :model-value="routeAddr"
+      :model-value="activeAddress"
       :variant-component="variantComponent"
       :variant-props="settingsProps"
       class="flex-1 min-h-0"
-      @update:model-value="handleSwipeChange"
+      @update:model-value="activeAddress = $event"
     />
-    <v-slide-group show-arrows selected-class="bg-success">
+
+    <!-- No throttle fallback -->
+    <div v-else class="flex flex-col items-center justify-center flex-1 gap-4">
+      <h2 class="text-2xl font-bold opacity-50">No Throttle Assigned</h2>
+      <v-btn color="pink" variant="outlined" @click="$router.push({ name: 'throttle-list' })">
+        Go to Throttle List
+      </v-btn>
+    </div>
+
+    <!-- 🚂 Nav chips -->
+    <v-slide-group selected-class="bg-success" show-arrows>
       <v-slide-group-item v-for="item in throttles" :key="item.id">
         <ThrottleNavItem v-if="item.address" :address="item.address" @select="handleSelect(item.address)" />
       </v-slide-group-item>

--- a/packages/modules/preferences/types.ts
+++ b/packages/modules/preferences/types.ts
@@ -4,21 +4,19 @@ export interface AppBackgroundPrefs {
 }
 
 export type ThrottleVariant = 'buttons' | 'slider' | 'dashboard'
+export type TileVariant = 'default' | 'dashboard'
 export type SpeedDisplayType = 'dial' | 'digital'
+
+export type ConductorRightPanel = 'turnouts' | 'effects' | 'signals' | 'devices' | 'routes'
 
 export interface ThrottleSettings {
   variant: ThrottleVariant
+  tileVariant?: TileVariant
   speedDisplayType: SpeedDisplayType
   showFunctions: boolean
   showSpeedometer: boolean
   showConsist: boolean
-}
-
-export type ConductorRightPanel = 'turnouts' | 'effects' | 'signals' | 'devices' | 'routes'
-
-export interface ConductorSettings {
-  variant: ThrottleVariant
-  rightPanel: ConductorRightPanel
+  rightPanel?: ConductorRightPanel
 }
 
 export interface UserPreferences {
@@ -26,5 +24,4 @@ export interface UserPreferences {
     [appName: string]: AppBackgroundPrefs
   }
   throttleSettings?: ThrottleSettings
-  conductorSettings?: ConductorSettings
 }

--- a/packages/ui/src/DeviceConnection/DeviceConnectionList.vue
+++ b/packages/ui/src/DeviceConnection/DeviceConnectionList.vue
@@ -6,14 +6,16 @@ import { useDejaJS } from '@repo/deja'
 import DeviceConnectCard from './DeviceConnectCard.vue'
 
 interface Props {
-  devices: Device[]
-  availablePorts: string[]
+  devices?: Device[]
+  availablePorts?: string[]
   showHeader?: boolean
   showDetailsLink?: boolean
   serverOnline?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
+  devices: () => [],
+  availablePorts: () => [],
   showHeader: true,
   showDetailsLink: true,
   serverOnline: false,
@@ -27,7 +29,7 @@ const emit = defineEmits<{
   trackPowerToggle: [deviceId: string, newState: boolean]
 }>()
 
-const { getLayout } = useLayout()
+const { getLayout, getDevices } = useLayout()
 const { getTurnouts } = useTurnouts()
 const { getEffects } = useEfx()
 const { sendDejaCommand } = useDejaJS()
@@ -37,6 +39,14 @@ function handleRefreshPorts() {
 }
 
 const layout = getLayout()
+const layoutDevices = getDevices()
+
+// Use prop devices if provided, otherwise fall back to layout devices
+const resolvedDevices = computed(() =>
+  props.devices.length > 0
+    ? props.devices
+    : (layoutDevices?.value as Device[] ?? [])
+)
 
 // Fetch all turnouts and effects once during setup (proper VueFire composable usage)
 const allTurnouts = getTurnouts()
@@ -45,7 +55,7 @@ const allEffects = getEffects()
 const trackPower = computed(() => layout?.value?.dccEx?.power ?? null)
 
 const sortedDevices = computed(() => {
-  return [...props.devices].sort((a, b) => {
+  return [...resolvedDevices.value].sort((a, b) => {
     // deja-server always first
     if (a.type === 'deja-server') return -1
     if (b.type === 'deja-server') return 1
@@ -145,7 +155,7 @@ function getEffectCount(deviceId: string): number {
 
     <!-- Empty state -->
     <v-card
-      v-if="devices.length === 0"
+      v-if="resolvedDevices.length === 0"
       variant="tonal"
       class="text-center pa-8"
     >

--- a/packages/ui/src/ListControls/ListControlBar.vue
+++ b/packages/ui/src/ListControls/ListControlBar.vue
@@ -108,16 +108,9 @@ const showFilterSheet = ref(false)
     </div>
   </div>
 
-  <!-- Mobile: search bar + icon buttons (shown when container < 640px) -->
+  <!-- Mobile: icon buttons only, no search (shown when container < 640px) -->
   <div class="block @[640px]:hidden px-2 py-2">
     <div class="flex items-center gap-2">
-      <ListSearch
-        v-if="showSearch"
-        :model-value="controls.searchQuery.value"
-        @update:model-value="controls.searchQuery.value = $event"
-        :placeholder="searchPlaceholder"
-        :collapsible="false"
-      />
 
       <v-btn
         v-if="showView && viewOptions.length"

--- a/packages/ui/src/PageHeader/PageHeader.vue
+++ b/packages/ui/src/PageHeader/PageHeader.vue
@@ -50,26 +50,24 @@ const textClass = TEXT_CLASSES[resolvedColor] ?? TEXT_CLASSES.sky
 </script>
 
 <template>
-  <div class="mb-4">
+  <div class="mb-2">
     <!-- Title Row -->
-    <div :class="[gradientClass, 'px-5 pt-6 pb-4']">
-      <div class="flex items-start justify-between">
-        <div>
-          <h1 class="flex items-center tracking-tight" :class="textClass">
-            <v-icon v-if="icon" :class="textClass" class="mr-3" size="28">{{ icon }}</v-icon>
-            <span class="text-3xl font-black uppercase">{{ title }}</span>
-          </h1>
-          <div v-if="subtitle || $slots.subtitle" class="text-sm text-slate-400 mt-2 ml-[42px]">
-            <slot name="subtitle">{{ subtitle }}</slot>
-          </div>
-        </div>
-        <div v-if="$slots.actions" class="flex items-center gap-2 mt-1">
+    <div :class="[gradientClass, 'px-4 py-3']">
+      <div class="flex items-center justify-between">
+        <h1 class="flex items-center tracking-tight" :class="textClass">
+          <v-icon v-if="icon" :class="textClass" class="mr-2" size="24">{{ icon }}</v-icon>
+          <span class="text-2xl font-black uppercase">{{ title }}</span>
+        </h1>
+        <div v-if="$slots.actions" class="flex items-center gap-2">
           <slot name="actions" />
         </div>
       </div>
+      <div v-if="subtitle || $slots.subtitle" class="text-sm text-slate-400 mt-1 ml-[34px]">
+        <slot name="subtitle">{{ subtitle }}</slot>
+      </div>
     </div>
 
-    <!-- Controls Row (styling handled by ListControlBar's .lcb-bar class) -->
+    <!-- Controls Row -->
     <div v-if="hasControls()">
       <slot name="controls" />
     </div>


### PR DESCRIPTION
## Summary

Comprehensive mobile-first UI overhaul across the throttle app, conductor view, and shared components. 29 files changed, 1240 insertions, 535 deletions.

### 🎨 Throttle Tiles & List
- Redesigned `ThrottleTile` with loco-colored accent stripe and 3 variant modes (buttons/slider/dashboard)
- Dashboard tile matches the proto-device visual style (dark blue gradient, LCD speed display)
- New "Add Throttle" card with "By Address" / "From Roster" actions
- Shared `QuickAddLoco` component with onboarding-style input
- Fixed loco color display via `unref()` for ComputedRef script access

### 🚂 Conductor View
- Merged conductor settings into throttle settings (shared variant + rightPanel)
- Right panel items force full-width; CTC switches 2-per-row centered
- Routes header responsive with compact prop
- Uses `ThrottleSwipeContainer` with real user settings

### 🎛️ Dashboard Throttle
- Slider uses `step=1` (0–126) instead of notch stops (0–8)
- Speed buttons in single compact row (-5, -1, +1, +5)
- EZ Consist, functions toggle, stop/eject in device header
- Touch-action fixes for slider on mobile

### 📱 Navigation & Settings
- Bottom nav active state bug fix (reactive `computed` vs stale `ref`)
- Updated default favorites (added roster + settings, removed routes)
- Removed Quick Menu and Speedometer switches
- Combined conductor/throttle settings into single section
- Command palette: search pinned at top, scrollable content below
- No auto-focus on search for touch devices

### 🔧 Shared Components
- `CurrentSpeed` compact mode, `ThrottleButtonControls` compact prop
- `DeviceConnectionList` optional props with layout fallback
- `ListControlBar` hidden search on mobile
- Signout → redirect to `/login` on all apps
- `mdi-eject` icon replaces `mdi-parking` throughout

## Test plan
- [ ] Verify throttle list on mobile — tiles render with accent colors, eject works
- [ ] Test all 3 throttle variants (buttons/slider/dashboard) on `/throttle/:address`
- [ ] Test conductor view — 3-column layout, right panel full-width items
- [ ] Verify command palette — search at top, scrollable content
- [ ] Check bottom nav highlights correctly when navigating between pages
- [ ] Test signout redirect to login on cloud and throttle apps
- [ ] Verify settings page — combined throttle section with right panel picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)