### PR TITLE
Default all throttle pages to the same configurable background

### DIFF
--- a/apps/throttle/src/App.vue
+++ b/apps/throttle/src/App.vue
@@ -41,18 +41,11 @@ const mainContentRef = useTemplateRef('mainContentRef')
 const { isDark, themePreference } = useThemeSwitcher()
 const { open: openCommandPalette } = useCommandPalette()
 
+// All pages share the same app-level default background (Ambient Glow).
+// Users can override the default or set per-page backgrounds in Settings.
 const throttleDefaults: AppBackgroundPrefs = {
-  default: 'none',
-  pages: {
-    '/': 'viaduct',
-    '/turnouts': 'forest',
-    '/roster': 'forest',
-    '/routes': 'forest',
-    '/signals': 'forest',
-    '/effects': 'viaduct',
-    '/conductor': 'viaduct',
-    '/connect': 'viaduct',
-  },
+  default: 'decor',
+  pages: {},
 }
 </script>
 


### PR DESCRIPTION
## Summary

All throttle pages now default to a **single** background instead of the previous mix of per-page defaults (`viaduct`/`forest`). The shared default is **Ambient Glow** (`decor`) — the purple/violet/blue glow effect.

This remains fully configurable: the existing background-preference system (Settings → Backgrounds, backed by `useUserPreferences`/Firestore) still lets users change the app-wide default or set per-page overrides, and those take priority over this default.

## Change

Single edit in `apps/throttle/src/App.vue`:

```ts
// before — each page had its own default
default: 'none',
pages: { '/': 'viaduct', '/turnouts': 'forest', '/roster': 'forest', ... }

// after — every page shares one app-level default
default: 'decor', // Ambient Glow
pages: {},
```

Resolution order (unchanged, in `PageBackground.vue`): user preference → these app defaults → `none`. Existing users keep any background they've already chosen.

## Verification

- Lint: `App.vue` clean (pre-existing repo-wide lint errors are in unrelated files)
- Type-check: `vue-tsc --noEmit` passes clean

## Note

The throttle detail view (`/throttle/:address`) wasn't in the old defaults, so it had no page background before — it will now show Ambient Glow beneath its own subtle inline glow blobs (both purple-toned, so they complement each other).

https://claude.ai/code/session_0147VRvnLnjrtYL9BXJQ8DAH

---
_Generated by [Claude Code](https://claude.ai/code/session_0147VRvnLnjrtYL9BXJQ8DAH)_