### PR TITLE
feat(effects-integration): sound play/stop rings, turnout effectId, UX improvements

### DIFF
--- a/apps/cloud/src/Core/UI/FeatureGate.vue
+++ b/apps/cloud/src/Core/UI/FeatureGate.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+defineProps<{
+  feature: string
+  description?: string
+}>()
+</script>
+
+<template>
+  <div class="relative">
+    <div class="opacity-35 pointer-events-none select-none">
+      <slot />
+    </div>
+    <v-chip
+      size="x-small"
+      color="purple"
+      variant="tonal"
+      prepend-icon="mdi-lock-outline"
+      class="absolute top-1 right-2"
+    >
+      {{ feature }}
+    </v-chip>
+  </div>
+</template>

--- a/apps/cloud/src/Core/UI/TypePickerGrid.vue
+++ b/apps/cloud/src/Core/UI/TypePickerGrid.vue
@@ -1,0 +1,151 @@
+<script setup lang="ts">
+export interface TypeOption {
+  value: string
+  label: string
+  icon?: string
+  color?: string
+  description?: string
+  disabled?: boolean
+}
+
+defineProps<{
+  options: TypeOption[]
+  modelValue?: string
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+}>()
+</script>
+
+<template>
+  <div v-if="options.length === 0" class="type-picker-grid__empty">
+    <v-icon icon="mdi-help-circle" size="32" class="opacity-40" />
+    <p class="text-sm opacity-60 mt-2">No options available.</p>
+  </div>
+
+  <div v-else class="type-picker-grid">
+    <button
+      v-for="opt in options"
+      :key="opt.value"
+      type="button"
+      :disabled="opt.disabled"
+      class="type-picker-grid__tile"
+      :class="{
+        'type-picker-grid__tile--selected': modelValue === opt.value,
+        'type-picker-grid__tile--disabled': opt.disabled,
+      }"
+      @click="!opt.disabled && emit('update:modelValue', opt.value)"
+    >
+      <div class="type-picker-grid__tile-header">
+        <v-avatar :color="opt.color || 'slate'" variant="tonal" size="34" rounded="lg">
+          <v-icon :icon="opt.icon || 'mdi-help'" :color="opt.color" size="18" />
+        </v-avatar>
+
+        <div class="type-picker-grid__tile-text">
+          <div class="type-picker-grid__tile-name">{{ opt.label }}</div>
+          <div v-if="opt.description" class="type-picker-grid__tile-desc">{{ opt.description }}</div>
+        </div>
+
+        <v-icon
+          v-if="modelValue === opt.value"
+          icon="mdi-check-circle"
+          color="cyan"
+          size="18"
+          class="type-picker-grid__tile-check"
+        />
+        <v-chip v-else-if="opt.disabled" size="x-small" variant="tonal" class="type-picker-grid__tile-check opacity-60">
+          Soon
+        </v-chip>
+      </div>
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.type-picker-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 0.6rem;
+}
+
+.type-picker-grid__tile {
+  display: flex;
+  flex-direction: column;
+  padding: 0.75rem;
+  text-align: left;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  background: rgba(15, 23, 42, 0.55);
+  color: #e0f2fe;
+  cursor: pointer;
+  transition:
+    border-color 150ms ease,
+    background 150ms ease,
+    transform 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.type-picker-grid__tile:hover:not(.type-picker-grid__tile--disabled) {
+  border-color: rgba(56, 189, 248, 0.5);
+  background: rgba(56, 189, 248, 0.06);
+  transform: translateY(-1px);
+}
+
+.type-picker-grid__tile--selected {
+  border-color: rgba(56, 189, 248, 0.8);
+  background: rgba(56, 189, 248, 0.12);
+  box-shadow: 0 12px 28px -18px rgba(56, 189, 248, 0.65);
+}
+
+.type-picker-grid__tile--disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.type-picker-grid__tile-header {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  min-width: 0;
+}
+
+.type-picker-grid__tile-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.type-picker-grid__tile-name {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #f8fafc;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.type-picker-grid__tile-desc {
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(148, 163, 184, 0.72);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.type-picker-grid__tile-check {
+  flex-shrink: 0;
+}
+
+.type-picker-grid__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+  border: 1px dashed rgba(148, 163, 184, 0.25);
+  border-radius: 0.75rem;
+  background: rgba(15, 23, 42, 0.35);
+}
+</style>

--- a/apps/cloud/src/Effects/EffectForm.vue
+++ b/apps/cloud/src/Effects/EffectForm.vue
@@ -5,6 +5,7 @@ import { efxTypes } from '@repo/modules/effects/constants'
 import { createLogger } from '@repo/utils'
 import { DevicePickerChip, DevicePickerGrid } from '@repo/ui'
 import ViewJson from '@/Core/UI/ViewJson.vue'
+import TypePickerGrid, { type TypeOption } from '@/Core/UI/TypePickerGrid.vue'
 import MacroForm from '@/Effects/MacroForm.vue'
 import IALEDForm from '@/Effects/IALEDForm.vue'
 import LcdDisplay from '@/Core/UI/LcdDisplay.vue'
@@ -93,6 +94,16 @@ const showDevicePickerDialog = ref(false)
 const loading = ref(false)
 const selectedSoundFile = ref<string>(props.efx?.sound || '')
 const showSoundDialog = ref(false)
+
+const efxTypeOptions = computed<TypeOption[]>(() =>
+  efxTypes.map((t) => ({
+    value: t.value,
+    label: t.label,
+    icon: t.icon,
+    color: t.color,
+  }))
+)
+
 const rules: ValidationRules = {
   required: [(val) => !!val || 'Required.']
 }
@@ -309,20 +320,7 @@ async function handleWledRun() {
           <div class="form-section__row-label mb-2">
             <span class="form-section__row-name">Effect Type</span>
           </div>
-          <v-btn-toggle v-model="efxType" divided class="flex-wrap h-auto" size="x-large">
-            <v-btn
-              v-for="efxOpt in efxTypes"
-              :value="efxOpt.value"
-              :key="efxOpt.value"
-              class="min-h-48 min-w-48 border"
-              :color="color"
-            >
-              <div class="flex flex-col">
-                <v-icon v-if="efxOpt.icon" size="32" :color="efxOpt.color" class="stroke-none">{{ efxOpt.icon }}</v-icon>
-                <div class="mt-4">{{ efxOpt.label }}</div>
-              </div>
-            </v-btn>
-          </v-btn-toggle>
+          <TypePickerGrid v-model="efxType" :options="efxTypeOptions" />
         </div>
       </template>
 

--- a/apps/cloud/src/Effects/MacroAdd.vue
+++ b/apps/cloud/src/Effects/MacroAdd.vue
@@ -2,18 +2,13 @@
 import { computed, ref } from 'vue'
 import { useEfx, type Effect } from '@repo/modules/effects'
 import { useLocos, type Loco } from '@repo/modules/locos'
-import { useTurnouts, type Turnout } from '@repo/modules'
-import { createLogger } from '@repo/utils'
-
-const log = createLogger('MacroAdd')
+import { useTurnouts, type Turnout, efxTypes } from '@repo/modules'
 
 const emit = defineEmits(['add', 'close'])
 
 interface MacroLoco extends Loco {
   speed: number
   direction: 'forward' | 'reverse'
-  isSelected?: boolean
-  type: string
 }
 
 const { getEffects } = useEfx()
@@ -24,153 +19,226 @@ const effects = getEffects()
 const turnouts = getTurnouts()
 const locos = getLocos()
 
-const effectChips = ref([] as Effect[])
-const locoChips = ref([] as MacroLoco[])
-const turnoutChips = ref([] as Turnout[])
-const throttles = computed(() => locoChips.value.map((loco: Loco) => ({
-  speed: 0,
-  direction: 'forward',
-  type: 'throttle',
-  ...loco,
-} as MacroLoco)) as MacroLoco[])
+// --- search state ---
+const effectSearch = ref('')
+const turnoutSearch = ref('')
 
-function handleOk() {
-  log.debug('handleOk', effectChips.value, turnoutChips.value, locoChips.value, throttles.value)
-  emit('add', effectChips.value, turnoutChips.value, throttles.value)
+// --- selection state ---
+const selectedEffects = ref<Effect[]>([])
+const selectedTurnouts = ref<Turnout[]>([])
+const selectedLocos = ref<MacroLoco[]>([])
+
+// --- filtered lists ---
+const filteredEffects = computed(() => {
+  const q = effectSearch.value.trim().toLowerCase()
+  if (!q) return effects.value ?? []
+  return (effects.value ?? []).filter((e) =>
+    e.name?.toLowerCase().includes(q) ||
+    e.type?.toLowerCase().includes(q) ||
+    e.id?.toLowerCase().includes(q),
+  )
+})
+
+const filteredTurnouts = computed(() => {
+  const q = turnoutSearch.value.trim().toLowerCase()
+  if (!q) return turnouts.value ?? []
+  return (turnouts.value ?? []).filter((t) =>
+    t.name?.toLowerCase().includes(q) ||
+    t.device?.toLowerCase().includes(q) ||
+    t.id?.toLowerCase().includes(q),
+  )
+})
+
+function effectIcon(type: string) {
+  return efxTypes.find((t) => t.value === type)?.icon ?? 'mdi-lightning-bolt'
 }
 
+function toggleEffect(efx: Effect) {
+  const idx = selectedEffects.value.findIndex((e) => e.id === efx.id)
+  if (idx === -1) selectedEffects.value.push(efx)
+  else selectedEffects.value.splice(idx, 1)
+}
+
+function toggleTurnout(t: Turnout) {
+  const idx = selectedTurnouts.value.findIndex((s) => s.id === t.id)
+  if (idx === -1) selectedTurnouts.value.push(t)
+  else selectedTurnouts.value.splice(idx, 1)
+}
+
+function toggleLoco(loco: Loco) {
+  const idx = selectedLocos.value.findIndex((l) => l.id === loco.id)
+  if (idx === -1) {
+    selectedLocos.value.push({ ...loco, speed: 0, direction: 'forward' } as MacroLoco)
+  } else {
+    selectedLocos.value.splice(idx, 1)
+  }
+}
+
+function isEffectSelected(efx: Effect) {
+  return selectedEffects.value.some((e) => e.id === efx.id)
+}
+
+function isTurnoutSelected(t: Turnout) {
+  return selectedTurnouts.value.some((s) => s.id === t.id)
+}
+
+function isLocoSelected(loco: Loco) {
+  return selectedLocos.value.some((l) => l.id === loco.id)
+}
+
+function selectedLoco(loco: Loco): MacroLoco | undefined {
+  return selectedLocos.value.find((l) => l.id === loco.id)
+}
+
+function handleOk() {
+  emit('add', selectedEffects.value, selectedTurnouts.value, selectedLocos.value)
+}
 </script>
+
 <template>
-  <v-card
-      min-width="400"
-      prepend-icon="mdi-plus"
-      title="Add to Macro"
-       color="deep-purple"
-    >
-      <template #text>
-        <v-sheet class="p-4 mb-4" color="surface">
-          <h2 class="text-lg">Effects</h2>
-          <v-chip-group column multiple 
-            variant="flat"
-            v-model="effectChips">
-            <v-chip v-for="chip in effects" :key="chip.id" :value="chip"
-              size="small"
-              color="deep-purple"
-              variant="outlined"
-              selected
-            >
-            {{ chip.name }}
-          </v-chip>
-          </v-chip-group>
-        </v-sheet>
-        <v-divider class="my-4 border-fuchsia-500"></v-divider>
-        <v-sheet class="p-4 mb-4" color="surface">
-          <h2 class="text-lg">Turnouts</h2>
-          <v-chip-group column multiple 
-            variant="flat"
-            v-model="turnoutChips">
-            <v-chip v-for="chip in turnouts" :key="chip.id" :value="chip"
-              size="small"
-              color="yellow"
-              variant="outlined"
-              selected
-            >{{ chip.name }}</v-chip>
-          </v-chip-group>
-        </v-sheet>
-        <v-divider class="my-4 border-fuchsia-500"></v-divider>
-        <v-sheet class="p-4 mb-4" color="surface">
-          <h2 class="text-lg">Locos</h2>
-          <v-chip-group column multiple 
-            variant="flat"
-            v-model="locoChips">
-            <v-chip v-for="chip in locos" :key="chip.id" :value="chip"
-              size="small"
-              color="yellow"
-              variant="outlined"
-              selected
-            >{{ chip.name }}</v-chip>
-          </v-chip-group>
-        </v-sheet>
-        <v-divider class="my-4 border-fuchsia-500"></v-divider>
-        <v-sheet class="p-4 mb-4" color="surface">
-          <h2 class="text-lg">Throttles</h2>
-          <v-item-group 
-            v-model="throttles" multiple>
-            <v-row>
-              <v-col  v-for="item in locoChips" :key="item.address" cols="12" md="4" :value="item">
-                <v-item 
-                  size="large"
-                  color="blue"
-                  variant="outlined"
-                  selected
-                  :value="item"
-                  v-slot="{ isSelected, toggle }"
-                >
-                  <v-sheet class="flex items-center justify-start gap-2" color="surface">
-                    <v-avatar :color="item?.meta?.color" :variant="isSelected ? 'flat' : 'outlined'" @click="toggle">{{ item.address }}</v-avatar>
-                    <v-text-field
-                      v-model="item.speed"
-                      type="number"
-                      min="0"
-                      max="128"
-                      class="w-[7rem] flex-grow-0"
-                      label="Speed"
-                      hide-details
-                      single-line
-                      variant="outlined"
-                      append-inner-icon="mdi-speedometer"
-                      inset
-                    ></v-text-field>
-                    <v-btn
-                      :append-icon="item.direction === 'forward' ? 'mdi-arrow-right' : 'mdi-arrow-left'"
-                      variant="outlined"
-                      color="blue"
-                      @click="item.direction = item.direction === 'forward' ? 'reverse' : 'forward'"
-                    >{{item.direction === 'forward' ? 'fwd' : 'rev'}}</v-btn>
-                  </v-sheet>  
-                  <pre>{{item.direction}}</pre>
-                  <pre>{{Boolean(item?.isSelected).toString()}}</pre>
-                </v-item>
-              </v-col>
-            </v-row>
-          </v-item-group>
-          <pre>{{throttles}}</pre>
-          <!-- <v-item-group 
-            v-model="locoChips" multiple>
-            <v-row>
-              <v-col  v-for="item in locoChips" :key="item" :value="item" cols="12"
-                md="4">
-                <v-item 
-                  size="large"
-                  color="blue"
-                  variant="outlined"
-                  selected
-                  v-slot="{ isSelected, toggle }"
-                >
-                  
-                </v-item>
-              </v-col>
-            </v-row>
-          </v-item-group> -->
-        </v-sheet>
-        
+  <v-card min-width="480" max-width="640" color="surface">
+    <v-card-item>
+      <template #prepend>
+        <v-icon icon="mdi-plus" />
       </template>
-      <template v-slot:actions>
-        <v-btn
-          class="ms-auto"
-          text="Cancel"
+      <v-card-title>Add to Macro</v-card-title>
+    </v-card-item>
+
+    <v-card-text class="flex flex-col gap-4 max-h-[70vh] overflow-y-auto">
+
+      <!-- Effects -->
+      <div>
+        <div class="text-sm font-semibold opacity-60 mb-2 uppercase tracking-wide">Effects</div>
+        <v-text-field
+          v-model="effectSearch"
+          placeholder="Search effects…"
+          prepend-inner-icon="mdi-magnify"
           variant="outlined"
-          color="surface"
-          @click="$emit('close')"
-        ></v-btn>
-        <v-spacer></v-spacer>
-        <v-btn
-          class="ms-auto"
-          text="Ok"
-          variant="flat"
-          color="surface"
-          @click="handleOk"
-        ></v-btn>
-      </template>
-    </v-card>
+          density="compact"
+          clearable
+          hide-details
+          class="mb-2"
+        />
+        <div v-if="filteredEffects.length === 0" class="text-sm opacity-40 py-1">
+          No effects match "{{ effectSearch }}"
+        </div>
+        <div class="flex flex-wrap gap-1">
+          <v-btn
+            v-for="efx in filteredEffects"
+            :key="efx.id"
+            :prepend-icon="effectIcon(efx.type)"
+            :color="isEffectSelected(efx) ? 'deep-purple' : undefined"
+            :variant="isEffectSelected(efx) ? 'flat' : 'tonal'"
+            size="small"
+            class="m-0.5"
+            @click="toggleEffect(efx)"
+          >
+            {{ efx.name }}
+          </v-btn>
+        </div>
+      </div>
+
+      <v-divider />
+
+      <!-- Turnouts -->
+      <div>
+        <div class="text-sm font-semibold opacity-60 mb-2 uppercase tracking-wide">Turnouts</div>
+        <v-text-field
+          v-model="turnoutSearch"
+          placeholder="Search turnouts…"
+          prepend-inner-icon="mdi-magnify"
+          variant="outlined"
+          density="compact"
+          clearable
+          hide-details
+          class="mb-2"
+        />
+        <div v-if="filteredTurnouts.length === 0" class="text-sm opacity-40 py-1">
+          No turnouts match "{{ turnoutSearch }}"
+        </div>
+        <div class="flex flex-wrap gap-1">
+          <v-btn
+            v-for="t in filteredTurnouts"
+            :key="t.id"
+            prepend-icon="mdi-directions-fork"
+            :color="isTurnoutSelected(t) ? 'yellow' : undefined"
+            :variant="isTurnoutSelected(t) ? 'flat' : 'tonal'"
+            size="small"
+            class="m-0.5"
+            @click="toggleTurnout(t)"
+          >
+            {{ t.name }}
+          </v-btn>
+        </div>
+      </div>
+
+      <v-divider />
+
+      <!-- Locos / Throttles -->
+      <div>
+        <div class="text-sm font-semibold opacity-60 mb-2 uppercase tracking-wide">Locos</div>
+        <div class="flex flex-wrap gap-1 mb-3">
+          <v-btn
+            v-for="loco in locos"
+            :key="loco.id"
+            prepend-icon="mdi-train"
+            :color="isLocoSelected(loco) ? 'blue' : undefined"
+            :variant="isLocoSelected(loco) ? 'flat' : 'tonal'"
+            size="small"
+            class="m-0.5"
+            @click="toggleLoco(loco)"
+          >
+            {{ loco.name || loco.address }}
+          </v-btn>
+        </div>
+
+        <!-- Speed + direction controls for selected locos -->
+        <div v-if="selectedLocos.length > 0" class="flex flex-col gap-2">
+          <div class="text-xs opacity-50 uppercase tracking-wide mb-1">Throttle Settings</div>
+          <div
+            v-for="loco in selectedLocos"
+            :key="loco.id"
+            class="flex items-center gap-3 p-2 rounded-lg"
+            style="background: rgba(var(--v-theme-on-surface), 0.04)"
+          >
+            <v-avatar color="blue" variant="tonal" size="32">{{ loco.address }}</v-avatar>
+            <span class="text-sm font-medium flex-1">{{ loco.name || loco.address }}</span>
+            <v-text-field
+              v-model="loco.speed"
+              type="number"
+              min="0"
+              max="128"
+              label="Speed"
+              hide-details
+              single-line
+              variant="outlined"
+              density="compact"
+              append-inner-icon="mdi-speedometer"
+              style="max-width: 110px"
+            />
+            <v-btn
+              :append-icon="loco.direction === 'forward' ? 'mdi-arrow-right' : 'mdi-arrow-left'"
+              :color="loco.direction === 'forward' ? 'blue' : 'orange'"
+              variant="tonal"
+              size="small"
+              @click="loco.direction = loco.direction === 'forward' ? 'reverse' : 'forward'"
+            >
+              {{ loco.direction === 'forward' ? 'Fwd' : 'Rev' }}
+            </v-btn>
+          </div>
+        </div>
+      </div>
+
+    </v-card-text>
+
+    <v-card-actions>
+      <v-btn variant="outlined" @click="$emit('close')">Cancel</v-btn>
+      <v-spacer />
+      <v-btn color="primary" variant="flat" @click="handleOk">
+        Add {{ selectedEffects.length + selectedTurnouts.length + selectedLocos.length > 0
+          ? `(${selectedEffects.length + selectedTurnouts.length + selectedLocos.length})`
+          : '' }}
+      </v-btn>
+    </v-card-actions>
+  </v-card>
 </template>

--- a/apps/cloud/src/Sensors/SensorForm.vue
+++ b/apps/cloud/src/Sensors/SensorForm.vue
@@ -1,12 +1,15 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
-import { useLayout, type Device } from '@repo/modules'
+import { useLayout, type Device, efxTypes } from '@repo/modules'
+import { useEfx } from '@repo/modules/effects'
 import { useSensors, type Sensor, sensorTypes, sensorInputTypes } from '@repo/modules/sensors'
 import { createLogger } from '@repo/utils'
 import { DevicePickerChip, DevicePickerGrid, useNotification } from '@repo/ui'
 import ColorPickerRow from '@/Common/Color/ColorPickerRow.vue'
 import TagPicker from '@/Common/Tags/TagPicker.vue'
 import DevicePicker from '@/Layout/Devices/DevicePicker.vue'
+import EffectPicker from '@/Effects/EffectPicker.vue'
+import FeatureGate from '@/Core/UI/FeatureGate.vue'
 
 const log = createLogger('SensorForm')
 
@@ -16,8 +19,15 @@ const emit = defineEmits(['close'])
 const { getDevices } = useLayout()
 const { setSensor } = useSensors()
 const { notify } = useNotification()
+const { getEffects } = useEfx()
 
 const devices = getDevices()
+const effects = getEffects()
+const selectedEffect = computed(() => effects.value?.find((e) => e.id === effectId.value) ?? null)
+const selectedEffectName = computed(() => selectedEffect.value?.name ?? effectId.value ?? null)
+const selectedEffectIcon = computed(() =>
+  efxTypes.find((t) => t.value === selectedEffect.value?.type)?.icon ?? 'mdi-lightning-bolt'
+)
 
 const name = ref(props.sensor?.name ?? '')
 const device = ref(props.sensor?.device ?? '')
@@ -43,6 +53,7 @@ const loading = ref(false)
 // 📦 Add-vs-edit drives the device picker presentation.
 const isEdit = computed(() => !!props.sensor)
 const showDevicePickerDialog = ref(false)
+const showEffectPickerDialog = ref(false)
 const error = ref<string | null>(null)
 
 const deviceRules = computed(() => {
@@ -385,30 +396,38 @@ async function submit() {
         </div>
       </div>
 
-      <div class="form-section__grid" style="grid-template-columns: 1fr 1fr">
-        <div>
-          <label class="form-section__input-label">Linked Effect ID</label>
-          <v-text-field
-            v-model="effectId"
-            variant="outlined"
-            density="compact"
-            color="teal"
-            hide-details="auto"
-          />
-          <div class="form-section__input-hint">Effect to trigger when sensor activates</div>
+      <!-- Linked Effect -->
+      <div class="form-section__row">
+        <div class="form-section__row-label">
+          <span class="form-section__row-name">Effect</span>
+          <span class="form-section__row-desc">Trigger when sensor activates</span>
         </div>
-        <div>
-          <label class="form-section__input-label">Linked Automation ID</label>
-          <v-text-field
-            v-model="automationId"
-            variant="outlined"
-            density="compact"
-            color="teal"
-            hide-details="auto"
-          />
-          <div class="form-section__input-hint">Automation to run when sensor activates</div>
+        <div
+          class="flex items-center gap-2.5 px-3 py-1.5 rounded-lg border cursor-pointer"
+          style="border-color: rgba(var(--v-theme-on-surface), 0.08); background: rgba(var(--v-theme-on-surface), 0.03)"
+          @click="showEffectPickerDialog = true"
+        >
+          <v-icon v-if="selectedEffectName" :icon="selectedEffectIcon" size="14" class="text-white/40" />
+          <span class="text-sm text-white/60 truncate max-w-[140px]">{{ selectedEffectName || 'None' }}</span>
+          <v-icon size="14" class="text-white/25">mdi-chevron-right</v-icon>
         </div>
       </div>
+
+      <!-- Linked Automation ID — gated behind Automation Studio -->
+      <FeatureGate feature="Automation Studio" description="Automation to run when sensor activates">
+        <div class="form-section__grid" style="grid-template-columns: 1fr">
+          <div>
+            <label class="form-section__input-label">Linked Automation ID</label>
+            <v-text-field
+              v-model="automationId"
+              variant="outlined"
+              density="compact"
+              color="teal"
+              hide-details="auto"
+            />
+          </div>
+        </div>
+      </FeatureGate>
 
       <!-- ═══ ERROR + FOOTER ═══ -->
       <v-alert
@@ -433,6 +452,14 @@ async function submit() {
       :color="color"
       @select="showDevicePickerDialog = false"
       @cancel="showDevicePickerDialog = false; device = props?.sensor?.device ?? ''"
+    />
+  </v-dialog>
+
+  <v-dialog v-model="showEffectPickerDialog" max-width="80vw">
+    <EffectPicker
+      v-model="effectId"
+      @select="showEffectPickerDialog = false"
+      @cancel="showEffectPickerDialog = false; effectId = props?.sensor?.effectId ?? ''"
     />
   </v-dialog>
 </template>

--- a/apps/cloud/src/Turnouts/TurnoutForm.vue
+++ b/apps/cloud/src/Turnouts/TurnoutForm.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { useTurnouts, type Device, type Turnout } from '@repo/modules'
-import { useLayout } from '@repo/modules'
+import { useLayout, efxTypes } from '@repo/modules'
 import { DevicePickerChip, DevicePickerGrid } from '@repo/ui'
-// import { useEfx } from '@repo/modules/effects'
+import { useEfx } from '@repo/modules/effects'
 import { slugify, createLogger } from '@repo/utils'
 import TurnoutTypePicker from '@/Turnouts/TurnoutTypePicker.vue'
 import DevicePicker from '@/Layout/Devices/DevicePicker.vue'
@@ -25,12 +25,12 @@ const emit = defineEmits(['close'])
 const DEFAULT_DEVICE = 'dccex'
 const DEFAULT_TYPE = 'kato'
 
-// const { getEffects } = useEfx()
+const { getEffects } = useEfx()
 const { getDevices } = useLayout()
 const { setTurnout } = useTurnouts()
 
 const devices = getDevices()
-// const effects = getEffects()
+const effects = getEffects()
 
 const editEffect = ref(false)
 const editType = ref(false)
@@ -40,6 +40,7 @@ const name = ref(props.turnout?.name || '')
 const desc = ref(props.turnout?.desc || '')
 const index = ref(props.turnout?.turnoutIdx)
 const effectId = ref(props.turnout?.effectId)
+const invertEffect = ref(Boolean(props.turnout?.invertEffect))
 const device = ref(props.turnout?.device || DEFAULT_DEVICE)
 const straight = ref<number | undefined>(props.turnout?.straight)
 const divergent = ref<number | undefined>(props.turnout?.divergent)
@@ -87,6 +88,7 @@ async function submit(e: Promise<{ valid: boolean }>): Promise<void> {
     }
     if (effectId.value) {
       turnout.effectId = effectId.value
+      turnout.invertEffect = invertEffect.value
     }
     await setTurnout(turnoutId, turnout)
     loading.value = false
@@ -110,6 +112,7 @@ function reset() {
   tags.value = []
   index.value = undefined
   effectId.value = ''
+  invertEffect.value = false
   device.value = DEFAULT_DEVICE
   straight.value = undefined
   divergent.value = undefined
@@ -117,6 +120,11 @@ function reset() {
 }
 
 const title = computed(() => props.turnout ? `Edit Turnout: ${props.turnout.name}` : 'Add Turnout')
+const selectedEffect = computed(() => effects.value?.find((e) => e.id === effectId.value) ?? null)
+const selectedEffectName = computed(() => selectedEffect.value?.name ?? effectId.value ?? null)
+const selectedEffectIcon = computed(() =>
+  efxTypes.find((t) => t.value === selectedEffect.value?.type)?.icon ?? 'mdi-lightning-bolt'
+)
 </script>
 
 <template>
@@ -163,38 +171,10 @@ const title = computed(() => props.turnout ? `Edit Turnout: ${props.turnout.name
           <span class="form-section__title">Configuration</span>
         </div>
 
-        <div class="form-section__grid" style="grid-template-columns: 1fr 1fr">
-          <div>
-            <label class="form-section__input-label">Straight</label>
-            <v-text-field v-model="straight" variant="outlined" density="compact" color="amber" :rules="rules.required" hide-details="auto" placeholder="0" type="number" />
-            <div class="form-section__input-hint">Value for straight position</div>
-          </div>
-          <div>
-            <label class="form-section__input-label">Divergent</label>
-            <v-text-field v-model="divergent" variant="outlined" density="compact" color="amber" :rules="rules.required" hide-details="auto" placeholder="90" type="number" />
-            <div class="form-section__input-hint">Value for divergent position</div>
-          </div>
-        </div>
-
-        <!-- Type -->
-        <div class="form-section__row">
-          <div class="form-section__row-label">
-            <span class="form-section__row-name">Type</span>
-            <span class="form-section__row-desc">Turnout mechanism</span>
-          </div>
-          <div class="flex items-center gap-2.5 px-3 py-1.5 rounded-lg border cursor-pointer" style="border-color: rgba(var(--v-theme-on-surface), 0.08); background: rgba(var(--v-theme-on-surface), 0.03)" @click="editType = true">
-            <span class="text-sm text-white/60 capitalize">{{ turnoutType }}</span>
-            <v-icon size="14" class="text-white/25">mdi-chevron-right</v-icon>
-          </div>
-        </div>
-
         <!-- Device — grid inline for add, compact chip → dialog for edit -->
-        <div class="form-section__row" :class="{ 'form-section__row--block': !isEdit }">
+        <div class="px-5 py-2" :class="{ 'pb-4': !isEdit }">
           <template v-if="!isEdit">
-            <div class="form-section__row-label mb-2">
-              <span class="form-section__row-name">Device</span>
-              <span class="form-section__row-desc">Controller device</span>
-            </div>
+            <label class="form-section__input-label mb-2">Device</label>
             <DevicePickerGrid
               v-model="device"
               :devices="(devices ?? []) as Device[]"
@@ -210,6 +190,32 @@ const title = computed(() => props.turnout ? `Edit Turnout: ${props.turnout.name
           />
         </div>
 
+        <!-- Type -->
+        <div class="form-section__row">
+          <div class="form-section__row-label">
+            <span class="form-section__row-name">Type</span>
+            <span class="form-section__row-desc">Turnout mechanism</span>
+          </div>
+          <div class="flex items-center gap-2.5 px-3 py-1.5 rounded-lg border cursor-pointer" style="border-color: rgba(var(--v-theme-on-surface), 0.08); background: rgba(var(--v-theme-on-surface), 0.03)" @click="editType = true">
+            <span class="text-sm text-white/60 capitalize">{{ turnoutType }}</span>
+            <v-icon size="14" class="text-white/25">mdi-chevron-right</v-icon>
+          </div>
+        </div>
+
+        <!-- Straight / Divergent -->
+        <div class="form-section__grid" style="grid-template-columns: 1fr 1fr">
+          <div>
+            <label class="form-section__input-label">Straight</label>
+            <v-text-field v-model="straight" variant="outlined" density="compact" color="amber" :rules="rules.required" hide-details="auto" placeholder="0" type="number" />
+            <div class="form-section__input-hint">Value for straight position</div>
+          </div>
+          <div>
+            <label class="form-section__input-label">Divergent</label>
+            <v-text-field v-model="divergent" variant="outlined" density="compact" color="amber" :rules="rules.required" hide-details="auto" placeholder="90" type="number" />
+            <div class="form-section__input-hint">Value for divergent position</div>
+          </div>
+        </div>
+
         <!-- Effect -->
         <div class="form-section__row">
           <div class="form-section__row-label">
@@ -217,9 +223,19 @@ const title = computed(() => props.turnout ? `Edit Turnout: ${props.turnout.name
             <span class="form-section__row-desc">Sound or light on throw</span>
           </div>
           <div class="flex items-center gap-2.5 px-3 py-1.5 rounded-lg border cursor-pointer" style="border-color: rgba(var(--v-theme-on-surface), 0.08); background: rgba(var(--v-theme-on-surface), 0.03)" @click="editEffect = true">
-            <span class="text-sm text-white/60 truncate max-w-[120px]">{{ effectId || 'None' }}</span>
+            <v-icon v-if="selectedEffectName" :icon="selectedEffectIcon" size="14" class="text-white/40" />
+            <span class="text-sm text-white/60 truncate max-w-[140px]">{{ selectedEffectName || 'None' }}</span>
             <v-icon size="14" class="text-white/25">mdi-chevron-right</v-icon>
           </div>
+        </div>
+
+        <!-- Effect state invert — only shown when an effect is linked -->
+        <div v-if="effectId" class="form-section__row">
+          <div class="form-section__row-label">
+            <span class="form-section__row-name">Effect State</span>
+            <span class="form-section__row-desc">{{ invertEffect ? 'Inverted — effect off when thrown' : 'Matches — effect on when thrown' }}</span>
+          </div>
+          <v-switch v-model="invertEffect" color="amber" hide-details density="compact" />
         </div>
 
         <div class="form-section__footer">

--- a/apps/cloud/src/Turnouts/TurnoutPicker.vue
+++ b/apps/cloud/src/Turnouts/TurnoutPicker.vue
@@ -1,43 +1,35 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
-import { useEfx } from '@repo/modules/effects'
-import { efxTypes } from '@repo/modules'
+import { useTurnouts } from '@repo/modules'
 
 defineEmits(['select', 'cancel'])
-defineProps({
-  color: String,
-})
 const model = defineModel<string>()
-const { getEffects } = useEfx()
-const effects = getEffects()
+const { getTurnouts } = useTurnouts()
+const turnouts = getTurnouts()
 const search = ref('')
 
 const filtered = computed(() => {
   const q = search.value.trim().toLowerCase()
-  if (!q) return effects.value ?? []
-  return (effects.value ?? []).filter((e) =>
-    e.name?.toLowerCase().includes(q) ||
-    e.type?.toLowerCase().includes(q) ||
-    e.id?.toLowerCase().includes(q),
+  if (!q) return turnouts.value ?? []
+  return (turnouts.value ?? []).filter((t) =>
+    t.name?.toLowerCase().includes(q) ||
+    t.device?.toLowerCase().includes(q) ||
+    t.id?.toLowerCase().includes(q),
   )
 })
-
-function iconFor(type: string) {
-  return efxTypes.find((t) => t.value === type)?.icon ?? 'mdi-rocket'
-}
 </script>
 
 <template>
   <v-card class="mx-auto w-full h-full justify-between flex flex-col" color="surface">
     <v-card-item>
-      <v-card-title>Effect</v-card-title>
-      <v-card-subtitle>Select an effect to trigger on throw</v-card-subtitle>
+      <v-card-title>Turnout</v-card-title>
+      <v-card-subtitle>Select a turnout to link</v-card-subtitle>
     </v-card-item>
 
     <v-card-text class="flex flex-col gap-3">
       <v-text-field
         v-model="search"
-        placeholder="Search effects…"
+        placeholder="Search turnouts…"
         prepend-inner-icon="mdi-magnify"
         variant="outlined"
         density="compact"
@@ -47,20 +39,23 @@ function iconFor(type: string) {
       />
 
       <div v-if="filtered.length === 0" class="text-sm opacity-40 py-2 text-center">
-        No effects match "{{ search }}"
+        No turnouts match "{{ search }}"
       </div>
 
       <div class="flex flex-wrap gap-1">
         <v-btn
-          v-for="efx in filtered"
-          :key="efx.id"
-          :prepend-icon="iconFor(efx.type)"
-          :color="model === efx.id ? 'primary' : undefined"
-          :variant="model === efx.id ? 'flat' : 'tonal'"
+          v-for="t in filtered"
+          :key="t.id"
+          prepend-icon="mdi-directions-fork"
+          :color="model === t.id ? 'primary' : undefined"
+          :variant="model === t.id ? 'flat' : 'tonal'"
           class="m-1"
-          @click="model = efx.id"
+          @click="model = t.id"
         >
-          {{ efx.name }}
+          {{ t.name }}
+          <template #append>
+            <span class="text-xs opacity-50 ml-1">{{ t.device }}</span>
+          </template>
         </v-btn>
       </div>
     </v-card-text>

--- a/apps/cloud/src/Turnouts/TurnoutTypePicker.vue
+++ b/apps/cloud/src/Turnouts/TurnoutTypePicker.vue
@@ -1,70 +1,64 @@
 <script setup lang="ts">
+import TypePickerGrid, { type TypeOption } from '@/Core/UI/TypePickerGrid.vue'
 
 defineEmits(['select', 'cancel'])
 const model = defineModel<string>()
-
-const types = [
-  {
-    id: 'kato',
-    name: 'Kato'
-  },
-  {
-    id: 'servo',
-    name: 'Servo'
-  },
-  {
-    id: 'tortise',
-    name: 'Tortise',
-    disabled: true
-  },
-  {
-    id: 'dcc',
-    name: 'DCC',
-    disabled: true
-  }
-]
 
 defineProps({
   color: String
 })
 
+const types: TypeOption[] = [
+  {
+    value: 'kato',
+    label: 'Kato',
+    icon: 'mdi-directions-fork',
+    color: 'yellow',
+    description: 'Snap-action solenoid',
+  },
+  {
+    value: 'servo',
+    label: 'Servo',
+    icon: 'mdi-rotate-right',
+    color: 'blue',
+    description: 'Servo motor control',
+  },
+  {
+    value: 'tortise',
+    label: 'Tortise',
+    icon: 'mdi-swap-horizontal',
+    color: 'green',
+    description: 'Slow-motion machine',
+    disabled: true,
+  },
+  {
+    value: 'dcc',
+    label: 'DCC',
+    icon: 'mdi-chip',
+    color: 'indigo',
+    description: 'DCC accessory decoder',
+    disabled: true,
+  },
+]
 </script>
+
 <template>
-  <v-card class="mx-auto w-full h-full justify-between flex flex-col bg-zinc-500  bg-opacity-20"
-    variant="tonal"
-    density="compact"
-    :color="color">
-    <v-card-item class="font-weight-black">
-      <v-card-title class="font-weight-black">
-        Turnout Type
-      </v-card-title>
+  <v-card class="mx-auto w-full h-full justify-between flex flex-col" color="surface">
+    <v-card-item>
+      <v-card-title>Turnout Type</v-card-title>
+      <v-card-subtitle>Select the turnout mechanism</v-card-subtitle>
     </v-card-item>
+
     <v-card-text>
-      <v-btn-toggle v-model="model" divided class="flex-wrap h-auto" size="x-large">
-        <v-btn v-for="turnoutType in types" :value="turnoutType.id" :key="turnoutType.id"
-          class="min-h-48 min-w-48 border"
-          variant="flat"
-          :disabled="turnoutType?.disabled ?? false"
-          :color="color">
-          <div class="flex flex-col justify-center items-center">
-            <v-icon color="white" size="64">mdi-directions-fork</v-icon>
-            <div class="mt-4">{{ turnoutType.name }}</div>
-          </div> 
-        </v-btn>
-      </v-btn-toggle>
+      <TypePickerGrid v-model="model" :options="types" />
     </v-card-text>
+
     <v-card-actions>
-      <v-btn
-        prepend-icon="mdi-cancel"
-        variant="outlined"
-        @click="$emit('cancel')">
-        Cacnel
+      <v-btn prepend-icon="mdi-cancel" variant="outlined" @click="$emit('cancel')">
+        Cancel
       </v-btn>
-      <v-btn
-        prepend-icon="mdi-check"
-        :color="model"
-        variant="flat"
-        @click="$emit('select')">
+      <v-spacer />
+      <v-btn prepend-icon="mdi-check" color="primary" variant="flat" @click="$emit('select')">
         Save
       </v-btn>
     </v-card-actions>

--- a/apps/server/src/modules/turnouts.test.ts
+++ b/apps/server/src/modules/turnouts.test.ts
@@ -1,0 +1,329 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks — vi.hoisted runs before vi.mock factories so these refs
+// can be safely used inside factory closures.
+// ---------------------------------------------------------------------------
+
+const { mockSet, mockDb, mockConnections, mockDevices, mockSendTurnout } = vi.hoisted(() => {
+  // Must be set before the module loads — turnouts.ts reads LAYOUT_ID as a top-level constant.
+  process.env.LAYOUT_ID = 'layout-test'
+
+  const mockSet = vi.fn().mockResolvedValue(undefined)
+  const mockEffectsDoc = vi.fn(() => ({ set: mockSet }))
+  const mockEffectsCollection = vi.fn(() => ({ doc: mockEffectsDoc }))
+  const mockLayoutDoc = vi.fn(() => ({ collection: mockEffectsCollection }))
+  const mockDb = { collection: vi.fn(() => ({ doc: mockLayoutDoc })) }
+  const mockConnections = vi.fn()
+  const mockDevices = vi.fn()
+  const mockSendTurnout = vi.fn().mockResolvedValue(undefined)
+  return { mockSet, mockDb, mockConnections, mockDevices, mockSendTurnout }
+})
+
+vi.mock('@repo/firebase-config/firebase-admin-node', () => ({ db: mockDb }))
+
+vi.mock('firebase-admin/firestore', () => ({
+  FieldValue: { serverTimestamp: vi.fn(() => 'SERVER_TS') },
+}))
+
+vi.mock('../utils/logger.js', () => ({
+  log: {
+    log: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}))
+
+vi.mock('../lib/dcc.js', () => ({
+  dcc: { sendTurnout: mockSendTurnout },
+}))
+
+vi.mock('./layout.js', () => ({
+  layout: { connections: mockConnections, devices: mockDevices },
+}))
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import { turnoutCommand, handleTurnout, handleTurnoutChange } from './turnouts.js'
+import { log } from '../utils/logger.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSnapshot(changes: Array<{ type: 'added' | 'modified'; id: string; data: Record<string, unknown> }>) {
+  return {
+    docChanges: () =>
+      changes.map((c) => ({
+        type: c.type,
+        doc: { id: c.id, data: () => c.data },
+      })),
+  }
+}
+
+/** Flush all pending microtasks from async-in-forEach callbacks. */
+async function flush() {
+  await new Promise<void>((r) => setTimeout(r, 0))
+}
+
+// ---------------------------------------------------------------------------
+// turnoutCommand — pure, no mocking needed
+// ---------------------------------------------------------------------------
+
+describe('turnoutCommand', () => {
+  const base = { id: 't1', name: 'Main Yard', device: 'dev-1', state: false }
+
+  it('returns undefined for unknown type', () => {
+    expect(turnoutCommand({ ...base, type: 'unknown' as never })).toBeUndefined()
+  })
+
+  describe('kato', () => {
+    it('builds a kato command with state and turnoutIdx', () => {
+      const cmd = turnoutCommand({ ...base, type: 'kato', turnoutIdx: 3 })
+      expect(cmd).toEqual({
+        action: 'turnout',
+        device: 'dev-1',
+        payload: { state: false, turnout: 3 },
+      })
+    })
+
+    it('reflects thrown state', () => {
+      const cmd = turnoutCommand({ ...base, type: 'kato', state: true, turnoutIdx: 3 })
+      expect((cmd as { payload: { state: boolean } }).payload.state).toBe(true)
+    })
+  })
+
+  describe('servo', () => {
+    const servo = { ...base, type: 'servo' as const, straight: 0, divergent: 90, turnoutIdx: 2 }
+
+    it('builds a servo command selecting straight position when closed', () => {
+      const cmd = turnoutCommand({ ...servo, state: false }) as { payload: { current: number; value: number } }
+      expect(cmd.payload.current).toBe(0)   // straight
+      expect(cmd.payload.value).toBe(90)    // divergent (target on next throw)
+    })
+
+    it('builds a servo command selecting divergent position when thrown', () => {
+      const cmd = turnoutCommand({ ...servo, state: true }) as { payload: { current: number; value: number } }
+      expect(cmd.payload.current).toBe(90)  // divergent
+      expect(cmd.payload.value).toBe(0)     // straight (target on next close)
+    })
+
+    it('returns undefined when straight === divergent', () => {
+      expect(turnoutCommand({ ...servo, straight: 45, divergent: 45 })).toBeUndefined()
+    })
+
+    it('returns undefined when values exceed 180', () => {
+      expect(turnoutCommand({ ...servo, straight: 0, divergent: 200 })).toBeUndefined()
+    })
+
+    it('returns undefined when values are negative', () => {
+      expect(turnoutCommand({ ...servo, straight: -10, divergent: 90 })).toBeUndefined()
+    })
+
+    it('returns undefined when turnoutIdx is missing', () => {
+      const { turnoutIdx: _, ...noIdx } = servo
+      expect(turnoutCommand(noIdx as never)).toBeUndefined()
+    })
+
+    it('returns undefined when straight is undefined', () => {
+      const { straight: _, ...noStraight } = servo
+      expect(turnoutCommand(noStraight as never)).toBeUndefined()
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleTurnoutChange — state tracking + effect triggering
+// ---------------------------------------------------------------------------
+
+describe('handleTurnoutChange', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Device not connected → handleTurnout exits early without DCC commands
+    mockConnections.mockReturnValue({})
+    mockDevices.mockReturnValue([])
+  })
+
+  it('records initial state on "added" and does not call handleTurnout', async () => {
+    await handleTurnoutChange(makeSnapshot([
+      { type: 'added', id: 'ta1', data: { state: false, device: 'd1', type: 'kato' } },
+    ]))
+    await flush()
+    expect(mockSendTurnout).not.toHaveBeenCalled()
+  })
+
+  it('calls handleTurnout when state changes on "modified"', async () => {
+    // Seed initial state
+    await handleTurnoutChange(makeSnapshot([
+      { type: 'added', id: 'tb1', data: { state: false, device: 'd1', type: 'kato' } },
+    ]))
+    await flush()
+
+    // Simulate state flip — device IS connected for this one to reach dcc.sendTurnout
+    mockConnections.mockReturnValue({
+      d1: { isConnected: true, topic: 'deja/d1', publish: vi.fn().mockResolvedValue(undefined) },
+    })
+    mockDevices.mockReturnValue([{ id: 'd1', type: 'kato', connection: 'wifi' }])
+
+    await handleTurnoutChange(makeSnapshot([
+      { type: 'modified', id: 'tb1', data: { id: 'tb1', state: true, device: 'd1', type: 'kato', turnoutIdx: 1 } },
+    ]))
+    await flush()
+
+    // Connection publish was invoked (handleTurnout reached device command path)
+    const conn = mockConnections()['d1']
+    expect(conn.publish).toHaveBeenCalled()
+  })
+
+  it('does NOT call handleTurnout when state is unchanged', async () => {
+    await handleTurnoutChange(makeSnapshot([
+      { type: 'added', id: 'tc1', data: { state: true, device: 'd1', type: 'kato' } },
+    ]))
+    await flush()
+
+    await handleTurnoutChange(makeSnapshot([
+      { type: 'modified', id: 'tc1', data: { id: 'tc1', state: true, device: 'd1', type: 'kato' } },
+    ]))
+    await flush()
+
+    expect(mockSendTurnout).not.toHaveBeenCalled()
+    // db.collection should not have been called for effects either
+    expect(mockSet).not.toHaveBeenCalled()
+  })
+
+  it('triggers linked effect when effectId is set and state changes', async () => {
+    await handleTurnoutChange(makeSnapshot([
+      { type: 'added', id: 'td1', data: { state: false, device: 'd1', type: 'kato' } },
+    ]))
+    await flush()
+
+    await handleTurnoutChange(makeSnapshot([
+      {
+        type: 'modified',
+        id: 'td1',
+        data: { id: 'td1', state: true, device: 'd1', type: 'kato', effectId: 'whistle-sound' },
+      },
+    ]))
+    await flush()
+
+    expect(mockDb.collection).toHaveBeenCalledWith('layouts')
+    expect(mockSet).toHaveBeenCalledWith(
+      { state: true, timestamp: 'SERVER_TS' },
+      { merge: true },
+    )
+    expect(log.success).toHaveBeenCalledWith(
+      expect.stringContaining('whistle-sound'),
+    )
+  })
+
+  it('does NOT trigger an effect when effectId is absent', async () => {
+    await handleTurnoutChange(makeSnapshot([
+      { type: 'added', id: 'te1', data: { state: false, device: 'd1', type: 'kato' } },
+    ]))
+    await flush()
+
+    await handleTurnoutChange(makeSnapshot([
+      { type: 'modified', id: 'te1', data: { id: 'te1', state: true, device: 'd1', type: 'kato' } },
+    ]))
+    await flush()
+
+    expect(mockSet).not.toHaveBeenCalled()
+  })
+
+  it('logs an error and continues when the effect write fails', async () => {
+    mockSet.mockRejectedValueOnce(new Error('Firestore unavailable'))
+
+    await handleTurnoutChange(makeSnapshot([
+      { type: 'added', id: 'tf1', data: { state: false, device: 'd1', type: 'kato' } },
+    ]))
+    await flush()
+
+    await handleTurnoutChange(makeSnapshot([
+      {
+        type: 'modified',
+        id: 'tf1',
+        data: { id: 'tf1', state: true, device: 'd1', type: 'kato', effectId: 'horn-effect' },
+      },
+    ]))
+    await flush()
+
+    expect(log.error).toHaveBeenCalledWith(
+      expect.stringContaining('tf1'),
+      expect.any(Error),
+    )
+  })
+
+  it('inverts the effect state when invertEffect is true', async () => {
+    await handleTurnoutChange(makeSnapshot([
+      { type: 'added', id: 'th1', data: { state: false, device: 'd1', type: 'kato' } },
+    ]))
+    await flush()
+
+    await handleTurnoutChange(makeSnapshot([
+      {
+        type: 'modified',
+        id: 'th1',
+        data: { id: 'th1', state: true, device: 'd1', type: 'kato', effectId: 'horn', invertEffect: true },
+      },
+    ]))
+    await flush()
+
+    // turnout thrown (true) → invertEffect → effect state should be false
+    expect(mockSet).toHaveBeenCalledWith(
+      { state: false, timestamp: 'SERVER_TS' },
+      { merge: true },
+    )
+  })
+
+  it('passes the turnout state (false) to the effect when closing', async () => {
+    await handleTurnoutChange(makeSnapshot([
+      { type: 'added', id: 'tg1', data: { state: true, device: 'd1', type: 'kato' } },
+    ]))
+    await flush()
+
+    await handleTurnoutChange(makeSnapshot([
+      {
+        type: 'modified',
+        id: 'tg1',
+        data: { id: 'tg1', state: false, device: 'd1', type: 'kato', effectId: 'bell-effect' },
+      },
+    ]))
+    await flush()
+
+    expect(mockSet).toHaveBeenCalledWith(
+      { state: false, timestamp: 'SERVER_TS' },
+      { merge: true },
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleTurnout — device routing (unit-level, device not connected)
+// ---------------------------------------------------------------------------
+
+describe('handleTurnout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockConnections.mockReturnValue({})
+    mockDevices.mockReturnValue([])
+  })
+
+
+  it('exits early when device is not connected', async () => {
+    await handleTurnout({ id: 't1', device: 'missing', state: true, type: 'kato', name: 'T1' })
+    expect(mockSendTurnout).not.toHaveBeenCalled()
+    expect(log.error).toHaveBeenCalledWith('Device not connected', 'missing')
+  })
+
+  it('sends DCC-EX serial command for dcc-ex device type', async () => {
+    mockConnections.mockReturnValue({ 'dccex-1': { isConnected: true } })
+    mockDevices.mockReturnValue([{ id: 'dccex-1', type: 'dcc-ex' }])
+
+    await handleTurnout({ id: 't1', device: 'dccex-1', state: true, type: 'kato', name: 'T1', turnoutIdx: 5 })
+    expect(mockSendTurnout).toHaveBeenCalledWith({ state: true, turnoutIdx: 5 }, 'dccex-1')
+  })
+})

--- a/apps/server/src/modules/turnouts.ts
+++ b/apps/server/src/modules/turnouts.ts
@@ -1,4 +1,4 @@
-import { type DocumentData } from 'firebase/firestore'
+import { FieldValue, type DocumentData } from 'firebase-admin/firestore'
 import { db } from '@repo/firebase-config/firebase-admin-node'
 import type { Turnout, KatoCommand, ServoCommand } from '@repo/modules'
 import { log } from '../utils/logger.js'
@@ -160,8 +160,23 @@ export async function handleTurnoutChange(
     }
     if (change.type === 'modified') {
       if (turnoutStates[change.doc.id] !== change.doc.data()?.state) {
-        turnoutStates[change.doc.id] = change.doc.data()?.state
-        await handleTurnout(change.doc.data())
+        const turnoutData = change.doc.data() as Turnout
+        turnoutStates[change.doc.id] = turnoutData.state
+        await handleTurnout(turnoutData)
+        if (turnoutData.effectId && layoutId) {
+          try {
+            const effectState = turnoutData.invertEffect ? !turnoutData.state : turnoutData.state
+            await db
+              .collection('layouts')
+              .doc(layoutId)
+              .collection('effects')
+              .doc(turnoutData.effectId)
+              .set({ state: effectState, timestamp: FieldValue.serverTimestamp() }, { merge: true })
+            log.success(`[TURNOUTS] Triggered effect ${turnoutData.effectId} for turnout ${change.doc.id}`)
+          } catch (error) {
+            log.error(`[TURNOUTS] Failed to trigger effect for turnout ${change.doc.id}:`, error)
+          }
+        }
       }
     }
   })

--- a/packages/modules/turnouts/types.ts
+++ b/packages/modules/turnouts/types.ts
@@ -6,6 +6,7 @@ export interface Turnout {
   device: string
   divergent?: number
   effectId?: string
+  invertEffect?: boolean
   id: string
   lastUpdated?: string
   name: string

--- a/packages/ui/src/Effects/EffectButton.vue
+++ b/packages/ui/src/Effects/EffectButton.vue
@@ -1,39 +1,62 @@
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
-import { useEfx, efxTypes, type Effect } from '@repo/modules'
+import { computed } from 'vue'
+import { efxTypes, type Effect } from '@repo/modules'
 import { useHaptics } from '../composables/useHaptics'
 
-const { runEffect } = useEfx()
-
 interface Props {
-  effect: Effect,
-  isRunning: boolean,
+  effect: Effect
+  isRunning: boolean
+  progress?: number
 }
 
 const props = defineProps<Props>()
-const state = defineModel('state', {
-  type: Boolean
-})
+const state = defineModel('state', { type: Boolean })
 const { vibrate } = useHaptics()
-const efxType = computed(() => efxTypes.find((type) => type.value === props?.effect?.type))
 
+const efxType = computed(() => efxTypes.find((type) => type.value === props?.effect?.type))
+const isSound = computed(() => props.effect?.type === 'sound')
+const accentColor = computed(() => props.effect?.color || efxType.value?.color || 'primary')
 </script>
 
 <template>
-  <v-btn 
+  <!-- Sound: circular play/stop button with progress ring + name label -->
+  <div v-if="isSound" class="inline-flex flex-col items-center gap-1 m-1">
+    <div class="relative inline-flex items-center justify-center w-[52px] h-[52px]">
+      <v-progress-circular
+        :model-value="isRunning ? progress : 0"
+        :size="52"
+        :width="3"
+        :color="accentColor"
+        bg-color="transparent"
+        class="absolute inset-0 pointer-events-none"
+      />
+      <v-btn
+        :icon="isRunning ? 'mdi-stop' : 'mdi-play'"
+        :color="isRunning ? 'red-lighten-2' : accentColor"
+        variant="tonal"
+        size="small"
+        @click="state = !state; vibrate('light')"
+      />
+    </div>
+    <span class="text-xs text-center max-w-[72px] truncate opacity-80">{{ effect?.name }}</span>
+  </div>
+
+  <!-- Non-sound: standard wide button -->
+  <v-btn
+    v-else
     class="m-1"
-    :color="effect?.color || 'primary'"
+    :color="accentColor"
     :disabled="isRunning"
     :loading="isRunning"
     variant="tonal"
     @click="state = !state; vibrate('light')"
   >
     <template #prepend>
-      <v-icon :icon="efxType?.icon || 'mdi-help'"></v-icon>
+      <v-icon :icon="efxType?.icon || 'mdi-help'" />
     </template>
-    {{effect?.name}}
+    {{ effect?.name }}
     <template #append>
-      <v-icon icon="mdi-circle" :color="state ? 'green' : 'red'" class="w-4 h-4"></v-icon>
+      <v-icon icon="mdi-circle" :color="state ? 'green' : 'red'" class="w-4 h-4" />
     </template>
   </v-btn>
 </template>

--- a/packages/ui/src/Effects/EffectCard.vue
+++ b/packages/ui/src/Effects/EffectCard.vue
@@ -5,8 +5,9 @@ import { useHaptics } from '../composables/useHaptics'
 import ListItemCard from '../DeviceConfig/ListItemCard.vue'
 
 interface Props {
-  effect: Effect,
-  isRunning: boolean,
+  effect: Effect
+  isRunning: boolean
+  progress?: number
 }
 
 const props = defineProps<Props>()
@@ -30,6 +31,7 @@ const accentColor = computed(
   () => props.effect?.color || efxType.value?.color || 'purple',
 )
 const icon = computed(() => efxType.value?.icon || 'mdi-lightbulb')
+const isSound = computed(() => props.effect?.type === 'sound')
 </script>
 
 <template>
@@ -65,7 +67,28 @@ const icon = computed(() => efxType.value?.icon || 'mdi-lightbulb')
     </template>
 
     <div class="flex items-center gap-2 flex-wrap">
+      <!-- Sound: play/stop button with progress ring -->
+      <div v-if="isSound" class="relative inline-flex items-center justify-center w-[48px] h-[48px]">
+        <v-progress-circular
+          :model-value="isRunning ? progress : 0"
+          :size="48"
+          :width="3"
+          :color="accentColor"
+          bg-color="transparent"
+          class="absolute inset-0 pointer-events-none"
+        />
+        <v-btn
+          :icon="isRunning ? 'mdi-stop' : 'mdi-play'"
+          :color="isRunning ? 'red-lighten-2' : accentColor"
+          variant="text"
+          size="small"
+          @click="state = !state; vibrate('light')"
+        />
+      </div>
+
+      <!-- Non-sound: standard toggle switch -->
       <v-switch
+        v-else
         v-model="state"
         :color="accentColor"
         hide-details

--- a/packages/ui/src/Effects/EffectItem.vue
+++ b/packages/ui/src/Effects/EffectItem.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
-import { useTimeoutFn } from '@vueuse/core'
+import { useTimeoutFn, useIntervalFn } from '@vueuse/core'
 import { useEfx, type Effect } from '@repo/modules/effects'
 import { createLogger } from '@repo/utils'
 import EffectSwitch from './EffectSwitch.vue'
@@ -19,47 +19,95 @@ const props = defineProps<Props>()
 const { runEffect } = useEfx()
 const state = ref(props.effect?.state)
 const isRunning = ref(false)
+const progress = ref(0)
+
+const isSound = computed(() => props.effect.type === 'sound')
+
+// Prefer stored duration; fall back to detecting from audio metadata
+const resolvedDurationMs = ref((props.effect.soundDuration ?? 5) * 1000)
+if (isSound.value && !props.effect.soundDuration) {
+  const audioUrl = props.effect.soundBlobUrl || props.effect.sound
+  if (audioUrl) {
+    const audio = new Audio()
+    audio.src = audioUrl
+    audio.addEventListener('loadedmetadata', () => {
+      if (isFinite(audio.duration) && audio.duration > 0) {
+        resolvedDurationMs.value = audio.duration * 1000
+      }
+    }, { once: true })
+  }
+}
+
+const timeoutMs = computed(() => isSound.value ? resolvedDurationMs.value : 2000)
+
+let playStartTime = 0
+
+const { pause: pauseProgress, resume: resumeProgress } = useIntervalFn(() => {
+  progress.value = Math.min(100, ((Date.now() - playStartTime) / resolvedDurationMs.value) * 100)
+}, 50, { immediate: false })
 
 const { start, stop } = useTimeoutFn(() => {
   isRunning.value = false
-}, 2000)
+  pauseProgress()
+  progress.value = 0
+  if (isSound.value) state.value = false
+}, timeoutMs)
 
 watch(state, async (newState) => {
   log.debug('Effect state watched to:', newState)
-  isRunning.value = true
-  stop()
-  start()
-  await runEffect({...props.effect, id: props.effect.id, state: newState})
+
+  if (isSound.value && !newState) {
+    isRunning.value = false
+    stop()
+    pauseProgress()
+    progress.value = 0
+  } else {
+    isRunning.value = true
+    stop()
+    start()
+    if (isSound.value) {
+      playStartTime = Date.now()
+      progress.value = 0
+      pauseProgress()
+      resumeProgress()
+    }
+  }
+
+  await runEffect({ ...props.effect, id: props.effect.id, state: newState })
 })
 </script>
 
 <template>
-  <EffectSwitch 
-    v-if="viewAs === 'switch'" 
-    :effect="effect" 
+  <EffectSwitch
+    v-if="viewAs === 'switch'"
+    :effect="effect"
     :is-running="isRunning"
+    :progress="progress"
     v-model:state.sync="state"
   />
-  <EffectCard 
-    v-else-if="viewAs === 'card'" 
-    :effect="effect" 
+  <EffectCard
+    v-else-if="viewAs === 'card'"
+    :effect="effect"
     :is-running="isRunning"
+    :progress="progress"
     v-model:state.sync="state"
   />
-  <EffectButton 
-    v-else-if="viewAs === 'button'" 
-    :effect="effect" 
+  <EffectButton
+    v-else-if="viewAs === 'button'"
+    :effect="effect"
     :is-running="isRunning"
+    :progress="progress"
     v-model:state.sync="state"
   />
-  <EffectRaw 
-    v-else-if="viewAs === 'raw'" 
-    :effect="effect" 
+  <EffectRaw
+    v-else-if="viewAs === 'raw'"
+    :effect="effect"
   />
-  <EffectButton 
-    v-else 
-    :effect="effect" 
+  <EffectButton
+    v-else
+    :effect="effect"
     :is-running="isRunning"
+    :progress="progress"
     v-model:state.sync="state"
   />
 </template>

--- a/packages/ui/src/Effects/EffectSwitch.vue
+++ b/packages/ui/src/Effects/EffectSwitch.vue
@@ -1,62 +1,78 @@
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
-import { useEfx, efxTypes, type Effect } from '@repo/modules'
+import { computed, watch } from 'vue'
+import { efxTypes, type Effect } from '@repo/modules'
 import { useHaptics } from '../composables/useHaptics'
 
-const { runEffect } = useEfx()
-
 interface Props {
-  effect: Effect,
-  isRunning: boolean,
+  effect: Effect
+  isRunning: boolean
+  progress?: number
 }
 
 const props = defineProps<Props>()
-const state = defineModel('state', {
-  type: Boolean
-})
+const state = defineModel('state', { type: Boolean })
 const { vibrate } = useHaptics()
 
-watch(state, () => {
-  vibrate('light')
-})
+watch(state, () => { vibrate('light') })
 
 const efxType = computed(() => efxTypes.find((type) => type.value === props?.effect?.type))
-
+const isSound = computed(() => props.effect?.type === 'sound')
+const accentColor = computed(() => props.effect?.color || efxType.value?.color || 'primary')
 </script>
 
 <template>
-  <v-card 
+  <v-card
     class="shadow-xl my-1 p-[1px] rounded-full"
-    :class="isRunning ? 'bg-gradient-to-r from-indigo-400 to-pink-900 ' : ''"
-    :color="effect?.color || 'primary'"
+    :class="isRunning ? 'bg-gradient-to-r from-indigo-400 to-pink-900' : ''"
+    :color="accentColor"
   >
-    <v-card-title 
+    <v-card-title
       class="flex flex-row items-center gap-4 justify-between rounded-full px-2 efx-switch-inner"
       :class="isRunning ? 'shadow-inner shadow-pink-500' : ''"
->
-      <v-icon
-        :icon="efxType?.icon || 'mdi-help'"
-        class="text-5xl m-3"></v-icon>
+    >
+      <v-icon :icon="efxType?.icon || 'mdi-help'" class="text-5xl m-3" />
       <h4 class="text-md font-bold mr-2">
-        {{effect?.name}}
+        {{ effect?.name }}
         <span class="hidden md:inline text-sm font-normal ml-2 opacity-60">
           <br />
-          <v-chip 
-            v-if="effect?.device" 
+          <v-chip
+            v-if="effect?.device"
             class="ml-2 text-xs"
             prepend-icon="mdi-memory"
             variant="outlined"
           >
-            {{effect?.device}}
+            {{ effect?.device }}
           </v-chip>
         </span>
       </h4>
-      <v-switch 
-        v-model="state" 
-        :color="effect?.color || 'primary'" 
-        :disabled="isRunning" 
-        :loading="isRunning" 
-        hide-details 
+
+      <!-- Sound: play/stop button with progress ring -->
+      <div v-if="isSound" class="relative inline-flex items-center justify-center w-[52px] h-[52px] mr-1">
+        <v-progress-circular
+          :model-value="isRunning ? progress : 0"
+          :size="52"
+          :width="3"
+          :color="accentColor"
+          bg-color="transparent"
+          class="absolute inset-0 pointer-events-none"
+        />
+        <v-btn
+          :icon="isRunning ? 'mdi-stop' : 'mdi-play'"
+          :color="isRunning ? 'red-lighten-2' : accentColor"
+          variant="text"
+          size="small"
+          @click="state = !state; vibrate('light')"
+        />
+      </div>
+
+      <!-- Non-sound: standard toggle switch -->
+      <v-switch
+        v-else
+        v-model="state"
+        :color="accentColor"
+        :disabled="isRunning"
+        :loading="isRunning"
+        hide-details
       />
     </v-card-title>
   </v-card>


### PR DESCRIPTION
## Summary

- 🔊 **Sound effects**: replace `v-switch` with play/stop button + animated progress ring. Uses `soundDuration` for deterministic timing; falls back to Audio metadata detection when not stored. Applied to cloud and throttle apps.
- 🔌 **Turnout effectId (server fix)**: server now triggers the linked effect when a turnout changes state. Supports `invertEffect` toggle so effect can mirror or invert turnout state.
- ✅ **20 Vitest tests** for `turnouts.ts` covering effectId trigger, invertEffect, kato/servo routing, state deduplication, and error handling.
- 🔍 **EffectPicker redesign**: solid `color="surface"` card with autofocus search — no yellow tint or transparency. Used in TurnoutForm, SensorForm, and MacroAdd.
- 📋 **MacroAdd rewrite**: EffectPicker-style search+toggle for effects and turnouts; loco throttle settings panel for selected locos; removed all debug `<pre>` tags.
- 🆕 **New components**:
  - `TurnoutPicker` — same pattern as EffectPicker for selecting turnouts
  - `FeatureGate` — dims slot content with a "Soon" lock chip for unreleased features
  - `TypePickerGrid` — reusable card tile grid matching DevicePickerGrid style
- 🎨 **Type pickers**: `TurnoutTypePicker` and `EffectForm` type picker now use `TypePickerGrid` — card tiles with icon, name, and description instead of large `v-btn-toggle` squares.

## Test plan

- [ ] Play a sound effect — button shows play icon, ring animates, switches to stop icon
- [ ] Stop mid-play — ring resets, button returns to play
- [ ] Throw a turnout with effectId set — linked effect toggles on Firestore
- [ ] Throw with invertEffect — effect state should be opposite of turnout state
- [ ] Open TurnoutForm, click Effect row — EffectPicker dialog opens with search
- [ ] Open SensorForm, click Effect row — same EffectPicker behavior; automation field shows FeatureGate lock
- [ ] Open MacroAdd — search filters effects and turnouts; loco throttle settings appear on selection
- [ ] Add new effect — TypePickerGrid shows all effect types as card tiles
- [ ] Edit turnout type — TypePickerGrid shows kato/servo/tortise/dcc tiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)