### PR TITLE
Default all throttle pages to the same configurable background

### DIFF
--- a/apps/throttle/src/App.vue
+++ b/apps/throttle/src/App.vue
@@ -41,18 +41,11 @@ const mainContentRef = useTemplateRef('mainContentRef')
 const { isDark, themePreference } = useThemeSwitcher()
 const { open: openCommandPalette } = useCommandPalette()
 
+// All pages share the same app-level default background (Ambient Glow).
+// Users can override the default or set per-page backgrounds in Settings.
 const throttleDefaults: AppBackgroundPrefs = {
-  default: 'none',
-  pages: {
-    '/': 'viaduct',
-    '/turnouts': 'forest',
-    '/roster': 'forest',
-    '/routes': 'forest',
-    '/signals': 'forest',
-    '/effects': 'viaduct',
-    '/conductor': 'viaduct',
-    '/connect': 'viaduct',
-  },
+  default: 'decor',
+  pages: {},
 }
 </script>
 


### PR DESCRIPTION
Replace the per-page background defaults (viaduct/forest) with a single
app-level default so every throttle page shares the same background. The
default is now Ambient Glow ('decor'). Users can still override the default
or set per-page backgrounds via Settings > Backgrounds.